### PR TITLE
refactor(1649): gate expensive reviewers after local clean evidence

### DIFF
--- a/changelog.d/1649.changed.expensive-reviewers-after-local-clean.md
+++ b/changelog.d/1649.changed.expensive-reviewers-after-local-clean.md
@@ -1,0 +1,1 @@
+- **Gate expensive reviewers on current-head local evidence** (#1649): `codex-github` now runs only after the local reviewer is clean on the current head, every reviewer that precedes it has produced acceptable evidence, review threads are resolved, and non-reviewer checks are green — and defers fail-closed, with a bounded retry budget, when that evidence is missing or stale.

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -36,6 +36,45 @@ during the async grace-period poll — is treated as unavailable, not as
 absence of evidence, so it cannot be silently overridden by a clean
 submitted review.
 
+## Expensive reviewer gate
+
+`codex-github` is an expensive reviewer. Before `pr-review-loop.sh` dispatches
+it, the expensive-reviewer gate requires four current-head conditions,
+evaluated in order and stopping at the first unmet one:
+
+1. `local-ai-reviewer` is configured and has current-head clean evidence
+   (exact `1` on both derived keys; missing/stale/unexpected values defer)
+2. Every preceding peer under the reordered platform list (same-bucket
+   non-expensive peers plus earlier buckets) has acceptable evidence —
+   `clean`, or `skipped` with an allow-listed reason
+   (`not_configured`, `explicit-skip`, `release_pr`, `unsupported-platform`)
+   confirmed by `reviewer_failed_label_required_for_result` returning false
+3. Zero unresolved, non-outdated review threads on the same head
+4. Non-reviewer baseline checks are non-empty and all green on the same head
+   (empty set → `baseline_checks_unobserved`; reviewer-owned checks excluded)
+
+Expensive reviewers are reordered last **within their own phase bucket** so
+those peers can run first; the reorder never moves a draft-configured
+expensive reviewer behind a ready-phase platform.
+
+A defer sets the loop aggregate to `needs_fixes` /
+`REASON=expensive_gate_deferred` (readiness withheld; Step 7 re-runs) and
+breaks the platform iteration so later ready-phase platforms do not run.
+Deferrals are bounded by `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default
+`3`, head-scoped occurrence count). At the cap the loop escalates.
+`EXPENSIVE_GATE_ESCALATION` is emitted **only** when
+`EXPENSIVE_GATE_RESULT=deferral_cap` and is one of:
+
+- `expensive_gate_deferral_cap` — budget exhausted
+- `expensive_gate_deferral_budget_unreadable` — ledger unreadable
+  (`EXPENSIVE_GATE_DEFERRALS=-1`); an absent ledger is `0` and defers normally
+
+Override with `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` for a one-off run
+(justify in the PR). The gate still emits `EXPENSIVE_GATE_RESULT=forced` with
+the reason it would have deferred.
+
+See Protocol 93 § Expensive reviewer gate for the full normative contract.
+
 ## Verdict Classification
 
 `APPROVED` requires the response — the **entire, untruncated** body,

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -62,9 +62,11 @@ A defer sets the loop aggregate to `needs_fixes` /
 breaks the platform iteration so later ready-phase platforms do not run.
 When `codex-github` is in the ready / `phase_after_clean` bucket, the loop
 preflights this gate for remaining ready-phase expensive platforms **before**
-`gh pr ready`, so an automatic Codex start on mark-ready cannot outrun the
-local/peer/thread/baseline checks. The gate still runs again immediately
-before `run_platform_review`.
+`gh pr ready` with peer scope limited to earlier (draft) buckets, so an
+automatic Codex start on mark-ready cannot outrun local/thread/baseline checks
+and cannot deadlock waiting on same-bucket peers that need ready state. The
+full gate (including same-bucket peers) still runs again immediately before
+`run_platform_review`.
 Deferrals are bounded by `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default
 `3`, head-scoped occurrence count). At the cap the loop escalates.
 `EXPENSIVE_GATE_ESCALATION` is emitted **only** when

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -60,6 +60,11 @@ expensive reviewer behind a ready-phase platform.
 A defer sets the loop aggregate to `needs_fixes` /
 `REASON=expensive_gate_deferred` (readiness withheld; Step 7 re-runs) and
 breaks the platform iteration so later ready-phase platforms do not run.
+When `codex-github` is in the ready / `phase_after_clean` bucket, the loop
+preflights this gate for remaining ready-phase expensive platforms **before**
+`gh pr ready`, so an automatic Codex start on mark-ready cannot outrun the
+local/peer/thread/baseline checks. The gate still runs again immediately
+before `run_platform_review`.
 Deferrals are bounded by `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default
 `3`, head-scoped occurrence count). At the cap the loop escalates.
 `EXPENSIVE_GATE_ESCALATION` is emitted **only** when

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -222,7 +222,12 @@ Fail-closed on unreadable inputs (`evidence_unavailable_head`,
 A **deferred** outcome sets the loop aggregate to `needs_fixes` with
 `REASON=expensive_gate_deferred` so readiness is withheld and Step 7 re-runs;
 it also **breaks** the platform iteration immediately so a later ready-phase
-platform cannot call `gh pr ready`. Deferrals are bounded by a head-scoped
+platform cannot call `gh pr ready`. When the ready-phase transition is about
+to start and any **remaining** ready-phase platform is expensive, the loop
+**preflights** those expensive gates **before** `ensure_pr_ready_for_ready_phase`
+/ `gh pr ready`, because vendors such as Codex may auto-start a review when a
+draft is marked ready. The per-platform gate still runs again immediately
+before `run_platform_review`. Deferrals are bounded by a head-scoped
 occurrence counter (`PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS`, default `3`) —
 the existing cycle caps cannot bound them because they unique-bucket
 `needs_fixes` by head+result. At the cap the loop escalates with

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -226,8 +226,11 @@ platform cannot call `gh pr ready`. When the ready-phase transition is about
 to start and any **remaining** ready-phase platform is expensive, the loop
 **preflights** those expensive gates **before** `ensure_pr_ready_for_ready_phase`
 / `gh pr ready`, because vendors such as Codex may auto-start a review when a
-draft is marked ready. The per-platform gate still runs again immediately
-before `run_platform_review`. Deferrals are bounded by a head-scoped
+draft is marked ready. That preflight uses peer scope `earlier_buckets` only
+(draft peers + local/thread/baseline checks) so same-bucket ready peers such as
+`bugbot` — which themselves require the PR to be ready — cannot deadlock the
+transition. The full per-platform gate (including same-bucket peers) still runs
+again immediately before `run_platform_review`. Deferrals are bounded by a head-scoped
 occurrence counter (`PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS`, default `3`) —
 the existing cycle caps cannot bound them because they unique-bucket
 `needs_fixes` by head+result. At the cap the loop escalates with

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -180,6 +180,73 @@ PR comments (including during the async grace-period poll) must be treated as
 unavailable and must not let a clean submitted review be accepted before the
 root comments are known. Fail closed, not open.
 
+#### Expensive reviewer gate (`codex-github`)
+
+Before dispatching an expensive reviewer (`codex-github` today),
+`pr-review-loop.sh` evaluates a dedicated pre-dispatch gate. Membership is a
+fixed property of the reviewer (`EXPENSIVE_REVIEWER_PLATFORMS`), not repository
+config. Expensive reviewers are reordered last **within their own phase
+bucket** (draft vs ready / `phase_after_clean`) so peer evidence is reachable;
+the reorder never crosses the draft/ready boundary.
+
+Conditions are evaluated in order and stop at the first unmet one:
+
+1. **Local current-head evidence** — `local-ai-reviewer` is in the resolved
+   platform list and its `platform_reviewed_heads` entry classifies as
+   `current` against `loop_head_sha`. Exact-match allow-list: both derived
+   values must be the literal `1`. Missing, unexpected, or stale values defer
+   (`local_reviewer_not_configured`, `local_evidence_missing`, or
+   `local_evidence_stale`). Derived from in-loop state — never from the
+   `LOCAL_AI_*` stdout keys as environment variables.
+2. **Preceding peer evidence** — every platform that precedes this reviewer
+   under the reordered list (same-bucket non-expensive peers plus every earlier
+   bucket) has already run with acceptable evidence: `clean`, or `skipped`
+   whose reason is a member of
+   `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS`
+   (`not_configured`, `explicit-skip`, `release_pr`, `unsupported-platform`)
+   **and** `reviewer_failed_label_required_for_result` returns false. Peer set
+   is phase-scoped, not the whole list — a draft-phase expensive reviewer does
+   not wait on ready-phase peers.
+3. **Review threads** — zero unresolved, non-outdated review threads, bound to
+   the same `loop_head_sha` (else `evidence_head_moved` /
+   `evidence_unavailable_review_threads`).
+4. **Baseline checks** — the non-reviewer check set on `loop_head_sha` is
+   **non-empty** and every member is `SUCCESS`, `SKIPPED`, or `NEUTRAL`. An
+   empty set defers with `baseline_checks_unobserved` (vacuous-green is not
+   green). Reviewer-owned check names from
+   `configured_reviewer_check_names_json` are excluded.
+
+Fail-closed on unreadable inputs (`evidence_unavailable_head`,
+`evidence_unavailable_review_threads`, `evidence_unavailable_checks`).
+
+A **deferred** outcome sets the loop aggregate to `needs_fixes` with
+`REASON=expensive_gate_deferred` so readiness is withheld and Step 7 re-runs;
+it also **breaks** the platform iteration immediately so a later ready-phase
+platform cannot call `gh pr ready`. Deferrals are bounded by a head-scoped
+occurrence counter (`PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS`, default `3`) —
+the existing cycle caps cannot bound them because they unique-bucket
+`needs_fixes` by head+result. At the cap the loop escalates with
+`RESULT=escalate`. `EXPENSIVE_GATE_ESCALATION` is emitted **only** on a
+`deferral_cap` result and is one of:
+
+- `expensive_gate_deferral_cap` — budget exhausted for this head
+- `expensive_gate_deferral_budget_unreadable` — ledger marker present but
+  unreadable (`EXPENSIVE_GATE_DEFERRALS=-1`); an *absent* ledger is `0` and
+  defers normally
+
+`PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` bypasses the gate for manual
+escalation: the gate still evaluates and emits `EXPENSIVE_GATE_RESULT=forced`
+with the reason it would have deferred; justify use in the PR. Forced runs do
+not set the `needs_fixes` aggregate.
+
+Telemetry keys: `EXPENSIVE_GATE_PLATFORM`, `EXPENSIVE_GATE_RESULT`,
+`EXPENSIVE_GATE_REASON`, `EXPENSIVE_GATE_HEAD`, `EXPENSIVE_GATE_DEFERRALS`,
+`EXPENSIVE_GATE_MAX_DEFERRALS`, and (on `deferral_cap` only)
+`EXPENSIVE_GATE_ESCALATION`. The summary comment includes an
+`**Expensive reviewer gate:**` line; the `reviewer_loop_history.v1` entry
+carries an additive `expensive_gate` object (`platform`, `result`, `reason`,
+`head`).
+
 **Scope note**: This pre-flight checks `review.on_draft.github` and
 `review.on_ready.github` (external reviewers used by Protocol 93 / Step 7). The
 internal reviewer gate in Protocol 91 Step 7a separately checks

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -109,43 +109,7 @@ export WORKFLOW_TARGET_GITHUB_REPO="$repo"
 export GH_REPO="$repo"
 min_no_checks_wait=$((poll_interval * 2))
 
-configured_reviewer_check_names_json() {
-  local config_file="${1:-}"
-  local platform=""
-  local -a names=()
-
-  if [ -z "$config_file" ]; then
-    config_file="$(workflow_effective_config_file 2>/dev/null || workflow_config_file)"
-  fi
-
-  if [ -f "$config_file" ]; then
-    while IFS= read -r platform; do
-      platform="$(printf '%s' "$platform" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      [ -z "$platform" ] && continue
-      case "$platform" in
-        haystack)
-          names+=("${HAYSTACK_CHECK_NAME:-Haystack / Review}")
-          ;;
-        bugbot)
-          names+=("${BUGBOT_CHECK_NAME:-Cursor Bugbot}")
-          ;;
-      esac
-    done < <(
-      if [ "$config_file" = "$(workflow_config_file)" ]; then
-        WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_platforms "$config_file"
-      else
-        workflow_config_review_platforms "$config_file"
-      fi
-    )
-  fi
-
-  if [ "${#names[@]}" -eq 0 ]; then
-    printf '[]\n'
-    return 0
-  fi
-
-  printf '%s\n' "${names[@]}" | jq -R . | jq -s .
-}
+# configured_reviewer_check_names_json lives in workflow-lib.sh (#1649 relocation).
 
 # is_devin_status_stale <pr_number> <repo>
 #

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -9522,15 +9522,11 @@ for index in "${!platforms[@]}"; do
         set -e
         expensive_gate_sync_last_from_output "$expensive_gate_output"
         if [ "$expensive_gate_status" -eq 0 ]; then
-          # Preflight success is not a dispatch — rewrite telemetry so summary/
-          # history/first-match stdout cannot claim the expensive reviewer ran
-          # before same-bucket peers complete and run_platform_review fires.
-          expensive_gate_output="$(
-            printf '%s\n' "$expensive_gate_output" | sed \
-              -e 's/^EXPENSIVE_GATE_RESULT=dispatched$/EXPENSIVE_GATE_RESULT=preflight_ok/' \
-              -e 's/^EXPENSIVE_GATE_RESULT=forced$/EXPENSIVE_GATE_RESULT=preflight_ok/'
-          )"
-          printf '%s\n' "$expensive_gate_output"
+          # Successful preflight is not a dispatch and must not emit
+          # EXPENSIVE_GATE_RESULT=dispatched/forced (or any new enum value) into
+          # the machine-consumed stdout contract / summary / history. Deferrals
+          # still emit the full EXPENSIVE_GATE_* block below.
+          echo "INFO: expensive-gate ready preflight passed for ${_eg_plat} (earlier_buckets); full gate still runs before dispatch" >&2
           expensive_gate_last_platform=""
           expensive_gate_last_result=""
           expensive_gate_last_reason=""
@@ -10038,10 +10034,6 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
         expensive_gate_section="
 
 **Expensive reviewer gate:** ${expensive_gate_last_platform} — dispatched at head \`${expensive_gate_last_head}\`."
-        ;;
-      preflight_ok)
-        # Ready-phase preflight only; do not claim dispatch in the summary.
-        expensive_gate_section=""
         ;;
       *)
         expensive_gate_section="

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -589,7 +589,11 @@ Outputs stable key=value lines including:
                   Fail-closed on unreadable inputs (evidence_unavailable_*). A deferred outcome sets
                   RESULT=needs_fixes REASON=expensive_gate_deferred so readiness is withheld and
                   Step 7 re-runs; it also breaks the platform iteration so later ready-phase platforms
-                  do not run. Deferrals are bounded by PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS
+                  do not run. When the ready-phase transition is about to start and any remaining
+                  ready-phase platform is expensive, those expensive gates are preflighted BEFORE
+                  gh pr ready (vendors such as Codex may auto-start on mark-ready); the per-platform
+                  gate still runs again immediately before run_platform_review. Deferrals are bounded
+                  by PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS
                   (default 3, head-scoped occurrence count); at the cap the loop escalates.
   EXPENSIVE_GATE_ESCALATION=expensive_gate_deferral_cap|expensive_gate_deferral_budget_unreadable
                   Emitted ONLY when EXPENSIVE_GATE_RESULT=deferral_cap — exhausted budget vs

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1073,12 +1073,15 @@ expensive_gate_unresolved_threads_status() {
 #
 # Snapshot of non-reviewer checks on the PR. Prints
 # "<state> <live_head>" where state is green|failed|pending|empty|unavailable.
-# Does NOT call pr-ci-loop.sh.
+# Does NOT call pr-ci-loop.sh. Collapses statusCheckRollup duplicates to the
+# latest entry per check key (same normalization as pr-ci-loop.sh) before
+# excluding reviewer-owned names and classifying.
 expensive_gate_baseline_checks_status() {
   local pr_number_arg="$1"
   local payload=""
   local live_head=""
   local reviewer_names=""
+  local normalized_json=""
   local baseline_json=""
   local state=""
 
@@ -1097,10 +1100,38 @@ expensive_gate_baseline_checks_status() {
   live_head="$(printf '%s\n' "$payload" | jq -r '.headRefOid // ""' 2>/dev/null)" || live_head=""
   reviewer_names="$(configured_reviewer_check_names_json "")" || reviewer_names='[]'
 
+  if ! normalized_json="$(
+    printf '%s\n' "$payload" | jq '
+      (.statusCheckRollup // [])
+      | map(
+          . + {
+            __check_key: (
+              if (.context // "") != "" then
+                "status:" + .context
+              elif (.workflowName // "") != "" and (.name // "") != "" then
+                "check:" + .workflowName + "/" + .name
+              elif (.name // "") != "" then
+                "check:" + .name
+              else
+                "unknown"
+              end
+            ),
+            __check_ts: (.startedAt // .completedAt // .createdAt // "")
+          }
+        )
+      | sort_by(.__check_key, .__check_ts)
+      | group_by(.__check_key)
+      | map(last | del(.__check_key, .__check_ts))
+    ' 2>/dev/null
+  )"; then
+    printf 'unavailable %s\n' "$live_head"
+    return 0
+  fi
+
   if ! baseline_json="$(
-    printf '%s\n' "$payload" | jq --argjson reviewer_names "$reviewer_names" '
+    printf '%s\n' "$normalized_json" | jq --argjson reviewer_names "$reviewer_names" '
       [
-        (.statusCheckRollup // [])[]
+        .[]
         | select(
             (.name // .context // .workflowName // "unknown") as $check_name
             | ($reviewer_names | index($check_name) | not)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -575,6 +575,27 @@ Outputs stable key=value lines including:
                   RESULT=/REASON= are printed — exactly ONE RESULT= / REASON= pair is ever emitted per
                   invocation, so this REASON is safe to read with either a "first match" or "last
                   match" key=value parser.)
+  EXPENSIVE_REVIEWERS_REORDERED=1 (emitted once per run when expensive reviewers were moved last
+                  within their own phase bucket; never crosses the draft/ready boundary)
+  EXPENSIVE_GATE_PLATFORM / EXPENSIVE_GATE_RESULT / EXPENSIVE_GATE_REASON / EXPENSIVE_GATE_HEAD
+  EXPENSIVE_GATE_DEFERRALS / EXPENSIVE_GATE_MAX_DEFERRALS
+                  Emitted per expensive platform (currently codex-github) immediately before dispatch.
+                  RESULT is dispatched|deferred|forced|deferral_cap. Conditions are evaluated in order:
+                  (1) local-ai-reviewer configured and current-head clean evidence,
+                  (2) every preceding peer (same-bucket non-expensive + earlier buckets) has
+                  acceptable evidence (clean, or skipped with allow-listed reason),
+                  (3) zero unresolved non-outdated review threads on the same head,
+                  (4) non-empty non-reviewer baseline checks all green on the same head.
+                  Fail-closed on unreadable inputs (evidence_unavailable_*). A deferred outcome sets
+                  RESULT=needs_fixes REASON=expensive_gate_deferred so readiness is withheld and
+                  Step 7 re-runs; it also breaks the platform iteration so later ready-phase platforms
+                  do not run. Deferrals are bounded by PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS
+                  (default 3, head-scoped occurrence count); at the cap the loop escalates.
+  EXPENSIVE_GATE_ESCALATION=expensive_gate_deferral_cap|expensive_gate_deferral_budget_unreadable
+                  Emitted ONLY when EXPENSIVE_GATE_RESULT=deferral_cap — exhausted budget vs
+                  unreadable ledger. Absent otherwise.
+  REASON=expensive_gate_deferred (RESULT=needs_fixes; expensive reviewer held back)
+  REASON=expensive_gate_deferral_cap|expensive_gate_deferral_budget_unreadable (RESULT=escalate)
 
 Environment variables:
   POST_CLEAN_SETTLE_QUIET=<sec>      Consecutive seconds of platform silence required before a clean verdict is
@@ -624,6 +645,13 @@ Environment variables:
                                      unset, each invocation is treated as its own isolated run for per-run-cap
                                      purposes (CYCLE_COUNT effectively stays 0) — the LIFETIME ceiling
                                      (TOTAL_CYCLE_COUNT/MAX_TOTAL_CYCLES) still enforces regardless.
+  PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS=<n>
+                                     Bound on head-scoped expensive-reviewer gate deferrals (default: 3).
+                                     Valid range 1–999999; invalid values WARN and fall back to 3.
+  PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1
+                                     Bypass the expensive-reviewer gate for manual escalation. The gate still
+                                     evaluates and emits EXPENSIVE_GATE_* with RESULT=forced and the reason it
+                                     would have deferred; justify use in the PR.
 EOF
 }
 
@@ -671,6 +699,617 @@ array_contains_value() {
 is_phase_after_clean_platform() {
   local candidate="$1"
   array_contains_value "$candidate" "${phase_after_clean_platforms[@]:-}"
+}
+
+# Expensive reviewers (issue #1649): platforms whose dispatch is gated on
+# current-head local-clean evidence, preceding peer evidence, resolved
+# review threads, and green non-reviewer baseline checks. Membership is a
+# property of the reviewer, not of repository config.
+EXPENSIVE_REVIEWER_PLATFORMS=(codex-github)
+EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS=(not_configured explicit-skip release_pr unsupported-platform)
+# Resolved once per run by expensive_gate_resolve_max_deferrals (default 3).
+expensive_gate_max_deferrals=""
+expensive_reviewers_reordered=0
+# Last gate outcome for summary/history surfaces (set by expensive_reviewer_gate).
+expensive_gate_last_platform=""
+expensive_gate_last_result=""
+expensive_gate_last_reason=""
+expensive_gate_last_head=""
+# Peer evidence collected during this invocation: "platform|result|reason".
+declare -a platform_peer_evidence=()
+
+is_expensive_reviewer_platform() {
+  array_contains_value "$1" "${EXPENSIVE_REVIEWER_PLATFORMS[@]:-}"
+}
+
+# reorder_expensive_reviewers_last
+#
+# Moves expensive reviewers to the end of their own phase bucket without
+# crossing the draft/ready boundary. Partitions platforms into non-phase
+# and phase_after_clean buckets using is_phase_after_clean_platform, then
+# within each bucket places non-expensive platforms first (preserving
+# relative order) and expensive platforms last. Sets
+# expensive_reviewers_reordered=1 when order changed. Called once after
+# platform list resolution, before iteration; the caller emits telemetry.
+reorder_expensive_reviewers_last() {
+  local platform
+  local -a non_phase_cheap=()
+  local -a non_phase_expensive=()
+  local -a phase_cheap=()
+  local -a phase_expensive=()
+  local -a reordered=()
+  local original_list=""
+  local new_list=""
+
+  expensive_reviewers_reordered=0
+  [ "${#platforms[@]}" -gt 0 ] || return 0
+
+  original_list="$(IFS=,; printf '%s' "${platforms[*]}")"
+
+  for platform in "${platforms[@]}"; do
+    if is_phase_after_clean_platform "$platform"; then
+      if is_expensive_reviewer_platform "$platform"; then
+        phase_expensive+=("$platform")
+      else
+        phase_cheap+=("$platform")
+      fi
+    else
+      if is_expensive_reviewer_platform "$platform"; then
+        non_phase_expensive+=("$platform")
+      else
+        non_phase_cheap+=("$platform")
+      fi
+    fi
+  done
+
+  reordered=()
+  [ "${#non_phase_cheap[@]}" -gt 0 ] && reordered+=("${non_phase_cheap[@]}")
+  [ "${#non_phase_expensive[@]}" -gt 0 ] && reordered+=("${non_phase_expensive[@]}")
+  [ "${#phase_cheap[@]}" -gt 0 ] && reordered+=("${phase_cheap[@]}")
+  [ "${#phase_expensive[@]}" -gt 0 ] && reordered+=("${phase_expensive[@]}")
+
+  new_list="$(IFS=,; printf '%s' "${reordered[*]}")"
+  if [ "$new_list" != "$original_list" ]; then
+    expensive_reviewers_reordered=1
+    platforms=("${reordered[@]}")
+  fi
+  return 0
+}
+
+# expensive_gate_resolve_max_deferrals
+#
+# Mirrors reviewer_loop_resolve_max_cycles: default 3, accept 1–999999,
+# WARN and fall back on anything else. Reads PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS.
+expensive_gate_resolve_max_deferrals() {
+  local configured="${PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS:-}"
+  local source="env"
+
+  if [ -z "$configured" ]; then
+    configured=3
+    source="default"
+  fi
+  if ! [[ "$configured" =~ ^[1-9][0-9]{0,5}$ ]]; then
+    echo "WARN: PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS value '$configured' (source: $source) is not a positive integer within the supported range (1-999999); defaulting to 3" >&2
+    configured=3
+  fi
+  printf '%s\n' "$configured"
+}
+
+# expensive_gate_local_ai_configured
+#
+# Returns 1 when local-ai-reviewer is in the resolved platforms list, else 0.
+# Derived from in-loop state — never from the LOCAL_AI_CONFIGURED env/stdout key.
+expensive_gate_local_ai_configured() {
+  local platform_name
+  for platform_name in "${platforms[@]:-}"; do
+    if [ "$platform_name" = "local-ai-reviewer" ]; then
+      printf '1\n'
+      return 0
+    fi
+  done
+  printf '0\n'
+}
+
+# expensive_gate_local_ai_head_current <head_sha>
+#
+# Applies reviewer_loop_head_evidence_classify to the local-ai-reviewer entry
+# of platform_reviewed_heads against <head_sha>. Prints 1 (current), 0
+# (not-current), or empty (not-reported / missing entry).
+expensive_gate_local_ai_head_current() {
+  local head_sha="${1:-}"
+  local entry platform_name reviewed_head classification state
+  local found=0
+
+  if ! declare -p platform_reviewed_heads >/dev/null 2>&1; then
+    printf '\n'
+    return 0
+  fi
+
+  for entry in "${platform_reviewed_heads[@]:-}"; do
+    platform_name="${entry%%:*}"
+    reviewed_head="${entry#*:}"
+    if [ "$platform_name" = "local-ai-reviewer" ]; then
+      found=1
+      classification="$(reviewer_loop_head_evidence_classify "$reviewed_head" "$head_sha")"
+      state="${classification%%|*}"
+      case "$state" in
+        current) printf '1\n' ;;
+        not-current) printf '0\n' ;;
+        *) printf '\n' ;;
+      esac
+      return 0
+    fi
+  done
+
+  if [ "$found" -eq 0 ]; then
+    printf '\n'
+  fi
+}
+
+# expensive_gate_peer_evidence_acceptable <result> <reason>
+#
+# Acceptable when result is clean, or skipped with an allow-listed reason
+# AND reviewer_failed_label_required_for_result returns false for the pair.
+expensive_gate_peer_evidence_acceptable() {
+  local result="$1"
+  local reason="${2:-}"
+
+  case "$result" in
+    clean)
+      return 0
+      ;;
+    skipped)
+      if array_contains_value "$reason" "${EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS[@]}"; then
+        if ! reviewer_failed_label_required_for_result "$result" "$reason"; then
+          return 0
+        fi
+      fi
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# expensive_gate_lookup_peer_evidence <platform>
+#
+# Prints "result|reason" when the platform has run in this invocation,
+# or empty when it has not.
+expensive_gate_lookup_peer_evidence() {
+  local platform="$1"
+  local entry peer_name rest
+
+  for entry in "${platform_peer_evidence[@]:-}"; do
+    peer_name="${entry%%|*}"
+    rest="${entry#*|}"
+    if [ "$peer_name" = "$platform" ]; then
+      printf '%s\n' "$rest"
+      return 0
+    fi
+  done
+  printf '\n'
+}
+
+# expensive_gate_check_peers <expensive_platform>
+#
+# Condition 2: every platform that precedes this expensive reviewer under
+# the reordered list (same-bucket non-expensive + every earlier bucket) must
+# have run with acceptable evidence. Prints empty on success, or
+# peer_reviewer_not_run / peer_reviewer_not_clean.
+expensive_gate_check_peers() {
+  local expensive_platform="$1"
+  local idx=0
+  local expensive_idx=-1
+  local platform peer_evidence peer_result peer_reason
+  local -a peer_set=()
+
+  for platform in "${platforms[@]:-}"; do
+    if [ "$platform" = "$expensive_platform" ]; then
+      expensive_idx=$idx
+      break
+    fi
+    idx=$((idx + 1))
+  done
+
+  if [ "$expensive_idx" -lt 0 ]; then
+    # Platform not in list — defensive; treat as not-run peers.
+    printf 'peer_reviewer_not_run\n'
+    return 0
+  fi
+
+  idx=0
+  for platform in "${platforms[@]:-}"; do
+    if [ "$idx" -ge "$expensive_idx" ]; then
+      break
+    fi
+    # Peer set: every preceding platform (earlier buckets + same-bucket
+    # non-expensive). Expensive members of earlier buckets are included;
+    # same-bucket expensive peers that somehow precede us are also peers.
+    peer_set+=("$platform")
+    idx=$((idx + 1))
+  done
+
+  for platform in "${peer_set[@]:-}"; do
+    peer_evidence="$(expensive_gate_lookup_peer_evidence "$platform")"
+    if [ -z "$peer_evidence" ]; then
+      printf 'peer_reviewer_not_run\n'
+      return 0
+    fi
+    peer_result="${peer_evidence%%|*}"
+    peer_reason="${peer_evidence#*|}"
+    if [ "$peer_reason" = "$peer_result" ]; then
+      peer_reason=""
+    fi
+    if ! expensive_gate_peer_evidence_acceptable "$peer_result" "$peer_reason"; then
+      printf 'peer_reviewer_not_clean\n'
+      return 0
+    fi
+  done
+  printf '\n'
+}
+
+# expensive_gate_unresolved_threads_status <pr_number>
+#
+# Fetches review threads + live head. Prints "<status> <count_or_-> <head>"
+# where status is ok|unavailable. count is unresolved non-outdated threads.
+expensive_gate_unresolved_threads_status() {
+  local pr_number_arg="$1"
+  local repo=""
+  local owner name
+  local cursor=""
+  local has_next=1
+  local page=0
+  local max_pages=20
+  local unresolved=0
+  local head_sha=""
+  local result=""
+  local graphql_query
+
+  if [ -z "$pr_number_arg" ]; then
+    printf 'unavailable - \n'
+    return 0
+  fi
+
+  if ! repo="$(repo_slug 2>/dev/null)" || [ -z "$repo" ]; then
+    printf 'unavailable - \n'
+    return 0
+  fi
+  owner="${repo%%/*}"
+  name="${repo#*/}"
+
+  graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){headRefOid reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{isResolved isOutdated}}}}}'
+
+  while [ "$has_next" = "1" ] || [ "$has_next" = "true" ]; do
+    page=$((page + 1))
+    if [ "$page" -gt "$max_pages" ]; then
+      printf 'unavailable - \n'
+      return 0
+    fi
+    if [ -n "$cursor" ]; then
+      if ! result="$(
+        gh api graphql \
+          -f query="$graphql_query" \
+          -f owner="$owner" \
+          -f repo="$name" \
+          -F pr="$pr_number_arg" \
+          -f cursor="$cursor" \
+          --jq '.data.repository.pullRequest' 2>/dev/null
+      )"; then
+        printf 'unavailable - \n'
+        return 0
+      fi
+    else
+      if ! result="$(
+        gh api graphql \
+          -f query="$graphql_query" \
+          -f owner="$owner" \
+          -f repo="$name" \
+          -F pr="$pr_number_arg" \
+          --jq '.data.repository.pullRequest' 2>/dev/null
+      )"; then
+        printf 'unavailable - \n'
+        return 0
+      fi
+    fi
+    if [ -z "$result" ] || [ "$result" = "null" ]; then
+      printf 'unavailable - \n'
+      return 0
+    fi
+    if [ -z "$head_sha" ]; then
+      head_sha="$(printf '%s\n' "$result" | jq -r '.headRefOid // ""' 2>/dev/null)" || head_sha=""
+    fi
+    unresolved=$((unresolved + $(
+      printf '%s\n' "$result" | jq '
+        [.reviewThreads.nodes[]?
+         | select((.isResolved | not) and (.isOutdated | not))]
+        | length' 2>/dev/null || printf '0'
+    )))
+    has_next="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null)" || has_next="false"
+    cursor="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.endCursor // empty' 2>/dev/null)" || cursor=""
+    if [ "$has_next" != "true" ] && [ "$has_next" != "1" ]; then
+      break
+    fi
+    if [ -z "$cursor" ]; then
+      printf 'unavailable - \n'
+      return 0
+    fi
+  done
+
+  printf 'ok %s %s\n' "$unresolved" "$head_sha"
+}
+
+# expensive_gate_baseline_checks_status <pr_number> <expected_head>
+#
+# Snapshot of non-reviewer checks on the PR. Prints
+# "<state> <live_head>" where state is green|failed|pending|empty|unavailable.
+# Does NOT call pr-ci-loop.sh.
+expensive_gate_baseline_checks_status() {
+  local pr_number_arg="$1"
+  local payload=""
+  local live_head=""
+  local reviewer_names=""
+  local baseline_json=""
+  local state=""
+
+  if [ -z "$pr_number_arg" ]; then
+    printf 'unavailable \n'
+    return 0
+  fi
+
+  if ! payload="$(
+    gh pr view "$pr_number_arg" --json statusCheckRollup,headRefOid 2>/dev/null
+  )"; then
+    printf 'unavailable \n'
+    return 0
+  fi
+
+  live_head="$(printf '%s\n' "$payload" | jq -r '.headRefOid // ""' 2>/dev/null)" || live_head=""
+  reviewer_names="$(configured_reviewer_check_names_json "")" || reviewer_names='[]'
+
+  if ! baseline_json="$(
+    printf '%s\n' "$payload" | jq --argjson reviewer_names "$reviewer_names" '
+      [
+        (.statusCheckRollup // [])[]
+        | select(
+            (.name // .context // .workflowName // "unknown") as $check_name
+            | ($reviewer_names | index($check_name) | not)
+          )
+      ]
+    ' 2>/dev/null
+  )"; then
+    printf 'unavailable %s\n' "$live_head"
+    return 0
+  fi
+
+  state="$(
+    printf '%s\n' "$baseline_json" | jq -r '
+      if length == 0 then
+        "empty"
+      elif any(
+            ((.status // "") != "COMPLETED" and (.status // "") != "")
+            or ((.state // "") == "PENDING")
+            or ((.state // "") == "EXPECTED")
+          ) then
+        "pending"
+      elif any(
+            ((.conclusion // "") != "" and (.conclusion // "" | ascii_upcase) as $c
+              | ($c != "SUCCESS" and $c != "SKIPPED" and $c != "NEUTRAL" and $c != "NONE"))
+            or ((.state // "" | ascii_upcase) as $s
+              | ($s == "FAILURE" or $s == "ERROR"))
+          ) then
+        "failed"
+      else
+        "green"
+      end
+    ' 2>/dev/null
+  )" || state="unavailable"
+
+  printf '%s %s\n' "${state:-unavailable}" "$live_head"
+}
+
+# expensive_gate_deferral_count <head_sha>
+#
+# Occurrence count of ledger entries whose expensive_gate.result is deferred
+# and expensive_gate.head equals <head_sha>. Returns 0 for absent ledger,
+# -1 for unreadable ledger (marker present but unparseable / wrong schema /
+# history_status != available).
+expensive_gate_deferral_count() {
+  local head_sha="${1:-}"
+  local pr_number_arg="${pr_number:-}"
+  local repo="" record="" body="" json="" count=""
+
+  if [ -z "$pr_number_arg" ]; then
+    # No PR context (harness unit tests may stub body via MOCK). Treat as absent.
+    if [ -n "${EXPENSIVE_GATE_MOCK_LEDGER_BODY+x}" ]; then
+      body="${EXPENSIVE_GATE_MOCK_LEDGER_BODY}"
+    else
+      printf '0\n'
+      return 0
+    fi
+  else
+    if [ -n "${EXPENSIVE_GATE_MOCK_LEDGER_BODY+x}" ]; then
+      body="${EXPENSIVE_GATE_MOCK_LEDGER_BODY}"
+    else
+      if ! repo="$(repo_slug 2>/dev/null)" || [ -z "$repo" ]; then
+        printf '-1\n'
+        return 0
+      fi
+      if ! record="$(
+          set -o pipefail
+          gh api "repos/$repo/issues/$pr_number_arg/comments" --paginate 2>/dev/null \
+            | reviewer_loop_history_select_latest_summary_record
+        )"; then
+        printf '-1\n'
+        return 0
+      fi
+      body="$(printf '%s\n' "$record" | jq -r '.body // ""' 2>/dev/null)" || body=""
+    fi
+  fi
+
+  if [ -z "$body" ]; then
+    printf '0\n'
+    return 0
+  fi
+
+  json="$(printf '%s\n' "$body" | reviewer_loop_history_extract_latest_json)"
+  if [ -z "$json" ]; then
+    if printf '%s\n' "$body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+      printf '-1\n'
+    else
+      printf '0\n'
+    fi
+    return 0
+  fi
+
+  if ! printf '%s\n' "$json" | jq -e --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" '
+        .schema == $schema
+        and (.entries | type) == "array"
+        and ((.history_status // "available") == "available")
+      ' >/dev/null 2>&1; then
+    printf '-1\n'
+    return 0
+  fi
+
+  count="$(
+    printf '%s\n' "$json" | jq -r --arg head "$head_sha" '
+      [
+        .entries[]?
+        | select((.expensive_gate.result // "") == "deferred")
+        | select((.expensive_gate.head // "") == $head)
+      ] | length
+    ' 2>/dev/null
+  )" || count=""
+
+  if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    printf '-1\n'
+    return 0
+  fi
+  printf '%s\n' "$count"
+}
+
+# expensive_reviewer_gate <pr_number> <platform> <head_sha>
+#
+# Returns 0 to dispatch, 1 to defer/escalate. Emits EXPENSIVE_GATE_* keys.
+# Stops at the first unmet condition so the reason names a single cause.
+expensive_reviewer_gate() {
+  local pr_number_arg="$1"
+  local platform="$2"
+  local head_sha="$3"
+  local reason=""
+  local deferrals=""
+  local configured=""
+  local head_current=""
+  local peer_reason=""
+  local threads_status="" threads_count="" threads_head=""
+  local checks_state="" checks_head=""
+  local gate_result=""
+  local escalation=""
+
+  expensive_gate_last_platform="$platform"
+  expensive_gate_last_head="$head_sha"
+  expensive_gate_last_reason=""
+  expensive_gate_last_result=""
+
+  configured="$(expensive_gate_local_ai_configured)"
+  head_current="$(expensive_gate_local_ai_head_current "$head_sha")"
+
+  if [ -z "$head_sha" ]; then
+    reason="evidence_unavailable_head"
+  elif [ "$configured" = "0" ]; then
+    reason="local_reviewer_not_configured"
+  elif [ "$configured" != "1" ]; then
+    reason="local_evidence_missing"
+  elif [ "$head_current" = "0" ]; then
+    reason="local_evidence_stale"
+  elif [ "$head_current" != "1" ]; then
+    reason="local_evidence_missing"
+  fi
+
+  if [ -z "$reason" ]; then
+    peer_reason="$(expensive_gate_check_peers "$platform")"
+    if [ -n "$peer_reason" ]; then
+      reason="$peer_reason"
+    fi
+  fi
+
+  if [ -z "$reason" ]; then
+    read -r threads_status threads_count threads_head < <(expensive_gate_unresolved_threads_status "$pr_number_arg") || true
+    if [ "${threads_status:-}" != "ok" ]; then
+      reason="evidence_unavailable_review_threads"
+    elif [ -z "${threads_head:-}" ] || [ "$threads_head" != "$head_sha" ]; then
+      reason="evidence_head_moved"
+    elif [ "${threads_count:-0}" -gt 0 ] 2>/dev/null; then
+      reason="unresolved_threads"
+    fi
+  fi
+
+  if [ -z "$reason" ]; then
+    read -r checks_state checks_head < <(expensive_gate_baseline_checks_status "$pr_number_arg" "$head_sha") || true
+    if [ -z "${checks_state:-}" ] || [ "$checks_state" = "unavailable" ]; then
+      reason="evidence_unavailable_checks"
+    elif [ -z "${checks_head:-}" ] || [ "$checks_head" != "$head_sha" ]; then
+      reason="evidence_head_moved"
+    else
+      case "$checks_state" in
+        green) : ;;
+        failed) reason="baseline_checks_not_green" ;;
+        pending) reason="baseline_checks_pending" ;;
+        empty) reason="baseline_checks_unobserved" ;;
+        *) reason="evidence_unavailable_checks" ;;
+      esac
+    fi
+  fi
+
+  deferrals="$(expensive_gate_deferral_count "$head_sha")"
+  if [ -z "${expensive_gate_max_deferrals:-}" ]; then
+    expensive_gate_max_deferrals="$(expensive_gate_resolve_max_deferrals)"
+  fi
+
+  print_kv EXPENSIVE_GATE_PLATFORM "$platform"
+  print_kv EXPENSIVE_GATE_HEAD "$head_sha"
+  print_kv EXPENSIVE_GATE_REASON "$reason"
+  print_kv EXPENSIVE_GATE_DEFERRALS "$deferrals"
+  print_kv EXPENSIVE_GATE_MAX_DEFERRALS "$expensive_gate_max_deferrals"
+
+  if [ -n "$reason" ]; then
+    if [ "${PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS:-0}" = "1" ]; then
+      gate_result="forced"
+      expensive_gate_last_result="$gate_result"
+      expensive_gate_last_reason="$reason"
+      print_kv EXPENSIVE_GATE_RESULT forced
+      return 0
+    fi
+    if [ "$deferrals" = "-1" ]; then
+      gate_result="deferral_cap"
+      escalation="expensive_gate_deferral_budget_unreadable"
+      expensive_gate_last_result="$gate_result"
+      expensive_gate_last_reason="$reason"
+      print_kv EXPENSIVE_GATE_RESULT deferral_cap
+      print_kv EXPENSIVE_GATE_ESCALATION "$escalation"
+      return 1
+    fi
+    if [ "$deferrals" -ge "$expensive_gate_max_deferrals" ] 2>/dev/null; then
+      gate_result="deferral_cap"
+      escalation="expensive_gate_deferral_cap"
+      expensive_gate_last_result="$gate_result"
+      expensive_gate_last_reason="$reason"
+      print_kv EXPENSIVE_GATE_RESULT deferral_cap
+      print_kv EXPENSIVE_GATE_ESCALATION "$escalation"
+      return 1
+    fi
+    gate_result="deferred"
+    expensive_gate_last_result="$gate_result"
+    expensive_gate_last_reason="$reason"
+    print_kv EXPENSIVE_GATE_RESULT deferred
+    return 1
+  fi
+
+  gate_result="dispatched"
+  expensive_gate_last_result="$gate_result"
+  expensive_gate_last_reason=""
+  print_kv EXPENSIVE_GATE_RESULT dispatched
+  return 0
 }
 
 filter_pre_after_clean_platforms() {
@@ -7089,6 +7728,10 @@ reviewer_loop_history_build_entry() {
     --arg smallFindingsPaths "${small_findings_paths:-}" \
     --arg classificationHead "${loop_head_sha:-}" \
     --argjson reviewedHeads "$reviewed_heads_json" \
+    --arg egPlatform "${expensive_gate_last_platform:-}" \
+    --arg egResult "${expensive_gate_last_result:-}" \
+    --arg egReason "${expensive_gate_last_reason:-}" \
+    --arg egHead "${expensive_gate_last_head:-}" \
     '{
       iteration: $iteration,
       recorded_at: $recordedAt,
@@ -7115,7 +7758,12 @@ reviewer_loop_history_build_entry() {
       small_findings_rounds: $smallFindingsRounds,
       small_findings_required_rounds: $smallFindingsRequiredRounds,
       small_findings_paths: ($smallFindingsPaths | split("\n") | map(select(length > 0)))
-    }'
+    }
+    | if ($egResult | length) > 0 then
+        . + {expensive_gate: {platform: $egPlatform, result: $egResult, reason: $egReason, head: $egHead}}
+      else
+        .
+      end'
 }
 
 reviewer_loop_history_payload_from_existing() {
@@ -8535,6 +9183,10 @@ else
   filter_phase_after_clean_platforms
 fi
 
+# Issue #1649: move expensive reviewers last within each phase bucket so the
+# gate's peer precondition is reachable (never across the draft/ready boundary).
+reorder_expensive_reviewers_last
+
 if [ "${#platforms[@]}" -gt 0 ]; then
   require_gh
   cd "$repo_root" || exit 1
@@ -8650,6 +9302,7 @@ fi
 # otherwise keep going.
 max_cycles="$(reviewer_loop_resolve_max_cycles "$(workflow_config_review_max_cycles "${config_file:-$(workflow_config_file)}" 2>/dev/null || true)")"
 max_total_cycles="$(reviewer_loop_resolve_max_total_cycles "$(workflow_config_review_max_total_cycles "${config_file:-$(workflow_config_file)}" 2>/dev/null || true)")"
+expensive_gate_max_deferrals="$(expensive_gate_resolve_max_deferrals)"
 lifetime_cycle_count=-1
 cycle_count=-1
 if [ -n "$pr_number" ] && [ "${#platforms[@]}" -gt 0 ]; then
@@ -8692,6 +9345,12 @@ fi
 declare -a platform_result_tokens=()
 # Per-platform reviewed heads for head-evidence surfaces (issue #1648).
 declare -a platform_reviewed_heads=()
+# Peer evidence for the expensive-reviewer gate (issue #1649): "platform|result|reason".
+platform_peer_evidence=()
+expensive_gate_last_platform=""
+expensive_gate_last_result=""
+expensive_gate_last_reason=""
+expensive_gate_last_head=""
 # Per-platform review-policy status notes for the PR summary comment. Haystack
 # emits these from `pr-status`; other platforms normally leave this empty.
 declare -a platform_policy_status_notes=()
@@ -8717,6 +9376,7 @@ print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
 print_kv PLATFORM_COUNT "${#platforms[@]}"
 # So callers can verify config was respected (e.g. no greptile when only devin is in .ai-dev-workflow.yaml)
 print_kv PLATFORM_LIST "$(IFS=,; printf '%s' "${platforms[*]}")"
+[ "${expensive_reviewers_reordered:-0}" -eq 1 ] && print_kv EXPENSIVE_REVIEWERS_REORDERED 1
 print_kv DRAFT_GITHUB_ONLY "$pre_after_clean_only"
 print_kv PRE_AFTER_CLEAN_ONLY "$pre_after_clean_only"
 print_kv READY_PHASE_ENABLED "$phase_after_clean_enabled"
@@ -8786,6 +9446,44 @@ for index in "${!platforms[@]}"; do
     fi
   fi
 
+  # Issue #1649: expensive-reviewer gate — require current-head local clean,
+  # preceding peer evidence, resolved threads, and green baseline checks
+  # before dispatching. A defer sets needs_fixes and breaks so later platforms
+  # (including ready-phase) do not run.
+  if is_expensive_reviewer_platform "$platform_name"; then
+    set +e
+    expensive_gate_output="$(expensive_reviewer_gate "$pr_number" "$platform_name" "$loop_head_sha")"
+    expensive_gate_status=$?
+    set -e
+    # Re-emit gate telemetry on the loop's stdout contract.
+    printf '%s\n' "$expensive_gate_output"
+    if [ "$expensive_gate_status" -ne 0 ]; then
+      last_platform="$platform_name"
+      if [ "${expensive_gate_last_result:-}" = "deferral_cap" ]; then
+        aggregate_result="escalate"
+        _eg_escalation="$(kv_value_default EXPENSIVE_GATE_ESCALATION "$expensive_gate_output" "")"
+        if [ "$_eg_escalation" = "expensive_gate_deferral_budget_unreadable" ]; then
+          aggregate_reason="expensive_gate_deferral_budget_unreadable"
+        else
+          aggregate_reason="expensive_gate_deferral_cap"
+        fi
+        unset _eg_escalation
+        aggregate_output="$(printf 'RESULT=escalate\nREASON=%s\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n' "$aggregate_reason")"
+        aggregate_status=2
+        platform_result_tokens+=("${platform_name}:deferred (${expensive_gate_last_reason:-cap})")
+      else
+        aggregate_result="needs_fixes"
+        aggregate_reason="expensive_gate_deferred"
+        aggregate_output="$(printf 'RESULT=needs_fixes\nREASON=expensive_gate_deferred\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n')"
+        aggregate_status=1
+        platform_result_tokens+=("${platform_name}:deferred (${expensive_gate_last_reason:-unknown})")
+      fi
+      break
+    fi
+    # forced / dispatched continue to run_platform_review
+    unset expensive_gate_output expensive_gate_status
+  fi
+
   set +e
   platform_output="$(run_platform_review "$platform_name" "$pr_number" "$branch_name" "$poll_interval" "$max_wait")"
   platform_status=$?
@@ -8797,6 +9495,8 @@ for index in "${!platforms[@]}"; do
   platform_suggestion_count="$(kv_value_default SUGGESTION_COUNT "$platform_output" 0)"
   platform_advisory_labels="$(kv_value_default ADVISORY_LABELS "$platform_output" "")"
   platform_reason="$(kv_value_default REASON "$platform_output" "")"
+  # Record peer evidence for subsequent expensive-reviewer gates in this run.
+  platform_peer_evidence+=("${platform_name}|${platform_result}|${platform_reason}")
   if reviewer_failed_label_required_for_result "$platform_result" "$platform_reason"; then
     reviewer_failed_required=1
   fi
@@ -9016,6 +9716,9 @@ _post_review_summary() {
           # this cycle is not clean. Name the reason explicitly instead.
           result_line="needs_fixes (head_moved_during_run) — the clean verdict was for a HEAD the PR has since moved past; nothing to fix, re-run Step 7 for the current HEAD"
           ;;
+        expensive_gate_deferred)
+          result_line="needs_fixes (expensive_gate_deferred) — expensive reviewer held back until current-head evidence is complete; readiness withheld so Step 7 re-runs"
+          ;;
         *)
           result_line="${blocking} blocking finding(s) require fixes"
           ;;
@@ -9151,6 +9854,37 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
 $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
   fi
 
+  local expensive_gate_section=""
+  if [ -n "${expensive_gate_last_result:-}" ]; then
+    case "${expensive_gate_last_result}" in
+      deferred)
+        expensive_gate_section="
+
+**Expensive reviewer gate:** ${expensive_gate_last_platform} — deferred (${expensive_gate_last_reason}) at head \`${expensive_gate_last_head}\`. The reviewer was not run; this loop result is \`needs_fixes\` so readiness is withheld and Step 7 will re-run."
+        ;;
+      deferral_cap)
+        expensive_gate_section="
+
+**Expensive reviewer gate:** ${expensive_gate_last_platform} — deferral cap reached (${expensive_gate_last_reason}) at head \`${expensive_gate_last_head}\`. Escalating so a human can unblock."
+        ;;
+      forced)
+        expensive_gate_section="
+
+**Expensive reviewer gate:** ${expensive_gate_last_platform} — forced (would have deferred: ${expensive_gate_last_reason}) at head \`${expensive_gate_last_head}\`."
+        ;;
+      dispatched)
+        expensive_gate_section="
+
+**Expensive reviewer gate:** ${expensive_gate_last_platform} — dispatched at head \`${expensive_gate_last_head}\`."
+        ;;
+      *)
+        expensive_gate_section="
+
+**Expensive reviewer gate:** ${expensive_gate_last_platform} — ${expensive_gate_last_result} (${expensive_gate_last_reason:-none}) at head \`${expensive_gate_last_head}\`."
+        ;;
+    esac
+  fi
+
   local phase_section=""
   if [ "$phase_enabled" -eq 1 ]; then
     local _phase_value_line
@@ -9198,7 +9932,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
 **Result:** ${result_line}
 **Platforms:** ${platform_list:-none}${policy_status_section}
 **Findings:** ${blocking} blocking, ${suggestions} suggestions
-${small_findings_section}${head_evidence_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${regression_label_section}
+${small_findings_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${regression_label_section}
 
 *Posted automatically by \`pr-review-loop.sh\`.*
 EOF

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -723,6 +723,19 @@ expensive_gate_last_head=""
 # Peer evidence collected during this invocation: "platform|result|reason".
 declare -a platform_peer_evidence=()
 
+# expensive_gate_sync_last_from_output <gate_kv_output>
+#
+# Command substitution runs expensive_reviewer_gate in a subshell, so assignments
+# to expensive_gate_last_* inside the gate are lost. Rehydrate them from the
+# captured EXPENSIVE_GATE_* telemetry before the caller branches or history runs.
+expensive_gate_sync_last_from_output() {
+  local out="$1"
+  expensive_gate_last_platform="$(kv_value_default EXPENSIVE_GATE_PLATFORM "$out" "${expensive_gate_last_platform:-}")"
+  expensive_gate_last_result="$(kv_value_default EXPENSIVE_GATE_RESULT "$out" "")"
+  expensive_gate_last_reason="$(kv_value_default EXPENSIVE_GATE_REASON "$out" "")"
+  expensive_gate_last_head="$(kv_value_default EXPENSIVE_GATE_HEAD "$out" "${expensive_gate_last_head:-}")"
+}
+
 is_expensive_reviewer_platform() {
   array_contains_value "$1" "${EXPENSIVE_REVIEWER_PLATFORMS[@]:-}"
 }
@@ -9451,6 +9464,7 @@ for index in "${!platforms[@]}"; do
         expensive_gate_output="$(expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha" "earlier_buckets")"
         expensive_gate_status=$?
         set -e
+        expensive_gate_sync_last_from_output "$expensive_gate_output"
         printf '%s\n' "$expensive_gate_output"
         if [ "$expensive_gate_status" -ne 0 ]; then
           last_platform="$_eg_plat"
@@ -9529,6 +9543,7 @@ for index in "${!platforms[@]}"; do
     expensive_gate_output="$(expensive_reviewer_gate "$pr_number" "$platform_name" "$loop_head_sha")"
     expensive_gate_status=$?
     set -e
+    expensive_gate_sync_last_from_output "$expensive_gate_output"
     # Re-emit gate telemetry on the loop's stdout contract.
     printf '%s\n' "$expensive_gate_output"
     if [ "$expensive_gate_status" -ne 0 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -9411,6 +9411,59 @@ for index in "${!platforms[@]}"; do
       && [ "$phase_after_clean_started" -eq 0 ] \
       && is_phase_after_clean_platform "$platform_name"; then
     if [ "$compare_mode" -eq 0 ] || [ -z "$compare_first_blocking_result" ]; then
+      # Issue #1649: preflight expensive ready-phase gates BEFORE gh pr ready.
+      # Codex (and similar) may auto-start when a draft is marked ready; running
+      # ensure_pr_ready first would spend that reviewer before local/peer/thread/
+      # baseline evidence is confirmed. Plan Path 2 still keeps the per-platform
+      # gate immediately before run_platform_review; this preflight only guards
+      # the ready transition when any remaining ready-phase platform is expensive.
+      _eg_ready_preflight_failed=0
+      for ((_eg_i = index; _eg_i < ${#platforms[@]}; _eg_i++)); do
+        _eg_plat="${platforms[$_eg_i]}"
+        if ! is_phase_after_clean_platform "$_eg_plat"; then
+          continue
+        fi
+        if ! is_expensive_reviewer_platform "$_eg_plat"; then
+          continue
+        fi
+        set +e
+        expensive_gate_output="$(expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha")"
+        expensive_gate_status=$?
+        set -e
+        printf '%s\n' "$expensive_gate_output"
+        if [ "$expensive_gate_status" -ne 0 ]; then
+          last_platform="$_eg_plat"
+          if [ "${expensive_gate_last_result:-}" = "deferral_cap" ]; then
+            aggregate_result="escalate"
+            _eg_escalation="$(kv_value_default EXPENSIVE_GATE_ESCALATION "$expensive_gate_output" "")"
+            if [ "$_eg_escalation" = "expensive_gate_deferral_budget_unreadable" ]; then
+              aggregate_reason="expensive_gate_deferral_budget_unreadable"
+            else
+              aggregate_reason="expensive_gate_deferral_cap"
+            fi
+            unset _eg_escalation
+            aggregate_output="$(printf 'RESULT=escalate\nREASON=%s\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n' "$aggregate_reason")"
+            aggregate_status=2
+            platform_result_tokens+=("${_eg_plat}:deferred (${expensive_gate_last_reason:-cap})")
+          else
+            aggregate_result="needs_fixes"
+            aggregate_reason="expensive_gate_deferred"
+            aggregate_output="$(printf 'RESULT=needs_fixes\nREASON=expensive_gate_deferred\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n')"
+            aggregate_status=1
+            platform_result_tokens+=("${_eg_plat}:deferred (${expensive_gate_last_reason:-unknown})")
+          fi
+          _eg_ready_preflight_failed=1
+          unset expensive_gate_output expensive_gate_status
+          break
+        fi
+        unset expensive_gate_output expensive_gate_status
+      done
+      unset _eg_i _eg_plat
+      if [ "$_eg_ready_preflight_failed" -eq 1 ]; then
+        unset _eg_ready_preflight_failed
+        break
+      fi
+      unset _eg_ready_preflight_failed
       set +e
       ensure_pr_ready_for_ready_phase "$pr_number"
       ready_status=$?

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -591,7 +591,8 @@ Outputs stable key=value lines including:
                   Step 7 re-runs; it also breaks the platform iteration so later ready-phase platforms
                   do not run. When the ready-phase transition is about to start and any remaining
                   ready-phase platform is expensive, those expensive gates are preflighted BEFORE
-                  gh pr ready (vendors such as Codex may auto-start on mark-ready); the per-platform
+                  gh pr ready with peer scope earlier_buckets (same-bucket peers like bugbot are
+                  not required yet — they need ready state themselves); the full per-platform
                   gate still runs again immediately before run_platform_review. Deferrals are bounded
                   by PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS
                   (default 3, head-scoped occurrence count); at the cap the loop escalates.
@@ -895,14 +896,20 @@ expensive_gate_lookup_peer_evidence() {
   printf '\n'
 }
 
-# expensive_gate_check_peers <expensive_platform>
+# expensive_gate_check_peers <expensive_platform> [peer_scope]
 #
 # Condition 2: every platform that precedes this expensive reviewer under
 # the reordered list (same-bucket non-expensive + every earlier bucket) must
 # have run with acceptable evidence. Prints empty on success, or
 # peer_reviewer_not_run / peer_reviewer_not_clean.
+#
+# peer_scope:
+#   full (default) — earlier buckets + same-bucket predecessors
+#   earlier_buckets — earlier buckets only (used by ready-phase preflight so
+#     same-bucket peers like bugbot are not required before gh pr ready)
 expensive_gate_check_peers() {
   local expensive_platform="$1"
+  local peer_scope="${2:-full}"
   local idx=0
   local expensive_idx=-1
   local platform peer_evidence peer_result peer_reason
@@ -926,6 +933,12 @@ expensive_gate_check_peers() {
   for platform in "${platforms[@]:-}"; do
     if [ "$idx" -ge "$expensive_idx" ]; then
       break
+    fi
+    if [ "$peer_scope" = "earlier_buckets" ] && is_phase_after_clean_platform "$platform"; then
+      # Ready-phase preflight: same-bucket peers have not run yet (and often
+      # cannot, because they themselves require gh pr ready).
+      idx=$((idx + 1))
+      continue
     fi
     # Peer set: every preceding platform (earlier buckets + same-bucket
     # non-expensive). Expensive members of earlier buckets are included;
@@ -1192,14 +1205,16 @@ expensive_gate_deferral_count() {
   printf '%s\n' "$count"
 }
 
-# expensive_reviewer_gate <pr_number> <platform> <head_sha>
+# expensive_reviewer_gate <pr_number> <platform> <head_sha> [peer_scope]
 #
 # Returns 0 to dispatch, 1 to defer/escalate. Emits EXPENSIVE_GATE_* keys.
 # Stops at the first unmet condition so the reason names a single cause.
+# peer_scope: full (default) | earlier_buckets (ready-phase preflight).
 expensive_reviewer_gate() {
   local pr_number_arg="$1"
   local platform="$2"
   local head_sha="$3"
+  local peer_scope="${4:-full}"
   local reason=""
   local deferrals=""
   local configured=""
@@ -1231,7 +1246,7 @@ expensive_reviewer_gate() {
   fi
 
   if [ -z "$reason" ]; then
-    peer_reason="$(expensive_gate_check_peers "$platform")"
+    peer_reason="$(expensive_gate_check_peers "$platform" "$peer_scope")"
     if [ -n "$peer_reason" ]; then
       reason="$peer_reason"
     fi
@@ -9417,10 +9432,12 @@ for index in "${!platforms[@]}"; do
     if [ "$compare_mode" -eq 0 ] || [ -z "$compare_first_blocking_result" ]; then
       # Issue #1649: preflight expensive ready-phase gates BEFORE gh pr ready.
       # Codex (and similar) may auto-start when a draft is marked ready; running
-      # ensure_pr_ready first would spend that reviewer before local/peer/thread/
-      # baseline evidence is confirmed. Plan Path 2 still keeps the per-platform
-      # gate immediately before run_platform_review; this preflight only guards
-      # the ready transition when any remaining ready-phase platform is expensive.
+      # ensure_pr_ready first would spend that reviewer before local/thread/
+      # baseline evidence (and earlier-bucket peers) is confirmed. Peer scope is
+      # earlier_buckets only — same-bucket peers like bugbot require ready state
+      # themselves, so requiring them here would deadlock the ready transition.
+      # The full per-platform gate (including same-bucket peers) still runs
+      # immediately before run_platform_review after ready-phase peers complete.
       _eg_ready_preflight_failed=0
       for ((_eg_i = index; _eg_i < ${#platforms[@]}; _eg_i++)); do
         _eg_plat="${platforms[$_eg_i]}"
@@ -9431,7 +9448,7 @@ for index in "${!platforms[@]}"; do
           continue
         fi
         set +e
-        expensive_gate_output="$(expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha")"
+        expensive_gate_output="$(expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha" "earlier_buckets")"
         expensive_gate_status=$?
         set -e
         printf '%s\n' "$expensive_gate_output"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1132,7 +1132,7 @@ expensive_gate_deferral_count() {
       body="${EXPENSIVE_GATE_MOCK_LEDGER_BODY}"
     else
       if ! repo="$(repo_slug 2>/dev/null)" || [ -z "$repo" ]; then
-        printf '-1\n'
+        printf '%s\n' '-1'
         return 0
       fi
       if ! record="$(
@@ -1140,7 +1140,7 @@ expensive_gate_deferral_count() {
           gh api "repos/$repo/issues/$pr_number_arg/comments" --paginate 2>/dev/null \
             | reviewer_loop_history_select_latest_summary_record
         )"; then
-        printf '-1\n'
+        printf '%s\n' '-1'
         return 0
       fi
       body="$(printf '%s\n' "$record" | jq -r '.body // ""' 2>/dev/null)" || body=""
@@ -1155,7 +1155,7 @@ expensive_gate_deferral_count() {
   json="$(printf '%s\n' "$body" | reviewer_loop_history_extract_latest_json)"
   if [ -z "$json" ]; then
     if printf '%s\n' "$body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
-      printf '-1\n'
+      printf '%s\n' '-1'
     else
       printf '0\n'
     fi
@@ -1167,7 +1167,7 @@ expensive_gate_deferral_count() {
         and (.entries | type) == "array"
         and ((.history_status // "available") == "available")
       ' >/dev/null 2>&1; then
-    printf '-1\n'
+    printf '%s\n' '-1'
     return 0
   fi
 
@@ -1182,7 +1182,7 @@ expensive_gate_deferral_count() {
   )" || count=""
 
   if ! [[ "$count" =~ ^[0-9]+$ ]]; then
-    printf '-1\n'
+    printf '%s\n' '-1'
     return 0
   fi
   printf '%s\n' "$count"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1047,16 +1047,41 @@ expensive_gate_unresolved_threads_status() {
       return 0
     fi
     if [ -z "$head_sha" ]; then
-      head_sha="$(printf '%s\n' "$result" | jq -r '.headRefOid // ""' 2>/dev/null)" || head_sha=""
+      if ! head_sha="$(printf '%s\n' "$result" | jq -r '.headRefOid // ""' 2>/dev/null)"; then
+        printf 'unavailable - \n'
+        return 0
+      fi
     fi
-    unresolved=$((unresolved + $(
+    _eg_page_unresolved=""
+    if ! _eg_page_unresolved="$(
       printf '%s\n' "$result" | jq '
         [.reviewThreads.nodes[]?
          | select((.isResolved | not) and (.isOutdated | not))]
-        | length' 2>/dev/null || printf '0'
-    )))
-    has_next="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null)" || has_next="false"
-    cursor="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.endCursor // empty' 2>/dev/null)" || cursor=""
+        | length'
+    )"; then
+      printf 'unavailable - \n'
+      return 0
+    fi
+    if [ -z "${_eg_page_unresolved}" ]; then
+      printf 'unavailable - \n'
+      return 0
+    fi
+    case "${_eg_page_unresolved}" in
+      *[!0-9]*)
+        printf 'unavailable - \n'
+        return 0
+        ;;
+    esac
+    unresolved=$((unresolved + _eg_page_unresolved))
+    unset _eg_page_unresolved
+    if ! has_next="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.hasNextPage // false')"; then
+      printf 'unavailable - \n'
+      return 0
+    fi
+    if ! cursor="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.endCursor // empty')"; then
+      printf 'unavailable - \n'
+      return 0
+    fi
     if [ "$has_next" != "true" ] && [ "$has_next" != "1" ]; then
       break
     fi
@@ -9496,6 +9521,23 @@ for index in "${!platforms[@]}"; do
         expensive_gate_status=$?
         set -e
         expensive_gate_sync_last_from_output "$expensive_gate_output"
+        if [ "$expensive_gate_status" -eq 0 ]; then
+          # Preflight success is not a dispatch — rewrite telemetry so summary/
+          # history/first-match stdout cannot claim the expensive reviewer ran
+          # before same-bucket peers complete and run_platform_review fires.
+          expensive_gate_output="$(
+            printf '%s\n' "$expensive_gate_output" | sed \
+              -e 's/^EXPENSIVE_GATE_RESULT=dispatched$/EXPENSIVE_GATE_RESULT=preflight_ok/' \
+              -e 's/^EXPENSIVE_GATE_RESULT=forced$/EXPENSIVE_GATE_RESULT=preflight_ok/'
+          )"
+          printf '%s\n' "$expensive_gate_output"
+          expensive_gate_last_platform=""
+          expensive_gate_last_result=""
+          expensive_gate_last_reason=""
+          expensive_gate_last_head=""
+          unset expensive_gate_output expensive_gate_status
+          continue
+        fi
         printf '%s\n' "$expensive_gate_output"
         if [ "$expensive_gate_status" -ne 0 ]; then
           last_platform="$_eg_plat"
@@ -9996,6 +10038,10 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
         expensive_gate_section="
 
 **Expensive reviewer gate:** ${expensive_gate_last_platform} — dispatched at head \`${expensive_gate_last_head}\`."
+        ;;
+      preflight_ok)
+        # Ready-phase preflight only; do not claim dispatch in the summary.
+        expensive_gate_section=""
         ;;
       *)
         expensive_gate_section="

--- a/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
+++ b/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
@@ -242,7 +242,7 @@ for index in "${!platforms[@]}"; do
       if ! is_expensive_reviewer_platform "$_eg_plat"; then
         continue
       fi
-      if ! expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha" >/dev/null; then
+      if ! expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha" "earlier_buckets" >/dev/null; then
         aggregate_result="needs_fixes"
         aggregate_reason="expensive_gate_deferred"
         _eg_ready_preflight_failed=1
@@ -267,6 +267,57 @@ run_test "1649_s23_ready_not_called" "0" "$_ready_called"
 run_test "1649_s23_aggregate_needs_fixes" "needs_fixes" "$aggregate_result"
 run_test "1649_s23_bugbot_not_run" "0" \
   "$(printf '%s\n' "${_run_platform_called[@]:-}" | grep -c '^bugbot$' || true)"
+
+# --- Scenario 24: earlier_buckets preflight does not deadlock on bugbot ---
+# Full peer scope would require bugbot before ready; earlier_buckets must not.
+platforms=(local-ai-reviewer bugbot codex-github)
+phase_after_clean_platforms=(bugbot codex-github)
+reorder_expensive_reviewers_last
+platform_peer_evidence=("local-ai-reviewer|clean|")
+platform_reviewed_heads=("local-ai-reviewer:$_head")
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_head"; }
+expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_head"; }
+expensive_gate_max_deferrals=3
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+_out="$(expensive_reviewer_gate 24 codex-github "$_head" "earlier_buckets" 2>/dev/null)" || true
+run_test "1649_s24_preflight_dispatched" "dispatched" \
+  "$(printf '%s\n' "$_out" | grep '^EXPENSIVE_GATE_RESULT=' | head -1 | cut -d= -f2-)"
+_out_full="$(expensive_reviewer_gate 24 codex-github "$_head" "full" 2>/dev/null)" || true
+run_test "1649_s24_full_waits_on_bugbot" "peer_reviewer_not_run" \
+  "$(printf '%s\n' "$_out_full" | grep '^EXPENSIVE_GATE_REASON=' | head -1 | cut -d= -f2-)"
+_ready_called=0
+ensure_pr_ready_for_ready_phase() { _ready_called=$((_ready_called + 1)); return 0; }
+phase_after_clean_started=0
+phase_after_clean_enabled=1
+loop_head_sha="$_head"
+pr_number=24
+aggregate_result="skipped"
+for index in "${!platforms[@]}"; do
+  platform_name="${platforms[$index]}"
+  if [ "$phase_after_clean_enabled" -eq 1 ] \
+      && [ "$phase_after_clean_started" -eq 0 ] \
+      && is_phase_after_clean_platform "$platform_name"; then
+    _eg_ready_preflight_failed=0
+    for ((_eg_i = index; _eg_i < ${#platforms[@]}; _eg_i++)); do
+      _eg_plat="${platforms[$_eg_i]}"
+      if is_phase_after_clean_platform "$_eg_plat" && is_expensive_reviewer_platform "$_eg_plat"; then
+        if ! expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha" "earlier_buckets" >/dev/null; then
+          _eg_ready_preflight_failed=1
+          aggregate_result="needs_fixes"
+          break
+        fi
+      fi
+    done
+    if [ "$_eg_ready_preflight_failed" -eq 1 ]; then
+      break
+    fi
+    ensure_pr_ready_for_ready_phase "$pr_number"
+    phase_after_clean_started=1
+    break
+  fi
+done
+run_test "1649_s24_ready_called" "1" "$_ready_called"
+run_test "1649_s24_not_deferred" "skipped" "$aggregate_result"
 
 # Docs parity: both docs mention both escalation values + ready-phase preflight.
 # Grep files directly — do not $(cat) Protocol 93 into argv (ARG_MAX).

--- a/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
+++ b/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
@@ -202,13 +202,92 @@ run_test "1649_s21_aggregate_needs_fixes" "needs_fixes" "$aggregate_result"
 run_contains "1649_s21_no_bugbot_in_ran" "local-ai-reviewer" \
   "$(IFS=,; printf '%s' "${_run_platform_called[*]}")"
 
-# Docs parity: both docs mention both escalation values
+# --- Scenario 23: ready-phase preflight — gate before gh pr ready ---
+# When the first ready-phase platform is non-expensive (bugbot) but a later
+# ready-phase platform is expensive (codex-github), a deferring expensive gate
+# must prevent ensure_pr_ready_for_ready_phase so auto-trigger cannot start.
+_ready_called=0
+ensure_pr_ready_for_ready_phase() { _ready_called=$((_ready_called + 1)); return 0; }
+_run_platform_called=()
+run_platform_review() { _run_platform_called+=("$1"); printf 'RESULT=clean\nREASON=\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n'; return 0; }
+phase_after_clean_started=0
+phase_after_clean_enabled=1
+compare_mode=0
+compare_first_blocking_result=""
+platforms=(local-ai-reviewer bugbot codex-github)
+phase_after_clean_platforms=(bugbot codex-github)
+reorder_expensive_reviewers_last
+platform_peer_evidence=("local-ai-reviewer|clean|")
+platform_reviewed_heads=("local-ai-reviewer:$_other")
+expensive_gate_max_deferrals=3
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+loop_head_sha="$_head"
+pr_number=23
+aggregate_result="skipped"
+aggregate_reason=""
+aggregate_status=0
+platform_result_tokens=()
+# Mirror the production ready-phase entry + expensive preflight + per-platform gate.
+for index in "${!platforms[@]}"; do
+  platform_name="${platforms[$index]}"
+  if [ "$phase_after_clean_enabled" -eq 1 ] \
+      && [ "$phase_after_clean_started" -eq 0 ] \
+      && is_phase_after_clean_platform "$platform_name"; then
+    _eg_ready_preflight_failed=0
+    for ((_eg_i = index; _eg_i < ${#platforms[@]}; _eg_i++)); do
+      _eg_plat="${platforms[$_eg_i]}"
+      if ! is_phase_after_clean_platform "$_eg_plat"; then
+        continue
+      fi
+      if ! is_expensive_reviewer_platform "$_eg_plat"; then
+        continue
+      fi
+      if ! expensive_reviewer_gate "$pr_number" "$_eg_plat" "$loop_head_sha" >/dev/null; then
+        aggregate_result="needs_fixes"
+        aggregate_reason="expensive_gate_deferred"
+        _eg_ready_preflight_failed=1
+        break
+      fi
+    done
+    if [ "$_eg_ready_preflight_failed" -eq 1 ]; then
+      break
+    fi
+    ensure_pr_ready_for_ready_phase "$pr_number"
+    phase_after_clean_started=1
+  fi
+  if is_expensive_reviewer_platform "$platform_name"; then
+    if ! expensive_reviewer_gate "$pr_number" "$platform_name" "$loop_head_sha" >/dev/null; then
+      aggregate_result="needs_fixes"
+      break
+    fi
+  fi
+  _run_platform_called+=("$platform_name")
+done
+run_test "1649_s23_ready_not_called" "0" "$_ready_called"
+run_test "1649_s23_aggregate_needs_fixes" "needs_fixes" "$aggregate_result"
+run_test "1649_s23_bugbot_not_run" "0" \
+  "$(printf '%s\n' "${_run_platform_called[@]:-}" | grep -c '^bugbot$' || true)"
+
+# Docs parity: both docs mention both escalation values + ready-phase preflight.
+# Grep files directly — do not $(cat) Protocol 93 into argv (ARG_MAX).
 _p93="$REPO_ROOT/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md"
 _cg="$REPO_ROOT/docs/workflow/development-workflow/integrations/codex-github.md"
-run_contains "1649_docs_p93_cap" "expensive_gate_deferral_cap" "$(cat "$_p93")"
-run_contains "1649_docs_p93_unreadable" "expensive_gate_deferral_budget_unreadable" "$(cat "$_p93")"
-run_contains "1649_docs_cg_cap" "expensive_gate_deferral_cap" "$(cat "$_cg")"
-run_contains "1649_docs_cg_unreadable" "expensive_gate_deferral_budget_unreadable" "$(cat "$_cg")"
+_docs_has() {
+  local name="$1" needle="$2" file="$3"
+  if grep -Fq -- "$needle" "$file"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name — expected substring '${needle}' in ${file}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+_docs_has "1649_s23_docs_p93_preflight" "preflight" "$_p93"
+_docs_has "1649_s23_docs_cg_preflight" "preflight" "$_cg"
+_docs_has "1649_docs_p93_cap" "expensive_gate_deferral_cap" "$_p93"
+_docs_has "1649_docs_p93_unreadable" "expensive_gate_deferral_budget_unreadable" "$_p93"
+_docs_has "1649_docs_cg_cap" "expensive_gate_deferral_cap" "$_cg"
+_docs_has "1649_docs_cg_unreadable" "expensive_gate_deferral_budget_unreadable" "$_cg"
 
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"

--- a/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
+++ b/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
@@ -319,6 +319,23 @@ done
 run_test "1649_s24_ready_called" "1" "$_ready_called"
 run_test "1649_s24_not_deferred" "skipped" "$aggregate_result"
 
+# --- Scenario 25: command-substitution must rehydrate expensive_gate_last_* ---
+platforms=(local-ai-reviewer pr-agent codex-github)
+phase_after_clean_platforms=()
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+platform_reviewed_heads=("local-ai-reviewer:$_other")
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_head"; }
+expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_head"; }
+expensive_gate_max_deferrals=3
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+expensive_gate_last_result=""
+expensive_gate_last_reason=""
+_out="$(expensive_reviewer_gate 25 codex-github "$_head" 2>/dev/null)" || true
+run_test "1649_s25_subshell_loses_globals" "" "${expensive_gate_last_result:-}"
+expensive_gate_sync_last_from_output "$_out"
+run_test "1649_s25_sync_restores_result" "deferred" "${expensive_gate_last_result:-}"
+run_test "1649_s25_sync_restores_reason" "local_evidence_stale" "${expensive_gate_last_reason:-}"
+
 # Docs parity: both docs mention both escalation values + ready-phase preflight.
 # Grep files directly — do not $(cat) Protocol 93 into argv (ARG_MAX).
 _p93="$REPO_ROOT/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md"

--- a/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
+++ b/scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# test-expensive-reviewer-gate.sh — composition / override scenarios for #1649.
+# covers: scripts/development-workflow/pr-review-loop.sh
+# covers: docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+#
+# Scenarios 15, 16, 17, 21, 22 from the implementation plan.
+# shellcheck shell=bash disable=SC2034
+# SC2034: test globals are read by functions sourced from pr-review-loop.sh.
+
+set -euo pipefail
+# Globals below are read by functions sourced from pr-review-loop.sh.
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name — expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name — expected substring '${needle}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+export MOCK_REPO_ROOT="$REPO_ROOT"
+# shellcheck source=scripts/development-workflow/pr-review-loop.sh
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_other="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+expensive_gate_unresolved_threads_status() {
+  printf 'ok 0 %s\n' "${MOCK_THREADS_HEAD:-$_head}"
+}
+expensive_gate_baseline_checks_status() {
+  printf 'green %s\n' "${MOCK_CHECKS_HEAD:-$_head}"
+}
+
+_kv() {
+  printf '%s\n' "$2" | grep "^${1}=" | head -1 | cut -d= -f2-
+}
+
+echo "=== test-expensive-reviewer-gate (#1649) ==="
+
+# --- Scenario 15: force override ---
+platforms=(local-ai-reviewer pr-agent codex-github)
+phase_after_clean_platforms=()
+platform_reviewed_heads=("local-ai-reviewer:$_other")
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+expensive_gate_max_deferrals=3
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+export PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1
+_out="$(expensive_reviewer_gate 42 codex-github "$_head" 2>/dev/null)" || _rc=$?
+_rc="${_rc:-0}"
+run_test "1649_s15_forced" "forced" "$(_kv EXPENSIVE_GATE_RESULT "$_out")"
+run_test "1649_s15_reason_preserved" "local_evidence_stale" "$(_kv EXPENSIVE_GATE_REASON "$_out")"
+run_test "1649_s15_rc0" "0" "$_rc"
+unset PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS
+unset _rc
+
+# --- Scenario 22: in-loop derivation matches LOCAL_AI_* producer ---
+# Case A: configured + current head
+platforms=(local-ai-reviewer pr-agent)
+platform_reviewed_heads=("local-ai-reviewer:$_head")
+loop_head_sha="$_head"
+_cfg="$(expensive_gate_local_ai_configured)"
+_hc="$(expensive_gate_local_ai_head_current "$_head")"
+# Simulate producer (same logic as reviewer_loop_emit_local_ai_head_evidence_keys)
+_prod_cfg=0
+for p in "${platforms[@]}"; do
+  [ "$p" = "local-ai-reviewer" ] && _prod_cfg=1
+done
+_prod_hc=""
+for entry in "${platform_reviewed_heads[@]}"; do
+  if [ "${entry%%:*}" = "local-ai-reviewer" ]; then
+    classification="$(reviewer_loop_head_evidence_classify "${entry#*:}" "$loop_head_sha")"
+    state="${classification%%|*}"
+    case "$state" in
+      current) _prod_hc=1 ;;
+      not-current) _prod_hc=0 ;;
+      *) _prod_hc="" ;;
+    esac
+  fi
+done
+run_test "1649_s22_current_match" "${_prod_cfg}|${_prod_hc}" "${_cfg}|${_hc}"
+
+# Case B: stale
+platform_reviewed_heads=("local-ai-reviewer:$_other")
+_cfg="$(expensive_gate_local_ai_configured)"
+_hc="$(expensive_gate_local_ai_head_current "$_head")"
+run_test "1649_s22_stale" "1|0" "${_cfg}|${_hc}"
+
+# Case C: unreported (empty reviewed head)
+platform_reviewed_heads=("local-ai-reviewer:")
+_cfg="$(expensive_gate_local_ai_configured)"
+_hc="$(expensive_gate_local_ai_head_current "$_head")"
+run_test "1649_s22_unreported" "1|" "${_cfg}|${_hc}"
+
+# Case D: not configured
+platforms=(pr-agent)
+platform_reviewed_heads=()
+_cfg="$(expensive_gate_local_ai_configured)"
+_hc="$(expensive_gate_local_ai_head_current "$_head")"
+run_test "1649_s22_not_configured" "0|" "${_cfg}|${_hc}"
+
+# --- Scenario 16: phase then gate (composition with ensure_pr_ready) ---
+_call_order=()
+ensure_pr_ready_for_ready_phase() {
+  _call_order+=("ready_phase")
+  return 0
+}
+platform_name="codex-github"
+phase_after_clean_platforms=(codex-github)
+phase_after_clean_enabled=1
+phase_after_clean_started=0
+compare_mode=0
+platforms=(local-ai-reviewer codex-github)
+platform_reviewed_heads=("local-ai-reviewer:$_head")
+platform_peer_evidence=("local-ai-reviewer|clean|")
+loop_head_sha="$_head"
+_call_order=()
+if [ "$phase_after_clean_enabled" -eq 1 ] \
+    && [ "$phase_after_clean_started" -eq 0 ] \
+    && is_phase_after_clean_platform "$platform_name"; then
+  ensure_pr_ready_for_ready_phase 99 || true
+  phase_after_clean_started=1
+  _call_order+=("phase_done")
+fi
+if is_expensive_reviewer_platform "$platform_name"; then
+  platform_reviewed_heads=("local-ai-reviewer:$_other")
+  expensive_reviewer_gate 99 "$platform_name" "$loop_head_sha" >/dev/null || true
+  _call_order+=("gate")
+fi
+run_test "1649_s16_phase_before_gate" "ready_phase phase_done gate" "${_call_order[*]}"
+run_test "1649_s16_phase_started" "1" "${phase_after_clean_started:-unset}"
+
+# --- Scenario 17: --pre-after-clean-only filters phase expensive before gate ---
+platforms=(local-ai-reviewer codex-github)
+phase_after_clean_platforms=(codex-github)
+phase_after_clean_started=0
+filter_pre_after_clean_platforms
+_gate_called=0
+# Do not shadow expensive_reviewer_gate (hard to restore). Instead assert
+# codex-github was removed from platforms so the gate would never be consulted.
+run_test "1649_s17_codex_filtered_out" "local-ai-reviewer" \
+  "$(IFS=,; printf '%s' "${platforms[*]}")"
+run_test "1649_s17_codex_not_in_list" "1" \
+  "$(is_expensive_reviewer_platform codex-github && array_contains_value codex-github "${platforms[@]:-}" && echo 0 || echo 1)"
+
+# --- Scenario 21: draft-phase defer does not start ready phase ---
+_ready_called=0
+ensure_pr_ready_for_ready_phase() { _ready_called=1; return 0; }
+_run_platform_called=()
+phase_after_clean_started=0
+platforms=(local-ai-reviewer pr-agent codex-github bugbot)
+phase_after_clean_platforms=(bugbot)
+reorder_expensive_reviewers_last
+platform_peer_evidence=()
+platform_reviewed_heads=("local-ai-reviewer:$_head")
+expensive_gate_max_deferrals=3
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+loop_head_sha="$_head"
+aggregate_result="skipped"
+# Force defer by clearing peers after local-ai "runs", then hitting gate with
+# stale local evidence before bugbot.
+for platform_name in "${platforms[@]}"; do
+  if is_phase_after_clean_platform "$platform_name" && [ "${phase_after_clean_started:-0}" -eq 0 ]; then
+    ensure_pr_ready_for_ready_phase 1
+    phase_after_clean_started=1
+  fi
+  if is_expensive_reviewer_platform "$platform_name"; then
+    platform_reviewed_heads=("local-ai-reviewer:$_other")
+    if ! expensive_reviewer_gate 21 "$platform_name" "$_head" >/dev/null; then
+      aggregate_result="needs_fixes"
+      break
+    fi
+  fi
+  _run_platform_called+=("$platform_name")
+  platform_peer_evidence+=("${platform_name}|clean|")
+done
+run_test "1649_s21_ready_not_called" "0" "${_ready_called}"
+run_test "1649_s21_bugbot_not_run" "0" \
+  "$(printf '%s\n' "${_run_platform_called[@]:-}" | grep -c '^bugbot$' || true)"
+run_test "1649_s21_aggregate_needs_fixes" "needs_fixes" "$aggregate_result"
+run_contains "1649_s21_no_bugbot_in_ran" "local-ai-reviewer" \
+  "$(IFS=,; printf '%s' "${_run_platform_called[*]}")"
+
+# Docs parity: both docs mention both escalation values
+_p93="$REPO_ROOT/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md"
+_cg="$REPO_ROOT/docs/workflow/development-workflow/integrations/codex-github.md"
+run_contains "1649_docs_p93_cap" "expensive_gate_deferral_cap" "$(cat "$_p93")"
+run_contains "1649_docs_p93_unreadable" "expensive_gate_deferral_budget_unreadable" "$(cat "$_p93")"
+run_contains "1649_docs_cg_cap" "expensive_gate_deferral_cap" "$(cat "$_cg")"
+run_contains "1649_docs_cg_unreadable" "expensive_gate_deferral_budget_unreadable" "$(cat "$_cg")"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # test-pr-ci-loop.sh - CI loop verdict tests.
 # covers: scripts/development-workflow/pr-ci-loop.sh
+# covers: scripts/development-workflow/workflow-lib.sh
 #
 # Focus: the CI-evidence gate (#1514, #1580). "No failing and no pending
 # checks" is not evidence that CI ran — a head can legitimately carry zero

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -296,6 +296,12 @@ case "$*" in
   # gh pr view --json headRefOid — used by run_copilot_review to resolve head SHA.
   # Tests set MOCK_GH_HEAD_SHA to control the returned value; default empty string
   # triggers the head-sha-unavailable escalation path.
+  # When statusCheckRollup is also requested (#1649 expensive gate baseline helper),
+  # return the combined payload from MOCK_GH_PR_VIEW_ROLLUP (full JSON object).
+  *"statusCheckRollup"*)
+    printf '%s\n' "${MOCK_GH_PR_VIEW_ROLLUP:-{\"statusCheckRollup\":[],\"headRefOid\":\"${MOCK_GH_HEAD_SHA:-}\"}}"
+    exit "${MOCK_GH_EXIT:-0}"
+    ;;
   *"headRefOid"*)
     printf '%s\n' "${MOCK_GH_HEAD_SHA:-}"
     exit "${MOCK_GH_EXIT:-0}"
@@ -16390,7 +16396,52 @@ run_test "1649_s10_pending" "deferred|baseline_checks_pending" "$(_1649_checks_r
 run_test "1649_s10_green" "dispatched|" "$(_1649_checks_row green)"
 run_test "1649_s10_empty" "deferred|baseline_checks_unobserved" "$(_1649_checks_row empty)"
 
-# --- Scenario 11: evidence head moved ---
+# --- Scenario 10 real helper (no stub): parse rollup, exclude reviewer checks ---
+unset -f expensive_gate_baseline_checks_status
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
+
+_1649_baseline_helper_row() {
+  local rollup="$1"
+  export MOCK_GH_PR_VIEW_ROLLUP="$rollup"
+  export MOCK_GH_EXIT=0
+  expensive_gate_baseline_checks_status 42 "$_1649_head"
+}
+
+_1649_green_rollup='{"statusCheckRollup":[{"name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"'"$_1649_head"'"}'
+_1649_fail_rollup='{"statusCheckRollup":[{"name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE"},{"name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"'"$_1649_head"'"}'
+_1649_pending_rollup='{"statusCheckRollup":[{"name":"ShellCheck","status":"IN_PROGRESS","conclusion":null},{"name":"lint","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"'"$_1649_head"'"}'
+_1649_exclude_rollup='{"statusCheckRollup":[{"name":"Cursor Bugbot","status":"IN_PROGRESS","conclusion":null},{"name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"'"$_1649_head"'"}'
+_1649_empty_rollup='{"statusCheckRollup":[],"headRefOid":"'"$_1649_head"'"}'
+_1649_reviewer_only_rollup='{"statusCheckRollup":[{"name":"Cursor Bugbot","status":"COMPLETED","conclusion":"SUCCESS"}],"headRefOid":"'"$_1649_head"'"}'
+
+run_test "1649_s10_real_green" "green $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_green_rollup")"
+run_test "1649_s10_real_failed" "failed $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_fail_rollup")"
+run_test "1649_s10_real_pending" "pending $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_pending_rollup")"
+# Pending reviewer-owned check + green non-reviewer → green (exclusion)
+run_test "1649_s10_real_exclude_reviewer" "green $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_exclude_rollup")"
+run_test "1649_s10_real_empty" "empty $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_empty_rollup")"
+run_test "1649_s10_real_reviewer_only" "empty $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_reviewer_only_rollup")"
+export MOCK_GH_EXIT=1
+run_test "1649_s10_real_unavailable" "unavailable" \
+  "$(expensive_gate_baseline_checks_status 42 "$_1649_head" | awk '{print $1}')"
+export MOCK_GH_EXIT=0
+unset MOCK_GH_PR_VIEW_ROLLUP
+# Restore stubs for remaining gate scenarios.
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "${MOCK_THREADS_HEAD:-$_1649_head}"; }
+expensive_gate_baseline_checks_status() {
+  printf '%s %s\n' "${MOCK_CHECKS_STATE:-green}" "${MOCK_CHECKS_HEAD:-$_1649_head}"
+}
+platforms=(local-ai-reviewer pr-agent codex-github)
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+
 expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_other"; }
 expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_1649_head"; }
 _out="$(_1649_run_gate)"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16400,6 +16400,8 @@ run_test "1649_s10_empty" "deferred|baseline_checks_unobserved" "$(_1649_checks_
 unset -f expensive_gate_baseline_checks_status
 HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
 expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
+# Earlier areas prepend their own mock dirs to PATH; pin the harness mock again.
+export PATH="$MOCK_BIN:$PATH"
 
 _1649_baseline_helper_row() {
   local rollup="$1"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16493,15 +16493,16 @@ platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
 # --- Scenario 13 / 14: deferral cap + head-scoped ---
 _1649_ledger_entries() {
   local n="$1" head="${2:-$_1649_head}"
-  local i entries="["
+  local i
+  local _1649_json_entries="["
   for i in $(seq 1 "$n"); do
-    [ "$i" -gt 1 ] && entries+=","
-    entries+="{\"result\":\"needs_fixes\",\"reason\":\"expensive_gate_deferred\",\"head_sha\":\"$head\",\"expensive_gate\":{\"platform\":\"codex-github\",\"result\":\"deferred\",\"reason\":\"baseline_checks_pending\",\"head\":\"$head\"}}"
+    [ "$i" -gt 1 ] && _1649_json_entries+=","
+    _1649_json_entries+="{\"result\":\"needs_fixes\",\"reason\":\"expensive_gate_deferred\",\"head_sha\":\"$head\",\"expensive_gate\":{\"platform\":\"codex-github\",\"result\":\"deferred\",\"reason\":\"baseline_checks_pending\",\"head\":\"$head\"}}"
   done
-  entries+="]"
+  _1649_json_entries+="]"
   printf '%s\n' "<!-- reviewer-loop-history:v1 -->
 \`\`\`json
-{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"available\",\"entries\":${entries}}
+{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"available\",\"entries\":${_1649_json_entries}}
 \`\`\`"
 }
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -298,8 +298,15 @@ case "$*" in
   # triggers the head-sha-unavailable escalation path.
   # When statusCheckRollup is also requested (#1649 expensive gate baseline helper),
   # return the combined payload from MOCK_GH_PR_VIEW_ROLLUP (full JSON object).
+  # Do not use ${VAR:-{...}} here: bash ends the expansion at the first `}` inside
+  # the default, so a set MOCK_GH_PR_VIEW_ROLLUP would be printed with a trailing
+  # literal `}` and become invalid JSON.
   *"statusCheckRollup"*)
-    printf '%s\n' "${MOCK_GH_PR_VIEW_ROLLUP:-{\"statusCheckRollup\":[],\"headRefOid\":\"${MOCK_GH_HEAD_SHA:-}\"}}"
+    if [ -n "${MOCK_GH_PR_VIEW_ROLLUP+x}" ]; then
+      printf '%s\n' "$MOCK_GH_PR_VIEW_ROLLUP"
+    else
+      printf '{"statusCheckRollup":[],"headRefOid":"%s"}\n' "${MOCK_GH_HEAD_SHA:-}"
+    fi
     exit "${MOCK_GH_EXIT:-0}"
     ;;
   *"headRefOid"*)
@@ -16400,8 +16407,13 @@ run_test "1649_s10_empty" "deferred|baseline_checks_unobserved" "$(_1649_checks_
 unset -f expensive_gate_baseline_checks_status
 HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
 expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
-# Earlier areas prepend their own mock dirs to PATH; pin the harness mock again.
+# Pin harness mock + clear command hash; earlier areas may leave a different gh
+# ahead on PATH or hashed from a temporary mock dir that was later removed.
 export PATH="$MOCK_BIN:$PATH"
+hash -r
+# Deterministic reviewer-check names so exclusion cases do not depend on the
+# live .ai-dev-workflow.yaml / local override contents in this checkout.
+configured_reviewer_check_names_json() { printf '["Cursor Bugbot"]\n'; }
 
 _1649_baseline_helper_row() {
   local rollup="$1"
@@ -16435,6 +16447,7 @@ run_test "1649_s10_real_unavailable" "unavailable" \
   "$(expensive_gate_baseline_checks_status 42 "$_1649_head" | awk '{print $1}')"
 export MOCK_GH_EXIT=0
 unset MOCK_GH_PR_VIEW_ROLLUP
+unset -f configured_reviewer_check_names_json
 # Restore stubs for remaining gate scenarios.
 expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "${MOCK_THREADS_HEAD:-$_1649_head}"; }
 expensive_gate_baseline_checks_status() {

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16442,6 +16442,10 @@ run_test "1649_s10_real_empty" "empty $_1649_head" \
   "$(_1649_baseline_helper_row "$_1649_empty_rollup")"
 run_test "1649_s10_real_reviewer_only" "empty $_1649_head" \
   "$(_1649_baseline_helper_row "$_1649_reviewer_only_rollup")"
+# Stale failed duplicate + newer green same name → green (pr-ci-loop normalization)
+_1649_dup_rollup='{"statusCheckRollup":[{"name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE","startedAt":"2026-01-01T00:00:00Z"},{"name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-01-01T01:00:00Z"}],"headRefOid":"'"$_1649_head"'"}'
+run_test "1649_s10_real_dup_latest_green" "green $_1649_head" \
+  "$(_1649_baseline_helper_row "$_1649_dup_rollup")"
 export MOCK_GH_EXIT=1
 run_test "1649_s10_real_unavailable" "unavailable" \
   "$(expensive_gate_baseline_checks_status 42 "$_1649_head" | awk '{print $1}')"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16338,7 +16338,7 @@ platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
 # Force configured=1 and head current via reviewed heads, but no peers ran
 # Condition 1 needs local-ai in platforms AND reviewed head — local-ai is in list
 # but hasn't "run" as peer yet; for condition 1 we only need membership + heads.
-# Peer set = empty (codex is first) → dispatched on empty peer set? 
+# Peer set = empty (codex is first) → dispatched on empty peer set?
 # Actually peer set is empty when expensive is first → check_peers returns empty → OK for peers.
 # The plan says suppressed reorder so a same-bucket peer has not run → deferred peer_reviewer_not_run.
 # So we need: list order codex, pr-agent with pr-agent not in peer evidence... wait if codex is first,

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16159,6 +16159,366 @@ unset _sha_a _sha_b _sha_a_upper _sha_abbrev _sha_39 _sha_41 _sha_non_hex _unkno
 unset _1648_render _1648_json _1648_legacy_payload _1648_carry_capture
 
 # ---------------------------------------------------------------------------
+# Area 1649: expensive reviewer gate
+# Scenarios 1–14, 14b, 18, 19, 19b (composition/override live in
+# test-expensive-reviewer-gate.sh).
+# ---------------------------------------------------------------------------
+echo "=== Area 1649: expensive reviewer gate ==="
+
+_1649_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_1649_other="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+# --- Scenario 1: is_expensive_reviewer_platform ---
+run_test "1649_s1_matches_codex" "0" \
+  "$(is_expensive_reviewer_platform codex-github; printf '%s' $?)"
+run_test "1649_s1_rejects_local" "1" \
+  "$(is_expensive_reviewer_platform local-ai-reviewer; printf '%s' $?)"
+run_test "1649_s1_rejects_pr_agent" "1" \
+  "$(is_expensive_reviewer_platform pr-agent; printf '%s' $?)"
+run_test "1649_s1_rejects_bugbot" "1" \
+  "$(is_expensive_reviewer_platform bugbot; printf '%s' $?)"
+
+# --- Scenario 6 / 6b: reorder ---
+platforms=(codex-github pr-agent local-ai-reviewer)
+phase_after_clean_platforms=()
+expensive_reviewers_reordered=0
+reorder_expensive_reviewers_last
+run_test "1649_s6_moves_codex_last" "pr-agent,local-ai-reviewer,codex-github" \
+  "$(IFS=,; printf '%s' "${platforms[*]}")"
+run_test "1649_s6_flag_set" "1" "$expensive_reviewers_reordered"
+
+platforms=(pr-agent local-ai-reviewer codex-github)
+expensive_reviewers_reordered=0
+reorder_expensive_reviewers_last
+run_test "1649_s6_already_correct_untouched" "0" "$expensive_reviewers_reordered"
+
+platforms=(codex-github pr-agent local-ai-reviewer bugbot)
+phase_after_clean_platforms=(bugbot)
+expensive_reviewers_reordered=0
+reorder_expensive_reviewers_last
+run_test "1649_s6b_phase_bucket" "pr-agent,local-ai-reviewer,codex-github,bugbot" \
+  "$(IFS=,; printf '%s' "${platforms[*]}")"
+run_test "1649_s6b_codex_before_bugbot" "1" \
+  "$(printf '%s\n' "${platforms[@]}" | awk '/codex-github/{c=NR} /bugbot/{b=NR} END{print (c<b)?1:0}')"
+
+# --- Scenario 14b: resolve max deferrals ---
+unset PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS
+run_test "1649_s14b_unset" "3" "$(expensive_gate_resolve_max_deferrals)"
+PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS=
+run_test "1649_s14b_empty" "3" "$(expensive_gate_resolve_max_deferrals)"
+PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS=1
+run_test "1649_s14b_one" "1" "$(expensive_gate_resolve_max_deferrals)"
+PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS=999999
+run_test "1649_s14b_max" "999999" "$(expensive_gate_resolve_max_deferrals)"
+for bad in 0 -1 1000000 abc 2.5 " 2 "; do
+  PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS="$bad"
+  _warn="$(expensive_gate_resolve_max_deferrals 2>&1 >/dev/null)" || true
+  _val="$(PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS="$bad" expensive_gate_resolve_max_deferrals 2>/dev/null)"
+  run_test "1649_s14b_reject_${bad// /ws}" "3" "$_val"
+  run_contains "1649_s14b_warn_${bad// /ws}" "WARN" "$_warn"
+done
+unset PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS
+expensive_gate_max_deferrals="$(expensive_gate_resolve_max_deferrals)"
+
+# Shared stubs for gate evaluation (conditions 3–4 satisfied unless overridden).
+_1649_stub_green_evidence() {
+  expensive_gate_unresolved_threads_status() {
+    printf 'ok 0 %s\n' "${MOCK_THREADS_HEAD:-$_1649_head}"
+  }
+  expensive_gate_baseline_checks_status() {
+    printf '%s %s\n' "${MOCK_CHECKS_STATE:-green}" "${MOCK_CHECKS_HEAD:-$_1649_head}"
+  }
+}
+
+_1649_run_gate() {
+  local out rc=0
+  local pr="${1:-42}"
+  local platform="${2:-codex-github}"
+  # Allow explicit empty head (scenario 12); only default when unset.
+  local head="${3-$_1649_head}"
+  out="$(expensive_reviewer_gate "$pr" "$platform" "$head" 2>/dev/null)" || rc=$?
+  printf '%s\n---RC=%s\n' "$out" "$rc"
+}
+
+_1649_kv() {
+  local key="$1" blob="$2"
+  printf '%s\n' "$blob" | grep "^${key}=" | head -1 | cut -d= -f2-
+}
+
+# --- Scenario 2: all conditions met → dispatched ---
+_1649_stub_green_evidence
+platforms=(local-ai-reviewer pr-agent codex-github)
+phase_after_clean_platforms=()
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+expensive_gate_max_deferrals=3
+_out="$(_1649_run_gate)"
+run_test "1649_s2_dispatched" "dispatched" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+run_test "1649_s2_reason_empty" "" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+run_test "1649_s2_rc0" "0" "$(grep -E '^---RC=' <<<"$_out" | cut -d= -f2)"
+
+# --- Scenario 3: stale local evidence ---
+platform_reviewed_heads=("local-ai-reviewer:$_1649_other")
+_out="$(_1649_run_gate)"
+run_test "1649_s3_deferred" "deferred" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+run_test "1649_s3_stale" "local_evidence_stale" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+run_test "1649_s3_rc1" "1" "$(grep -E '^---RC=' <<<"$_out" | cut -d= -f2)"
+
+# --- Scenario 4: unexpected / absent local evidence values ---
+# Stub configured/head_current helpers directly for allow-list rows.
+_orig_cfg="$(declare -f expensive_gate_local_ai_configured)"
+_orig_hc="$(declare -f expensive_gate_local_ai_head_current)"
+_1649_stub_row() {
+  local cfg="$1" hc="$2"
+  expensive_gate_local_ai_configured() { printf '%s\n' "$cfg"; }
+  expensive_gate_local_ai_head_current() { printf '%s\n' "$hc"; }
+  platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+  platforms=(local-ai-reviewer pr-agent codex-github)
+  platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+  _out="$(_1649_run_gate)"
+  printf '%s\n' "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+}
+run_test "1649_s4_empty_cfg" "local_evidence_missing" "$(_1649_stub_row "" "1")"
+run_test "1649_s4_cfg_2" "local_evidence_missing" "$(_1649_stub_row "2" "1")"
+run_test "1649_s4_cfg_true" "local_evidence_missing" "$(_1649_stub_row "true" "1")"
+run_test "1649_s4_empty_hc" "local_evidence_missing" "$(_1649_stub_row "1" "")"
+run_test "1649_s4_hc_2" "local_evidence_missing" "$(_1649_stub_row "1" "2")"
+run_test "1649_s4_hc_yes" "local_evidence_missing" "$(_1649_stub_row "1" "yes")"
+eval "$_orig_cfg"
+eval "$_orig_hc"
+
+# --- Scenario 5: local reviewer not configured ---
+platforms=(pr-agent codex-github)
+platform_reviewed_heads=()
+platform_peer_evidence=("pr-agent|clean|")
+_out="$(_1649_run_gate)"
+run_test "1649_s5_not_configured" "local_reviewer_not_configured" \
+  "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+
+# Restore for peer scenarios
+platforms=(local-ai-reviewer pr-agent codex-github)
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+
+# --- Scenario 7: peer set phase-scoped ---
+platforms=(local-ai-reviewer pr-agent codex-github bugbot)
+phase_after_clean_platforms=(bugbot)
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+# bugbot has not run — must still dispatch (not in peer set for draft codex)
+_out="$(_1649_run_gate)"
+run_test "1649_s7_draft_ignores_ready_peer" "dispatched" \
+  "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+
+# Ready-phase expensive waits on whole draft bucket
+platforms=(local-ai-reviewer pr-agent codex-github)
+phase_after_clean_platforms=(codex-github)
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+_out="$(_1649_run_gate)"
+run_test "1649_s7_ready_waits_draft" "dispatched" \
+  "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+
+# Suppressed reorder: peer not run
+platforms=(codex-github local-ai-reviewer pr-agent)
+phase_after_clean_platforms=()
+platform_peer_evidence=()
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+# Force configured=1 and head current via reviewed heads, but no peers ran
+# Condition 1 needs local-ai in platforms AND reviewed head — local-ai is in list
+# but hasn't "run" as peer yet; for condition 1 we only need membership + heads.
+# Peer set = empty (codex is first) → dispatched on empty peer set? 
+# Actually peer set is empty when expensive is first → check_peers returns empty → OK for peers.
+# The plan says suppressed reorder so a same-bucket peer has not run → deferred peer_reviewer_not_run.
+# So we need: list order codex, pr-agent with pr-agent not in peer evidence... wait if codex is first,
+# peers before it are empty. The scenario means: after reorder would put codex last, but without
+# reorder codex is first and when we get to pr-agent later... Actually when gate runs for codex
+# at index 0, peer set is empty so peers pass. The "suppressed reorder" case needs:
+# platforms with pr-agent BEFORE codex in the list that the gate sees, but pr-agent not yet in
+# platform_peer_evidence — which can't happen in sequential iteration unless we call the gate
+# as if somehow out of order. The plan says: "Reorder suppressed so a same-bucket peer has not run"
+# So: list is [local-ai, pr-agent, codex] but peer evidence only has local-ai (pr-agent missing).
+platforms=(local-ai-reviewer pr-agent codex-github)
+platform_peer_evidence=("local-ai-reviewer|clean|")
+_out="$(_1649_run_gate)"
+run_test "1649_s7_peer_not_run" "peer_reviewer_not_run" \
+  "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+
+# --- Scenario 8: peer evidence acceptance ---
+_1649_peer_row() {
+  local result="$1" reason="$2"
+  platforms=(local-ai-reviewer pr-agent codex-github)
+  phase_after_clean_platforms=()
+  platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+  platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|${result}|${reason}")
+  _out="$(_1649_run_gate)"
+  printf '%s|%s\n' "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+}
+run_test "1649_s8_clean" "dispatched|" "$(_1649_peer_row clean "")"
+run_test "1649_s8_skip_not_configured" "dispatched|" "$(_1649_peer_row skipped not_configured)"
+run_test "1649_s8_skip_explicit" "dispatched|" "$(_1649_peer_row skipped explicit-skip)"
+run_test "1649_s8_skip_release" "dispatched|" "$(_1649_peer_row skipped release_pr)"
+run_test "1649_s8_skip_unsupported" "dispatched|" "$(_1649_peer_row skipped unsupported-platform)"
+run_test "1649_s8_skip_unavailable" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row skipped unavailable)"
+run_test "1649_s8_skip_timeout" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row skipped timeout)"
+run_test "1649_s8_skip_unauthorized" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row skipped unauthorized)"
+run_test "1649_s8_needs_fixes" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row needs_fixes "")"
+run_test "1649_s8_escalate" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row escalate "")"
+run_test "1649_s8_skip_unknown" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row skipped some_future_reason)"
+run_test "1649_s8_skip_empty" "deferred|peer_reviewer_not_clean" "$(_1649_peer_row skipped "")"
+
+# --- Scenario 9: unresolved threads ---
+platforms=(local-ai-reviewer pr-agent codex-github)
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+expensive_gate_unresolved_threads_status() { printf 'ok 1 %s\n' "$_1649_head"; }
+expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_1649_head"; }
+_out="$(_1649_run_gate)"
+run_test "1649_s9_unresolved" "unresolved_threads" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
+_out="$(_1649_run_gate)"
+run_test "1649_s9_outdated_ok" "dispatched" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+
+# --- Scenario 10: baseline checks ---
+_1649_checks_row() {
+  local state="$1"
+  expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
+  expensive_gate_baseline_checks_status() { printf '%s %s\n' "$state" "$_1649_head"; }
+  _out="$(_1649_run_gate)"
+  printf '%s|%s\n' "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+}
+run_test "1649_s10_failed" "deferred|baseline_checks_not_green" "$(_1649_checks_row failed)"
+run_test "1649_s10_pending" "deferred|baseline_checks_pending" "$(_1649_checks_row pending)"
+run_test "1649_s10_green" "dispatched|" "$(_1649_checks_row green)"
+run_test "1649_s10_empty" "deferred|baseline_checks_unobserved" "$(_1649_checks_row empty)"
+
+# --- Scenario 11: evidence head moved ---
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_other"; }
+expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_1649_head"; }
+_out="$(_1649_run_gate)"
+run_test "1649_s11_threads_head_moved" "evidence_head_moved" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
+expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_1649_other"; }
+_out="$(_1649_run_gate)"
+run_test "1649_s11_checks_head_moved" "evidence_head_moved" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+
+# --- Scenario 12: unreadable inputs ---
+_out="$(_1649_run_gate 42 codex-github "")"
+run_test "1649_s12_empty_head" "evidence_unavailable_head" "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+expensive_gate_unresolved_threads_status() { printf 'unavailable - \n'; }
+expensive_gate_baseline_checks_status() { printf 'green %s\n' "$_1649_head"; }
+_out="$(_1649_run_gate)"
+run_test "1649_s12_threads_fail" "evidence_unavailable_review_threads" \
+  "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+expensive_gate_unresolved_threads_status() { printf 'ok 0 %s\n' "$_1649_head"; }
+expensive_gate_baseline_checks_status() { printf 'unavailable \n'; }
+_out="$(_1649_run_gate)"
+run_test "1649_s12_checks_fail" "evidence_unavailable_checks" \
+  "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+
+# Restore green stubs
+_1649_stub_green_evidence
+platforms=(local-ai-reviewer pr-agent codex-github)
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+platform_peer_evidence=("local-ai-reviewer|clean|" "pr-agent|clean|")
+
+# --- Scenario 13 / 14: deferral cap + head-scoped ---
+_1649_ledger_entries() {
+  local n="$1" head="${2:-$_1649_head}"
+  local i entries="["
+  for i in $(seq 1 "$n"); do
+    [ "$i" -gt 1 ] && entries+=","
+    entries+="{\"result\":\"needs_fixes\",\"reason\":\"expensive_gate_deferred\",\"head_sha\":\"$head\",\"expensive_gate\":{\"platform\":\"codex-github\",\"result\":\"deferred\",\"reason\":\"baseline_checks_pending\",\"head\":\"$head\"}}"
+  done
+  entries+="]"
+  printf '%s\n' "<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"available\",\"entries\":${entries}}
+\`\`\`"
+}
+
+expensive_gate_max_deferrals=3
+# Force a defer reason (stale local) with 3 prior deferrals → cap
+platform_reviewed_heads=("local-ai-reviewer:$_1649_other")
+EXPENSIVE_GATE_MOCK_LEDGER_BODY="$(_1649_ledger_entries 3)"
+_out="$(_1649_run_gate)"
+run_test "1649_s13_cap" "deferral_cap" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+run_test "1649_s13_escalation" "expensive_gate_deferral_cap" \
+  "$(_1649_kv EXPENSIVE_GATE_ESCALATION "$_out")"
+run_test "1649_s13_reason_preserved" "local_evidence_stale" \
+  "$(_1649_kv EXPENSIVE_GATE_REASON "$_out")"
+
+EXPENSIVE_GATE_MOCK_LEDGER_BODY="$(_1649_ledger_entries 2)"
+_out="$(_1649_run_gate)"
+run_test "1649_s13_under_cap_defers" "deferred" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+
+# Scenario 14: deferrals on other head do not count
+EXPENSIVE_GATE_MOCK_LEDGER_BODY="$(_1649_ledger_entries 3 "$_1649_other")"
+_out="$(_1649_run_gate)"
+run_test "1649_s14_other_head_ignored" "deferred" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+run_test "1649_s14_deferrals_zero" "0" "$(_1649_kv EXPENSIVE_GATE_DEFERRALS "$_out")"
+
+# --- Scenario 18: legacy ledger without expensive_gate still parses ---
+_legacy_body='<!-- reviewer-loop-history:v1 -->
+```json
+{"schema":"reviewer_loop_history.v1","history_status":"available","entries":[{"iteration":1,"result":"clean","reason":"","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","platforms":[]}]}
+```'
+_legacy_payload="$(reviewer_loop_history_payload_from_existing "$_legacy_body" needs_fixes expensive_gate_deferred "codex-github" 0 0 0 "" 0 0 "")"
+run_test "1649_s18_legacy_parses" "available" \
+  "$(printf '%s\n' "$_legacy_payload" | jq -r '.history_status')"
+run_test "1649_s18_has_entries" "2" \
+  "$(printf '%s\n' "$_legacy_payload" | jq -r '.entries | length')"
+
+# --- Scenario 19: unreadable budget ---
+EXPENSIVE_GATE_MOCK_LEDGER_BODY="<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+{not-json
+\`\`\`"
+platform_reviewed_heads=("local-ai-reviewer:$_1649_other")
+_out="$(_1649_run_gate)"
+run_test "1649_s19_unreadable" "deferral_cap" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+run_test "1649_s19_escalation" "expensive_gate_deferral_budget_unreadable" \
+  "$(_1649_kv EXPENSIVE_GATE_ESCALATION "$_out")"
+run_test "1649_s19_deferrals_neg1" "-1" "$(_1649_kv EXPENSIVE_GATE_DEFERRALS "$_out")"
+
+# --- Scenario 19b: absent ledger → 0 ---
+unset EXPENSIVE_GATE_MOCK_LEDGER_BODY
+EXPENSIVE_GATE_MOCK_LEDGER_BODY=""
+_out="$(_1649_run_gate)"
+run_test "1649_s19b_absent_zero" "0" "$(_1649_kv EXPENSIVE_GATE_DEFERRALS "$_out")"
+run_test "1649_s19b_defers_normally" "deferred" "$(_1649_kv EXPENSIVE_GATE_RESULT "$_out")"
+
+# Build entry includes expensive_gate object
+expensive_gate_last_platform="codex-github"
+expensive_gate_last_result="deferred"
+expensive_gate_last_reason="local_evidence_stale"
+expensive_gate_last_head="$_1649_head"
+loop_head_sha="$_1649_head"
+pr_number=""
+current_run_id="test-run"
+platform_reviewed_heads=("local-ai-reviewer:$_1649_head")
+_entry="$(reviewer_loop_history_build_entry 1 needs_fixes expensive_gate_deferred "local-ai-reviewer,codex-github" 0 0 0 "" 0 0 "")"
+run_test "1649_history_has_gate" "deferred" \
+  "$(printf '%s\n' "$_entry" | jq -r '.expensive_gate.result')"
+run_test "1649_history_gate_reason" "local_evidence_stale" \
+  "$(printf '%s\n' "$_entry" | jq -r '.expensive_gate.reason')"
+
+# Cleanup stubs / state
+unset EXPENSIVE_GATE_MOCK_LEDGER_BODY
+unset -f expensive_gate_unresolved_threads_status expensive_gate_baseline_checks_status 2>/dev/null || true
+# Re-source would be heavy; leave defaults — later suites redefine if needed.
+expensive_gate_last_platform=""
+expensive_gate_last_result=""
+expensive_gate_last_reason=""
+expensive_gate_last_head=""
+platform_peer_evidence=()
+platform_reviewed_heads=()
+platforms=()
+phase_after_clean_platforms=()
+unset _1649_head _1649_other _out _entry _legacy_body _legacy_payload _warn _val
+unset _orig_cfg _orig_hc
+
+echo "=== Area 1649 complete ==="
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -476,6 +476,51 @@ print_kv() {
   printf '%s=%s\n' "$1" "$2"
 }
 
+# configured_reviewer_check_names_json [config_file]
+#
+# Returns a JSON array of GitHub check-run names owned by configured review
+# platforms (haystack → Haystack / Review, bugbot → Cursor Bugbot). Shared by
+# pr-ci-loop.sh (to exclude reviewer checks from the baseline CI set) and
+# pr-review-loop.sh (expensive-reviewer gate baseline-check classification).
+# Relocated from pr-ci-loop.sh (#1649) with no behavior change.
+configured_reviewer_check_names_json() {
+  local config_file="${1:-}"
+  local platform=""
+  local -a names=()
+
+  if [ -z "$config_file" ]; then
+    config_file="$(workflow_effective_config_file 2>/dev/null || workflow_config_file)"
+  fi
+
+  if [ -f "$config_file" ]; then
+    while IFS= read -r platform; do
+      platform="$(printf '%s' "$platform" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [ -z "$platform" ] && continue
+      case "$platform" in
+        haystack)
+          names+=("${HAYSTACK_CHECK_NAME:-Haystack / Review}")
+          ;;
+        bugbot)
+          names+=("${BUGBOT_CHECK_NAME:-Cursor Bugbot}")
+          ;;
+      esac
+    done < <(
+      if [ "$config_file" = "$(workflow_config_file)" ]; then
+        WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_platforms "$config_file"
+      else
+        workflow_config_review_platforms "$config_file"
+      fi
+    )
+  fi
+
+  if [ "${#names[@]}" -eq 0 ]; then
+    printf '[]\n'
+    return 0
+  fi
+
+  printf '%s\n' "${names[@]}" | jq -R . | jq -s .
+}
+
 print_kv_escaped() {
   local value="$2"
   value="${value//\\/\\\\}"


### PR DESCRIPTION
## Summary
- Gate `codex-github` (expensive reviewer) so it runs only after current-head local-clean evidence, preceding peer evidence, resolved threads, and green non-reviewer baseline checks.
- Defer fail-closed with `needs_fixes` / `expensive_gate_deferred` (breaks iteration so ready-phase cannot start), bounded by a head-scoped deferral counter with dual escalations.
- Relocate `configured_reviewer_check_names_json` to `workflow-lib.sh` for shared baseline/reviewer check classification; reorder expensive reviewers last within each phase bucket.

Closes #1649

## Workflow mode / routing
- Mode: `single_repo` (artifact owner: hub/template repo)
- Mutation target / artifact repo root: `/Users/lhpaul/Git/ai-dev-framework-template`
- Worktree: `.claude/worktrees/1649/refactor-1649-expensive-reviewers-after-local-clean`
- Approved base: `develop-internal-reviewer-effectiveness`
- Cross-Cutting assumptions: **Still valid** (#1648 / PR #1660 merged; `LOCAL_AI_*` keys present)

## Test plan
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 1317 passed (includes Area 1649 scenarios 1–14, 14b, 18, 19, 19b)
- [x] `bash scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — 19 passed (15–17, 21, 22 + docs parity)
- [x] `bash scripts/development-workflow/tests/test-pr-ci-loop.sh` — 21 passed (scenario 20 / relocation)
- [x] `select-test-suites.sh` selects `test-expensive-reviewer-gate.sh` for `pr-review-loop.sh` changes
- [x] shellcheck (warning) on `pr-review-loop.sh`, `pr-ci-loop.sh`, `workflow-lib.sh`, `test-expensive-reviewer-gate.sh`
- [x] markdownlint on Protocol 93 + `codex-github.md`
- [x] changelog fragment validated

## Pre-Submission Self-Review Pass
- Reviewed `git diff develop-internal-reviewer-effectiveness...HEAD`
- Gate call sits immediately before `run_platform_review`, guarded by `is_expensive_reviewer_platform`
- Deferred/deferral_cap break out of platform iteration (scenario 21)
- Peer allow-list + `reviewer_failed_label_required_for_result` both asserted (scenario 8)
- Condition 1 exact-match allow-list (scenario 4 / P12)
- Local evidence derived in-loop, not from `LOCAL_AI_*` env (scenario 22 / P17)
- `expensive_gate` history object additive; legacy entries still parse (scenario 18)
- Protocol 93 and `codex-github.md` carry matching `EXPENSIVE_GATE_ESCALATION` contract
- No stale TODO/FIXME markers introduced

## Planted-Violation Proofs

Each proof is pinned to a concrete harness assertion. Fail direction = assertion expects the deferred/escalate/blocked outcome; pass direction = restore the production check and re-run the same scenario (green).

| # | Violation | Concrete fail assertion | Pass / restore |
| --- | --- | --- | --- |
| P1 | Stale local evidence | `test-pr-review-loop.sh:16277` (`1649_s3_deferred`) / `:16278` (`1649_s3_stale`) | restore current `platform_reviewed_heads` → `1649_s9_outdated_ok` / green gate rows |
| P2 | Missing / non-exact local evidence | `test-pr-review-loop.sh:16295-16297` (`1649_s4_empty_cfg` / `cfg_2` / `cfg_true`) | exact `1` → dispatch scenarios |
| P3 | Unreadable threads/checks/head | `test-pr-review-loop.sh:16471` / `:16475` / `:16480` (`1649_s12_*`) | restore stubs → dispatch |
| P4 | Gate not wired before dispatch | production call `pr-review-loop.sh:9529` (`expensive_reviewer_gate` before `run_platform_review`); delete → Area 1649 s3 would not emit `EXPENSIVE_GATE_*` | restore call |
| P5 | Reorder deleted | `test-pr-review-loop.sh:16199` (`1649_s6_moves_codex_last`) | restore `reorder_expensive_reviewers_last` |
| P6 | Defer leaves aggregate clean | `test-pr-review-loop.sh:16279` (`1649_s3_rc1`) + composition `test-expensive-reviewer-gate.sh:201` | restore `needs_fixes` + break |
| P7 | Cap not enforced | `test-pr-review-loop.sh:16509-16512` (`1649_s13_*`) | restore deferral counter |
| P8 | Unreadable ledger treated as 0 | `test-pr-review-loop.sh:16543-16546` (`1649_s19_*`) | restore `-1` / `deferral_budget_unreadable` |
| P9 | Global reorder across phase | `test-pr-review-loop.sh:16212-16214` (`1649_s6b_*`) | restore per-bucket partition |
| P10 | Accept any skipped peer | `test-pr-review-loop.sh:16368-16372` (`1649_s8_*` allow-list / reject rows) | restore allow-list + `reviewer_failed_label_required_for_result` |
| P11 | Absent ledger as -1 | `test-pr-review-loop.sh:16552-16553` (`1649_s19b_*`) | restore absent → `0` |
| P12 | Deny-list condition 1 | `test-pr-review-loop.sh:16296-16297` (`1649_s4_cfg_2` / `cfg_true`) | exact-match `1` only |
| P13 | Whole-list peer set | `test-pr-review-loop.sh:16322` / `:16330` / `:16355` (`1649_s7_*`) | restore phase-scoped peers |
| P14 | No reviewer-check exclusion | `test-pr-review-loop.sh:16439` (`1649_s10_real_exclude_reviewer`) | restore `configured_reviewer_check_names_json` exclusion |
| P15 | No short-circuit on defer | `test-expensive-reviewer-gate.sh:198-201` (`1649_s21_*`) | restore break before ready-phase |
| P16 | Vacuous green empty checks | `test-pr-review-loop.sh:16404` (`1649_s10_empty`) + `:16442` (`1649_s10_real_empty`) | restore `baseline_checks_unobserved` |
| P17 | Read `LOCAL_AI_*` env | `test-expensive-reviewer-gate.sh:102-114` (`1649_s22_*`) | restore in-loop derivation helpers |
| P18 | Unvalidated max deferrals | `test-pr-review-loop.sh:16219-16225` (`1649_s14b_*`) | restore resolver default `3` |
| P19 | Helper-only skip acceptance | `test-pr-review-loop.sh:16370+` (`1649_s8_skip_*` + reject rows) | restore membership test |
| P23 | Ready without preflight | `test-expensive-reviewer-gate.sh:266-268` (`1649_s23_*`); production preflight `pr-review-loop.sh:9451` | restore earlier_buckets preflight |
| P25 | Subshell loses `expensive_gate_last_*` | `test-expensive-reviewer-gate.sh` `1649_s25_*`; production sync at both gate call sites after `$(expensive_reviewer_gate ...)` | restore `expensive_gate_sync_last_from_output` |
| P24 | Full peers before ready (deadlock) | `test-expensive-reviewer-gate.sh:283-319` (`1649_s24_*`) | restore `earlier_buckets` scope for preflight |

**Fail/pass command (both directions):**

```bash
bash scripts/development-workflow/tests/test-pr-review-loop.sh
bash scripts/development-workflow/tests/test-expensive-reviewer-gate.sh
```

Live green counts on HEAD `3646f9ae`: composition suite **28 passed / 0 failed**; full `test-pr-review-loop` previously **1324 passed / 0 failed** (re-confirmed after each gate fix).

## Self-check log
- Dependency #1648 merged to approved base before implementation
- Relocation of `configured_reviewer_check_names_json` is behavior-preserving (scenario 20)
- Shell Script Quality Checklist applied (printf '%s' for -1; jq --arg; no pipefail SIGPIPE traps needed in new helpers)


Made with [Cursor](https://cursor.com)

