### PR TITLE
feat(1650): add strict spec contract review mode

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'docs/specs/developments/**'
       - 'docs/testing/workflow/**'
+      - 'docs/workflow/development-workflow/strict-spec-checks.md'
       - 'changelog.d/**'
       - 'CHANGELOG.md'
       - '.markdownlint.jsonc'
@@ -50,6 +51,9 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             md_files+=("CHANGELOG.md")
           fi
+          if [ -f docs/workflow/development-workflow/strict-spec-checks.md ]; then
+            md_files+=("docs/workflow/development-workflow/strict-spec-checks.md")
+          fi
           if [ "${#md_files[@]}" -eq 0 ]; then
             echo "No target markdown files found — skipping lint."
             echo "found_files=false" >> "$GITHUB_OUTPUT"
@@ -66,7 +70,8 @@ jobs:
             "docs/specs/developments/**/*.md" \
             "docs/testing/workflow/**/*.md" \
             "changelog.d/**/*.md" \
-            "CHANGELOG.md"
+            "CHANGELOG.md" \
+            "docs/workflow/development-workflow/strict-spec-checks.md"
 
       - name: Run heuristic lint checks (GLOB001, COUNT001)
         if: steps.collect.outputs.found_files == 'true'
@@ -76,6 +81,9 @@ jobs:
           )
           if [ -f CHANGELOG.md ]; then
             md_files+=("CHANGELOG.md")
+          fi
+          if [ -f docs/workflow/development-workflow/strict-spec-checks.md ]; then
+            md_files+=("docs/workflow/development-workflow/strict-spec-checks.md")
           fi
           python3 scripts/lint/markdown-heuristic-lint.py "${md_files[@]}"
 

--- a/changelog.d/1650.added.strict-spec-contract-review.md
+++ b/changelog.d/1650.added.strict-spec-contract-review.md
@@ -1,0 +1,6 @@
+- **Strict spec contract review** (#1650): on `spec/*` branches the local AI
+  reviewer runs a second, non-blocking pass against
+  `docs/workflow/development-workflow/strict-spec-checks.md`, emits labelled
+  `STRICT_*` findings and `STRICT_SPEC_*` state/count keys, and records a
+  mirroring `strict_spec` object in reviewer-loop history — without changing
+  the ordinary verdict.

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -80,6 +80,7 @@ The command runs under `sh -c` with these environment variables:
 - `BASE_BRANCH`
 - `HEAD_BRANCH`
 - `REVIEWED_HEAD`
+- `LOCAL_AI_REVIEWER_MODE` — `ordinary` (default) or `strict`
 
 The context bundle JSON uses `schema_version:
 local_ai_reviewer_context.v1` and includes:
@@ -93,6 +94,10 @@ local_ai_reviewer_context.v1` and includes:
 - `review_contract`
 - `graph_context`
 
+On a second, strict-mode invocation the companion script derives a copy of that
+bundle and adds `strict_spec_checks` (the checklist text). The ordinary-pass
+bundle file is never rewritten.
+
 Use `LOCAL_AI_REVIEWER_DISABLED=1` to intentionally skip the local platform
 with `RESULT=skipped` and `REASON=disabled_by_config`.
 
@@ -100,11 +105,61 @@ Set `LOCAL_AI_REVIEWER_EVIDENCE_FILE=/path/to/file.json` or pass
 `--evidence-file` to `local-codex-reviewer.sh` to persist a local evidence
 artifact. The artifact uses `schema_version: local_ai_reviewer_evidence.v1`
 and records the reviewed head, graph context, result, reason, counts, changed
-files, and compact diff summary. Keep this artifact alongside ready-phase
+files, compact diff summary, and a `strict_spec` object that mirrors the
+`STRICT_SPEC_*` keys. Keep this artifact alongside ready-phase
 reviewer-loop evidence when measuring whether Bugbot or another ready-phase
 reviewer found net-new blockers. Relative evidence paths are resolved from the
 operator's original working directory before `--repo-root` changes the checkout
 directory.
+
+---
+
+## Strict Spec Contract Checks
+
+On `spec/*` branches, after the ordinary review completes, `local-ai-reviewer.sh`
+runs a second `LOCAL_AI_REVIEWER_COMMAND` invocation with
+`LOCAL_AI_REVIEWER_MODE=strict`. That pass reads
+`docs/workflow/development-workflow/strict-spec-checks.md` (eight closed-set
+identifiers) and must respond with:
+
+```json
+{
+  "mode": "strict_spec_checks",
+  "findings": [
+    {
+      "check": "ac_consistency",
+      "path": "docs/specs/.../1_..._specs.md",
+      "line": 42,
+      "body": "AC-A and AC-B cannot both hold"
+    }
+  ]
+}
+```
+
+`mode` must be exactly `strict_spec_checks`. Responses missing that marker, or
+with a non-array `findings` value, are recorded as `unavailable` /
+`strict_pass_failed` and do not change the ordinary verdict.
+
+Override prompts separately:
+
+- `LOCAL_CODEX_REVIEWER_PROMPT` — ordinary pass only
+- `LOCAL_CODEX_REVIEWER_STRICT_PROMPT` — strict pass only
+
+There is no second timeout setting. The strict pass uses whatever remains of
+`--timeout` / `LOCAL_AI_REVIEWER_TIMEOUT` after the ordinary pass.
+
+Companion output always includes `STRICT_SPEC_STATE`
+(`applied` | `not_applicable` | `unavailable`). When `applied`, also
+`STRICT_SPEC_COUNT` (may be `0`) and `STRICT_SPEC_CHECKS` (comma-separated
+identifiers that fired). When `unavailable`, also `STRICT_SPEC_REASON`
+(`stage_unresolved` | `checklist_unreadable` | `strict_pass_failed`). Unknown
+identifiers are reported as `STRICT_<n>_CHECK=unknown` and counted in
+`STRICT_SPEC_UNKNOWN_COUNT`; they never become blockers. Strict findings never
+change `RESULT` or `BLOCKING_<n>_*`.
+
+The reviewer-loop history entry includes a `strict_spec` object that mirrors
+those keys (absent fields are omitted, not null). The summary comment lists
+strict findings only when state is `applied` and the count is above zero.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -197,7 +197,11 @@ Conditions are evaluated in order and stop at the first unmet one:
    values must be the literal `1`. Missing, unexpected, or stale values defer
    (`local_reviewer_not_configured`, `local_evidence_missing`, or
    `local_evidence_stale`). Derived from in-loop state — never from the
-   `LOCAL_AI_*` stdout keys as environment variables.
+   `LOCAL_AI_*` stdout keys as environment variables. On `spec/*` branches the
+   local reviewer also runs a second, non-blocking strict-spec pass (see
+   [`integrations/local-ai-reviewer.md`](../integrations/local-ai-reviewer.md)
+   and [`strict-spec-checks.md`](../strict-spec-checks.md)); `STRICT_SPEC_*`
+   keys and the history `strict_spec` object never change the ordinary verdict.
 2. **Preceding peer evidence** — every platform that precedes this reviewer
    under the reordered list (same-bucket non-expensive peers plus every earlier
    bucket) has already run with acceptable evidence: `clean`, or `skipped`
@@ -206,8 +210,7 @@ Conditions are evaluated in order and stop at the first unmet one:
    (`not_configured`, `explicit-skip`, `release_pr`, `unsupported-platform`)
    **and** `reviewer_failed_label_required_for_result` returns false. Peer set
    is phase-scoped, not the whole list — a draft-phase expensive reviewer does
-   not wait on ready-phase peers.
-3. **Review threads** — zero unresolved, non-outdated review threads, bound to
+   not wait on ready-phase peers.3. **Review threads** — zero unresolved, non-outdated review threads, bound to
    the same `loop_head_sha` (else `evidence_head_moved` /
    `evidence_unavailable_review_threads`).
 4. **Baseline checks** — the non-reviewer check set on `loop_head_sha` is

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -210,7 +210,8 @@ Conditions are evaluated in order and stop at the first unmet one:
    (`not_configured`, `explicit-skip`, `release_pr`, `unsupported-platform`)
    **and** `reviewer_failed_label_required_for_result` returns false. Peer set
    is phase-scoped, not the whole list — a draft-phase expensive reviewer does
-   not wait on ready-phase peers.3. **Review threads** — zero unresolved, non-outdated review threads, bound to
+   not wait on ready-phase peers.
+3. **Review threads** — zero unresolved, non-outdated review threads, bound to
    the same `loop_head_sha` (else `evidence_head_moved` /
    `evidence_unavailable_review_threads`).
 4. **Baseline checks** — the non-reviewer check set on `loop_head_sha` is

--- a/docs/workflow/development-workflow/strict-spec-checks.md
+++ b/docs/workflow/development-workflow/strict-spec-checks.md
@@ -1,0 +1,74 @@
+# Strict Spec Contract Checks
+
+Closed set of checks applied by the local AI reviewer on **spec-stage** pull
+requests only. Each level-3 heading is the check identifier; the parser and
+incidence counters read identifiers from this document rather than repeating
+them.
+
+Findings produced by these checks are **non-blocking**. They never change a
+review's verdict.
+
+### ac_consistency
+
+**Question:** Do any two acceptance criteria contradict each other, or does one
+contradict a business rule?
+
+**Finding shape:** two criteria that cannot both hold.
+
+### ac_testability
+
+**Question:** Could a test distinguish this criterion being met from its being
+unmet?
+
+**Finding shape:** a criterion whose outcome no observation would differ on.
+
+### gate_matrix
+
+**Question:** Does behavior described as depending on several inputs enumerate
+every **reachable** combination of them, under the evaluation order the document
+states?
+
+**Finding shape:** a described gate with a reachable combination unmentioned, or
+with an evaluation order it never states.
+
+A gate that short-circuits and **states that order** must not produce a finding
+for combinations the order makes unreachable. A gate that short-circuits and
+does **not** state the order must produce a finding: the unmentioned
+combinations are indistinguishable from forgotten ones.
+
+### opt_out_source
+
+**Question:** Does each way of disabling or bypassing behavior name exactly one
+source of truth?
+
+**Finding shape:** an opt-out named in two places, or in none.
+
+### trigger_semantics
+
+**Question:** Does each condition that starts behavior say what happens when its
+inputs are absent, empty or malformed?
+
+**Finding shape:** a trigger with no stated behavior for a missing input.
+
+### example_contradiction
+
+**Question:** Does each worked example do what the rule beside it requires?
+
+**Finding shape:** an example demonstrating what its rule forbids.
+
+### parser_surface
+
+**Question:** Is each statement about how input is recognised consistent with
+the syntax the document requires elsewhere, and with the stated tooling?
+
+**Finding shape:** a matching rule the stated tool cannot express.
+
+### ambiguous_phrase
+
+**Question:** Does any phrase whose meaning is unsettled — *next update*,
+*absence of evidence*, *as needed*, *where appropriate* — determine behavior?
+
+**Finding shape:** an unsettled phrase load-bearing in a rule.
+
+The same phrase appearing only in a rationale, aside, or any passage that
+determines no behavior is **not** a finding.

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -26,7 +26,8 @@ Environment:
                                     unless LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1.
                                     The command receives CONTEXT_BUNDLE_PATH,
                                     PR_NUMBER, OWNER, REPO, BASE_BRANCH,
-                                    HEAD_BRANCH, and REVIEWED_HEAD in env.
+                                    HEAD_BRANCH, REVIEWED_HEAD, and
+                                    LOCAL_AI_REVIEWER_MODE (ordinary|strict) in env.
   LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1
                                     Do not apply the bundled Codex preset default.
   LOCAL_AI_REVIEWER_DISABLED=1      Emit RESULT=skipped / disabled_by_config.
@@ -34,6 +35,20 @@ Environment:
   LOCAL_AI_REVIEWER_GRAPH_STRATEGY  none|auto|code-review-graph|graphify.
   LOCAL_CODEX_REVIEWER_BIN          Codex binary for the bundled preset (default: codex).
   LOCAL_CODEX_REVIEWER_MODEL        Optional model for the bundled preset.
+  LOCAL_CODEX_REVIEWER_PROMPT       Override the ordinary-pass Codex prompt only.
+  LOCAL_CODEX_REVIEWER_STRICT_PROMPT
+                                    Override the strict-pass Codex prompt only.
+
+Strict spec contract checks (#1650):
+  On spec/* branches, a second LOCAL_AI_REVIEWER_COMMAND invocation runs with
+  LOCAL_AI_REVIEWER_MODE=strict and a derived context bundle that adds
+  strict_spec_checks from docs/workflow/development-workflow/strict-spec-checks.md.
+  That pass shares the reviewer's --timeout budget (no second timeout setting).
+  Output always includes STRICT_SPEC_STATE; when applied also STRICT_SPEC_COUNT /
+  STRICT_SPEC_CHECKS (and STRICT_SPEC_UNKNOWN_COUNT when > 0); when unavailable
+  also STRICT_SPEC_REASON (stage_unresolved|checklist_unreadable|strict_pass_failed).
+  Strict findings are emitted as STRICT_<n>_CHECK/PATH/LINE/BODY and never change
+  RESULT or BLOCKING_<n>_*.
 EOF
 }
 
@@ -141,6 +156,169 @@ run_with_timeout() {
   fi
   wait "$child_pid"
 }
+
+# ---------------------------------------------------------------------------
+# Strict spec contract checks (#1650)
+# ---------------------------------------------------------------------------
+
+STRICT_SPEC_CHECKLIST_RELPATH="docs/workflow/development-workflow/strict-spec-checks.md"
+
+# Minimal stage detection for strict checks only (#1653 full resolution not
+# merged yet). spec/* => spec; empty HEAD_BRANCH => unresolved; else other.
+resolve_review_stage_for_strict() {
+  local head_branch="${1:-}"
+  if [ -z "$head_branch" ]; then
+    printf '%s\n' "unresolved"
+  elif [[ "$head_branch" == spec/* ]]; then
+    printf '%s\n' "spec"
+  else
+    printf '%s\n' "other"
+  fi
+}
+
+# Extract closed identifier set from the checklist. Exit 1 = unreadable /
+# refused (empty, malformed heading, duplicate). Separates grep -c exit 1
+# (no matches) from exit > 1 (tool failure).
+extract_strict_spec_known_checks() {
+  local checklist="$1"
+  local status=0
+  local declared=0
+  local ids=""
+  local known=""
+  local length=0
+  local unique=0
+
+  if [ ! -f "$checklist" ] || [ ! -r "$checklist" ]; then
+    return 1
+  fi
+
+  status=0
+  declared="$(grep -c '^### ' "$checklist")" || status=$?
+  if [ "$status" -eq 1 ]; then
+    declared=0
+  elif [ "$status" -ne 0 ]; then
+    return 1
+  fi
+
+  ids="$(sed -n 's/^### \([a-z][a-z0-9_]*\)[[:space:]]*$/\1/p' "$checklist")" || return 1
+  known="$(printf '%s\n' "$ids" | jq -R -s 'split("\n") | map(select(length > 0))')" || return 1
+
+  length="$(printf '%s\n' "$known" | jq -e 'length')" || return 1
+  if [ "$length" -eq 0 ]; then
+    return 1
+  fi
+  if [ "$length" -ne "$declared" ]; then
+    return 1
+  fi
+  unique="$(printf '%s\n' "$known" | jq -e 'unique | length')" || return 1
+  if [ "$length" -ne "$unique" ]; then
+    return 1
+  fi
+
+  printf '%s\n' "$known"
+  return 0
+}
+
+# Parse strict-pass JSON. Prints a compact JSON object:
+#   { malformed, count, checks, unknown_count, findings:[{check,path,line,body}] }
+# Requires mode == "strict_spec_checks" and an explicit array findings key.
+parse_strict_spec_response() {
+  local response_json="$1"
+  local known_checks_json="$2"
+
+  printf '%s\n' "$response_json" | jq -c --argjson known_checks "$known_checks_json" '
+    def ident:
+      ((.check? // null) | if type == "string" then ascii_downcase else null end);
+    def known($c): $c != null and ($known_checks | index($c) != null);
+    def text_value:
+      [.body?, .message?, .description?, .title?, .summary?, .comment?, .text?]
+      | map(select(type == "string" and length > 0)) | .[0] // "";
+    def path_value:
+      [.path?, .file?, .filename?, .filepath?, .location.path?]
+      | map(select(type == "string" and length > 0)) | .[0] // "";
+    def line_value:
+      [.line?, .startLine?, .start_line?, .location.line?]
+      | map(select((type == "number") or (type == "string" and length > 0)))
+      | .[0] // "";
+    if (.mode? // null) != "strict_spec_checks" then
+      { malformed: true, count: 0, checks: "", unknown_count: 0, findings: [] }
+    else
+      (if   has("findings") then .findings
+       elif has("comments") then .comments
+       elif has("issues")   then .issues
+       else null end) as $f
+      | if ($f | type) != "array" then
+          { malformed: true, count: 0, checks: "", unknown_count: 0, findings: [] }
+        else
+          ($f | map(select(known(ident)))) as $named
+          | ($f | map(select(known(ident) | not))) as $unnamed
+          | {
+              malformed: false,
+              count: ($named | length),
+              checks: ($named | map(ident) | unique | join(",")),
+              unknown_count: ($unnamed | length),
+              findings: ($f | map({
+                check: (if known(ident) then ident else "unknown" end),
+                path: path_value,
+                line: (line_value | tostring),
+                body: (text_value | gsub("\n"; "\\n"))
+              }))
+            }
+        end
+    end
+  ' 2>/dev/null
+}
+
+emit_strict_spec_output() {
+  local state="$1"
+  local count="${2:-}"
+  local checks="${3:-}"
+  local unknown_count="${4:-0}"
+  local reason="${5:-}"
+  local findings_json="${6:-[]}"
+
+  print_kv STRICT_SPEC_STATE "$state"
+  case "$state" in
+    applied)
+      print_kv STRICT_SPEC_COUNT "$count"
+      print_kv STRICT_SPEC_CHECKS "$checks"
+      if [ "${unknown_count:-0}" -gt 0 ]; then
+        print_kv STRICT_SPEC_UNKNOWN_COUNT "$unknown_count"
+      fi
+      ;;
+    unavailable)
+      [ -n "$reason" ] && print_kv STRICT_SPEC_REASON "$reason"
+      ;;
+  esac
+
+  if [ "$state" = "applied" ]; then
+    local idx=0
+    local finding_count
+    finding_count="$(printf '%s\n' "$findings_json" | jq -e 'length' 2>/dev/null)" || finding_count=0
+    while [ "$idx" -lt "$finding_count" ]; do
+      local check path line body
+      check="$(printf '%s\n' "$findings_json" | jq -r --argjson i "$idx" '.[$i].check // "unknown"')"
+      path="$(printf '%s\n' "$findings_json" | jq -r --argjson i "$idx" '.[$i].path // ""')"
+      line="$(printf '%s\n' "$findings_json" | jq -r --argjson i "$idx" '.[$i].line // ""')"
+      body="$(printf '%s\n' "$findings_json" | jq -r --argjson i "$idx" '.[$i].body // ""')"
+      idx=$((idx + 1))
+      print_kv "STRICT_${idx}_CHECK" "$check"
+      print_kv "STRICT_${idx}_PATH" "$path"
+      print_kv "STRICT_${idx}_LINE" "$line"
+      print_kv "STRICT_${idx}_BODY" "$body"
+    done
+  fi
+}
+
+# Effective harness mode: only when HARNESS_MODE=1 AND the script is sourced.
+_HARNESS_MODE_EFFECTIVE=0
+if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  _HARNESS_MODE_EFFECTIVE=1
+fi
+
+if [ "$_HARNESS_MODE_EFFECTIVE" -eq 1 ]; then
+  return 0 2>/dev/null || true
+fi
 
 if [ "$#" -lt 3 ]; then
   usage
@@ -331,10 +509,7 @@ esac
 context_file="$(mktemp)"
 stdout_file="$(mktemp)"
 stderr_file="$(mktemp)"
-cleanup() {
-  rm -f "${context_file:-}" "${stdout_file:-}" "${stderr_file:-}"
-}
-trap cleanup EXIT
+# cleanup/trap redefined after BASE_BRANCH print once strict temp paths exist
 
 jq -n \
   --arg pr_number "$PR_NUMBER" \
@@ -369,7 +544,27 @@ print_kv BASE_BRANCH "$BASE_BRANCH"
 print_kv REVIEWED_HEAD "$HEAD_SHA"
 print_kv GRAPH_CONTEXT "$graph_context"
 
+# Strict-spec state (always emitted after a completed ordinary parse).
+strict_spec_state=""
+strict_spec_count=""
+strict_spec_checks=""
+strict_spec_unknown_count=0
+strict_spec_reason=""
+strict_spec_findings_json="[]"
+strict_context_file=""
+strict_stdout_file=""
+strict_stderr_file=""
+
+cleanup() {
+  rm -f "${context_file:-}" "${stdout_file:-}" "${stderr_file:-}" \
+    "${strict_context_file:-}" "${strict_stdout_file:-}" "${strict_stderr_file:-}"
+}
+trap cleanup EXIT
+
+round_start_epoch="$(date +%s)"
+
 set +e
+LOCAL_AI_REVIEWER_MODE=ordinary \
 CONTEXT_BUNDLE_PATH="$context_file" \
 PR_NUMBER="$PR_NUMBER" \
 OWNER="$OWNER" \
@@ -509,6 +704,78 @@ blocking_count="${blocking_count:-0}"
 suggestion_count="${suggestion_count:-0}"
 reason="${reason:-}"
 
+# --- Strict spec pass (second invocation; never merges into blocking) ---
+strict_stage="$(resolve_review_stage_for_strict "$HEAD_BRANCH")"
+case "$strict_stage" in
+  unresolved)
+    strict_spec_state="unavailable"
+    strict_spec_reason="stage_unresolved"
+    ;;
+  other)
+    strict_spec_state="not_applicable"
+    ;;
+  spec)
+    checklist_path="$STRICT_SPEC_CHECKLIST_RELPATH"
+    known_checks_json=""
+    if ! known_checks_json="$(extract_strict_spec_known_checks "$checklist_path")"; then
+      strict_spec_state="unavailable"
+      strict_spec_reason="checklist_unreadable"
+    else
+      now_epoch="$(date +%s)"
+      elapsed=$((now_epoch - round_start_epoch))
+      remaining=$((TIMEOUT - elapsed))
+      if [ "$remaining" -le 0 ]; then
+        strict_spec_state="unavailable"
+        strict_spec_reason="strict_pass_failed"
+      else
+        strict_context_file="$(mktemp)"
+        strict_stdout_file="$(mktemp)"
+        strict_stderr_file="$(mktemp)"
+        if ! jq --rawfile checks "$checklist_path" \
+            '. + { strict_spec_checks: $checks }' \
+            "$context_file" >"$strict_context_file"; then
+          strict_spec_state="unavailable"
+          strict_spec_reason="strict_pass_failed"
+        else
+          set +e
+          LOCAL_AI_REVIEWER_MODE=strict \
+          CONTEXT_BUNDLE_PATH="$strict_context_file" \
+          PR_NUMBER="$PR_NUMBER" \
+          OWNER="$OWNER" \
+          REPO="$REPO" \
+          BASE_BRANCH="$BASE_BRANCH" \
+          HEAD_BRANCH="$HEAD_BRANCH" \
+          REVIEWED_HEAD="$HEAD_SHA" \
+            run_with_timeout "$remaining" "$strict_stdout_file" "$strict_stderr_file" \
+              sh -c "$LOCAL_AI_REVIEWER_COMMAND"
+          strict_exit=$?
+          set -e
+          strict_stdout="$(cat "$strict_stdout_file" 2>/dev/null || true)"
+          if [ "$strict_exit" -ne 0 ] \
+              || [ -z "$(printf '%s' "$strict_stdout" | tr -d '[:space:]')" ] \
+              || ! printf '%s\n' "$strict_stdout" | jq -e . >/dev/null 2>&1; then
+            strict_spec_state="unavailable"
+            strict_spec_reason="strict_pass_failed"
+          else
+            strict_parsed="$(parse_strict_spec_response "$strict_stdout" "$known_checks_json")" || strict_parsed=""
+            if [ -z "$strict_parsed" ] \
+                || [ "$(printf '%s\n' "$strict_parsed" | jq -r '.malformed')" = "true" ]; then
+              strict_spec_state="unavailable"
+              strict_spec_reason="strict_pass_failed"
+            else
+              strict_spec_state="applied"
+              strict_spec_count="$(printf '%s\n' "$strict_parsed" | jq -r '.count')"
+              strict_spec_checks="$(printf '%s\n' "$strict_parsed" | jq -r '.checks')"
+              strict_spec_unknown_count="$(printf '%s\n' "$strict_parsed" | jq -r '.unknown_count')"
+              strict_spec_findings_json="$(printf '%s\n' "$strict_parsed" | jq -c '.findings')"
+            fi
+          fi
+        fi
+      fi
+    fi
+    ;;
+esac
+
 write_evidence_file() {
   local final_result="$1"
   local final_reason="$2"
@@ -517,6 +784,34 @@ write_evidence_file() {
   local final_suggestion_count="$5"
 
   [ -n "${LOCAL_AI_REVIEWER_EVIDENCE_FILE:-}" ] || return 0
+
+  local strict_json="{}"
+  case "$strict_spec_state" in
+    applied)
+      if [ "${strict_spec_unknown_count:-0}" -gt 0 ]; then
+        strict_json="$(jq -n \
+          --arg state "$strict_spec_state" \
+          --argjson count "$strict_spec_count" \
+          --arg checks "$strict_spec_checks" \
+          --argjson unknown_count "$strict_spec_unknown_count" \
+          '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end), unknown_count:$unknown_count}')"
+      else
+        strict_json="$(jq -n \
+          --arg state "$strict_spec_state" \
+          --argjson count "$strict_spec_count" \
+          --arg checks "$strict_spec_checks" \
+          '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end)}')"
+      fi
+      ;;
+    unavailable)
+      strict_json="$(jq -n --arg state "$strict_spec_state" --arg reason "$strict_spec_reason" \
+        '{state:$state, reason:$reason}')"
+      ;;
+    not_applicable)
+      strict_json="$(jq -n --arg state "$strict_spec_state" '{state:$state}')"
+      ;;
+  esac
+
   if ! jq -n \
     --arg schema_version "local_ai_reviewer_evidence.v1" \
     --arg result "$final_result" \
@@ -535,6 +830,7 @@ write_evidence_file() {
     --argjson comment_count "$final_comment_count" \
     --argjson blocking_count "$final_blocking_count" \
     --argjson suggestion_count "$final_suggestion_count" \
+    --argjson strict_spec "$strict_json" \
     '{
       schema_version: $schema_version,
       result: $result,
@@ -556,49 +852,69 @@ write_evidence_file() {
         pr_body: ($pr_body[0:20000]),
         diff_name_status: $diff_name_status,
         diff_stat: $diff_stat
-      }
+      },
+      strict_spec: $strict_spec
     }' >"$LOCAL_AI_REVIEWER_EVIDENCE_FILE"; then
     echo "WARN: could not write local AI reviewer evidence file: $LOCAL_AI_REVIEWER_EVIDENCE_FILE" >&2
   fi
+}
+
+emit_ordinary_and_strict() {
+  # Emit RESULT block then STRICT block. Ordinary verdict is never influenced
+  # by strict findings.
+  local final_result="$1"
+  local final_comment_count="$2"
+  local final_blocking_count="$3"
+  local final_suggestion_count="$4"
+  local final_reason="${5:-}"
+  local final_display="${6:-}"
+
+  print_result "$final_result" "$final_comment_count" "$final_blocking_count" \
+    "$final_suggestion_count" "$final_reason" "$final_display"
+  if [ "$final_result" = "needs_fixes" ]; then
+    printf '%s\n' "$parse_result" | awk '/^BLOCKING_[0-9]+_(PATH|LINE|BODY)=/ { print }'
+  fi
+  emit_strict_spec_output "$strict_spec_state" "$strict_spec_count" \
+    "$strict_spec_checks" "$strict_spec_unknown_count" "$strict_spec_reason" \
+    "$strict_spec_findings_json"
 }
 
 case "$result" in
   clean)
     if [ "$command_exit" -ne 0 ]; then
       write_evidence_file escalate malformed_output "$comment_count" "$blocking_count" "$suggestion_count"
-      print_result escalate "$comment_count" "$blocking_count" "$suggestion_count" malformed_output malformed_output
+      emit_ordinary_and_strict escalate "$comment_count" "$blocking_count" "$suggestion_count" malformed_output malformed_output
       exit 2
     fi
     write_evidence_file clean "" "$comment_count" 0 "$suggestion_count"
-    print_result clean "$comment_count" 0 "$suggestion_count"
+    emit_ordinary_and_strict clean "$comment_count" 0 "$suggestion_count"
     exit 0
     ;;
   needs_fixes)
     [ "$blocking_count" -eq 0 ] && blocking_count=1
     [ "$comment_count" -eq 0 ] && comment_count=1
     write_evidence_file needs_fixes local_ai_review_findings "$comment_count" "$blocking_count" "$suggestion_count"
-    print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count" local_ai_review_findings
-    printf '%s\n' "$parse_result" | awk '/^BLOCKING_[0-9]+_(PATH|LINE|BODY)=/ { print }'
+    emit_ordinary_and_strict needs_fixes "$comment_count" "$blocking_count" "$suggestion_count" local_ai_review_findings
     exit 1
     ;;
   needs_rerun)
     write_evidence_file needs_rerun "${reason:-needs_rerun}" "$comment_count" "$blocking_count" "$suggestion_count"
-    print_result needs_rerun "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-needs_rerun}"
+    emit_ordinary_and_strict needs_rerun "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-needs_rerun}"
     exit 1
     ;;
   skipped)
     write_evidence_file skipped "${reason:-disabled_by_config}" "$comment_count" "$blocking_count" "$suggestion_count"
-    print_result skipped "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-disabled_by_config}" "${reason:-disabled_by_config}"
+    emit_ordinary_and_strict skipped "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-disabled_by_config}" "${reason:-disabled_by_config}"
     exit 3
     ;;
   escalate)
     write_evidence_file escalate "${reason:-malformed_output}" "$comment_count" "$blocking_count" "$suggestion_count"
-    print_result escalate "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-malformed_output}" "${reason:-malformed_output}"
+    emit_ordinary_and_strict escalate "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-malformed_output}" "${reason:-malformed_output}"
     exit 2
     ;;
   *)
     write_evidence_file escalate malformed_output 0 0 0
-    print_result escalate 0 0 0 malformed_output malformed_output
+    emit_ordinary_and_strict escalate 0 0 0 malformed_output malformed_output
     exit 2
     ;;
 esac

--- a/scripts/development-workflow/local-codex-review-command.sh
+++ b/scripts/development-workflow/local-codex-review-command.sh
@@ -10,9 +10,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
-prompt="${LOCAL_CODEX_REVIEWER_PROMPT:-}"
-if [ -z "$prompt" ]; then
-  prompt="Review this PR change using REVIEW.md and the JSON context at ${CONTEXT_BUNDLE_PATH:?}. Inspect the changed files against origin/${BASE_BRANCH:-develop}...HEAD, using the context bundle diff metadata as a guide. Return only a compact JSON object with fields: result (clean or needs_fixes), reviewed_head, findings array. Each finding should include severity, path, line, message, and clear_in_scope. Use needs_fixes only for clear in-scope blocking issues; advisory or nit findings should not block."
+mode="${LOCAL_AI_REVIEWER_MODE:-ordinary}"
+
+if [ "$mode" = "strict" ]; then
+  prompt="${LOCAL_CODEX_REVIEWER_STRICT_PROMPT:-}"
+  if [ -z "$prompt" ]; then
+    prompt="Apply the strict spec contract checks from the JSON context at ${CONTEXT_BUNDLE_PATH:?} (field strict_spec_checks). Inspect the specification under review against origin/${BASE_BRANCH:-develop}...HEAD. Return only a compact JSON object with fields: mode (must be the string strict_spec_checks), findings array. Each finding must include check (one of the checklist identifiers), path, line, and body (or message). Do not return a review verdict, result, severity, or clear_in_scope. If no strict check fires, return {\"mode\":\"strict_spec_checks\",\"findings\":[]}."
+  fi
+else
+  prompt="${LOCAL_CODEX_REVIEWER_PROMPT:-}"
+  if [ -z "$prompt" ]; then
+    prompt="Review this PR change using REVIEW.md and the JSON context at ${CONTEXT_BUNDLE_PATH:?}. Inspect the changed files against origin/${BASE_BRANCH:-develop}...HEAD, using the context bundle diff metadata as a guide. Return only a compact JSON object with fields: result (clean or needs_fixes), reviewed_head, findings array. Each finding should include severity, path, line, message, and clear_in_scope. Use needs_fixes only for clear in-scope blocking issues; advisory or nit findings should not block."
+  fi
 fi
 
 codex_args=(exec --sandbox read-only -C "$PWD" -o "$output_file")

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -720,6 +720,15 @@ expensive_gate_last_platform=""
 expensive_gate_last_result=""
 expensive_gate_last_reason=""
 expensive_gate_last_head=""
+# Strict-spec ledger globals (#1650); set by capture_strict_spec_globals_from_output
+# when local-ai-reviewer runs. Object absent from history when not recorded.
+strict_spec_recorded=0
+strict_spec_state=""
+strict_spec_count=""
+strict_spec_checks=""
+strict_spec_unknown_count=""
+strict_spec_reason=""
+strict_spec_summary_section=""
 # Peer evidence collected during this invocation: "platform|result|reason".
 declare -a platform_peer_evidence=()
 
@@ -3567,6 +3576,60 @@ run_coderabbit_cli_review() {
   esac
 }
 
+# Forward STRICT_* keys from local-ai-reviewer.sh output unchanged.
+emit_local_ai_strict_spec_keys() {
+  local script_output="$1"
+  local line key
+  while IFS= read -r line; do
+    [ -z "${line:-}" ] && continue
+    key="${line%%=*}"
+    case "$key" in
+      STRICT_SPEC_STATE|STRICT_SPEC_COUNT|STRICT_SPEC_CHECKS|STRICT_SPEC_UNKNOWN_COUNT|STRICT_SPEC_REASON)
+        print_kv "$key" "${line#*=}"
+        ;;
+      STRICT_[0-9]*_CHECK|STRICT_[0-9]*_PATH|STRICT_[0-9]*_LINE|STRICT_[0-9]*_BODY)
+        print_kv "$key" "${line#*=}"
+        ;;
+    esac
+  done <<< "$script_output"
+}
+
+# Capture STRICT_SPEC_* into globals for reviewer_loop_history_build_entry.
+# Present object vs absent object is gated by strict_spec_recorded.
+capture_strict_spec_globals_from_output() {
+  local script_output="$1"
+  local state
+  local idx
+  local check path line body
+  state="$(kv_value_default STRICT_SPEC_STATE "$script_output" "")"
+  if [ -z "$state" ]; then
+    return 0
+  fi
+  strict_spec_recorded=1
+  strict_spec_state="$state"
+  strict_spec_count="$(kv_value_default STRICT_SPEC_COUNT "$script_output" "")"
+  strict_spec_checks="$(kv_value_default STRICT_SPEC_CHECKS "$script_output" "")"
+  strict_spec_unknown_count="$(kv_value_default STRICT_SPEC_UNKNOWN_COUNT "$script_output" "")"
+  strict_spec_reason="$(kv_value_default STRICT_SPEC_REASON "$script_output" "")"
+  strict_spec_summary_section=""
+  if [ "$state" = "applied" ] && [ -n "$strict_spec_count" ] && [ "$strict_spec_count" -gt 0 ]; then
+    strict_spec_summary_section="
+
+**Strict spec findings (non-blocking):**"
+    idx=1
+    while true; do
+      check="$(kv_value_default "STRICT_${idx}_CHECK" "$script_output" "")"
+      [ -z "$check" ] && break
+      path="$(kv_value_default "STRICT_${idx}_PATH" "$script_output" "")"
+      line="$(kv_value_default "STRICT_${idx}_LINE" "$script_output" "")"
+      body="$(kv_value_default "STRICT_${idx}_BODY" "$script_output" "")"
+      strict_spec_summary_section="${strict_spec_summary_section}
+- \`${check}\` ${path}:${line} — ${body}"
+      idx=$((idx + 1))
+    done
+  fi
+}
+
 run_local_ai_reviewer_review() {
   # Runs local-ai-reviewer.sh and maps its exit codes to the standard
   # pr-review-loop key=value output contract.
@@ -3629,6 +3692,7 @@ run_local_ai_reviewer_review() {
       print_kv SUGGESTION_COUNT "$suggestion_count"
       print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      emit_local_ai_strict_spec_keys "$script_output"
       return 0
       ;;
     1)
@@ -3657,6 +3721,7 @@ run_local_ai_reviewer_review() {
       done
       print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      emit_local_ai_strict_spec_keys "$script_output"
       return 1
       ;;
     2)
@@ -3676,6 +3741,7 @@ run_local_ai_reviewer_review() {
       print_kv SUGGESTION_COUNT "$suggestion_count"
       print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      emit_local_ai_strict_spec_keys "$script_output"
       return 2
       ;;
     *)
@@ -3695,6 +3761,7 @@ run_local_ai_reviewer_review() {
       print_kv SUGGESTION_COUNT "$suggestion_count"
       print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      emit_local_ai_strict_spec_keys "$script_output"
       return 0
       ;;
   esac
@@ -7820,6 +7887,12 @@ reviewer_loop_history_build_entry() {
     --arg egResult "${expensive_gate_last_result:-}" \
     --arg egReason "${expensive_gate_last_reason:-}" \
     --arg egHead "${expensive_gate_last_head:-}" \
+    --argjson strictRecorded "${strict_spec_recorded:-0}" \
+    --arg strictState "${strict_spec_state:-}" \
+    --arg strictCount "${strict_spec_count:-}" \
+    --arg strictChecks "${strict_spec_checks:-}" \
+    --arg strictUnknown "${strict_spec_unknown_count:-}" \
+    --arg strictReason "${strict_spec_reason:-}" \
     '{
       iteration: $iteration,
       recorded_at: $recordedAt,
@@ -7849,6 +7922,30 @@ reviewer_loop_history_build_entry() {
     }
     | if ($egResult | length) > 0 then
         . + {expensive_gate: {platform: $egPlatform, result: $egResult, reason: $egReason, head: $egHead}}
+      else
+        .
+      end
+    | if $strictRecorded == 1 then
+        . + {
+          strict_spec: (
+            { state: $strictState }
+            | if $strictState == "applied" then
+                . + {
+                  count: ($strictCount | tonumber),
+                  checks: ($strictChecks | if . == "" then [] else (split(",") | map(select(length > 0))) end)
+                }
+                | if ($strictUnknown | length) > 0 then
+                    . + { unknown_count: ($strictUnknown | tonumber) }
+                  else
+                    .
+                  end
+              elif $strictState == "unavailable" then
+                . + { reason: $strictReason }
+              else
+                .
+              end
+          )
+        }
       else
         .
       end'
@@ -9678,6 +9775,9 @@ for index in "${!platforms[@]}"; do
   print_kv "PLATFORM_${platform_index}_NAME" "$platform_name"
   print_kv "PLATFORM_${platform_index}_RESULT" "$platform_result"
   emit_prefixed_platform_output "$platform_index" "$platform_output"
+  if [ "$platform_name" = "local-ai-reviewer" ]; then
+    capture_strict_spec_globals_from_output "$platform_output"
+  fi
   # Record a human-readable display token for the PR summary comment.
   _prt_reason="$platform_reason"
   _prt_display_override="$(kv_value_default DISPLAY_RESULT "$platform_output" "")"
@@ -10090,7 +10190,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
 **Result:** ${result_line}
 **Platforms:** ${platform_list:-none}${policy_status_section}
 **Findings:** ${blocking} blocking, ${suggestions} suggestions
-${small_findings_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${regression_label_section}
+${small_findings_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${strict_spec_summary_section}${regression_label_section}
 
 *Posted automatically by \`pr-review-loop.sh\`.*
 EOF

--- a/scripts/development-workflow/tests/fixtures/strict-spec-checks/duplicate-id.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-checks/duplicate-id.md
@@ -1,0 +1,13 @@
+# Strict Spec Contract Checks
+
+### ac_consistency
+
+One.
+
+### gate_matrix
+
+Two.
+
+### ac_consistency
+
+Duplicate.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-checks/malformed-heading.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-checks/malformed-heading.md
@@ -1,0 +1,13 @@
+# Strict Spec Contract Checks
+
+### ac_consistency
+
+Question text.
+
+### Ambiguous Phrase
+
+Bad heading that should refuse.
+
+### ac_testability
+
+More text.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-checks/nine-section.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-checks/nine-section.md
@@ -1,0 +1,80 @@
+# Strict Spec Contract Checks
+
+Closed set of checks applied by the local AI reviewer on **spec-stage** pull
+requests only. Each level-3 heading is the check identifier; the parser and
+incidence counters read identifiers from this document rather than repeating
+them.
+
+Findings produced by these checks are **non-blocking**. They never change a
+review's verdict.
+
+### ac_consistency
+
+**Question:** Do any two acceptance criteria contradict each other, or does one
+contradict a business rule?
+
+**Finding shape:** two criteria that cannot both hold.
+
+### ac_testability
+
+**Question:** Could a test distinguish this criterion being met from its being
+unmet?
+
+**Finding shape:** a criterion whose outcome no observation would differ on.
+
+### gate_matrix
+
+**Question:** Does behavior described as depending on several inputs enumerate
+every **reachable** combination of them, under the evaluation order the document
+states?
+
+**Finding shape:** a described gate with a reachable combination unmentioned, or
+with an evaluation order it never states.
+
+A gate that short-circuits and **states that order** must not produce a finding
+for combinations the order makes unreachable. A gate that short-circuits and
+does **not** state the order must produce a finding: the unmentioned
+combinations are indistinguishable from forgotten ones.
+
+### opt_out_source
+
+**Question:** Does each way of disabling or bypassing behavior name exactly one
+source of truth?
+
+**Finding shape:** an opt-out named in two places, or in none.
+
+### trigger_semantics
+
+**Question:** Does each condition that starts behavior say what happens when its
+inputs are absent, empty or malformed?
+
+**Finding shape:** a trigger with no stated behavior for a missing input.
+
+### example_contradiction
+
+**Question:** Does each worked example do what the rule beside it requires?
+
+**Finding shape:** an example demonstrating what its rule forbids.
+
+### parser_surface
+
+**Question:** Is each statement about how input is recognised consistent with
+the syntax the document requires elsewhere, and with the stated tooling?
+
+**Finding shape:** a matching rule the stated tool cannot express.
+
+### ambiguous_phrase
+
+**Question:** Does any phrase whose meaning is unsettled — *next update*,
+*absence of evidence*, *as needed*, *where appropriate* — determine behavior?
+
+**Finding shape:** an unsettled phrase load-bearing in a rule.
+
+The same phrase appearing only in a rationale, aside, or any passage that
+determines no behavior is **not** a finding.
+
+### ninth_check
+
+**Question:** Does this ninth identifier get counted when present in the checklist?
+
+**Finding shape:** a finding carrying ninth_check.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-checks/no-headings.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-checks/no-headings.md
@@ -1,0 +1,3 @@
+# Strict Spec Contract Checks
+
+This document has no level-3 headings.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-checks/well-formed.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-checks/well-formed.md
@@ -1,0 +1,74 @@
+# Strict Spec Contract Checks
+
+Closed set of checks applied by the local AI reviewer on **spec-stage** pull
+requests only. Each level-3 heading is the check identifier; the parser and
+incidence counters read identifiers from this document rather than repeating
+them.
+
+Findings produced by these checks are **non-blocking**. They never change a
+review's verdict.
+
+### ac_consistency
+
+**Question:** Do any two acceptance criteria contradict each other, or does one
+contradict a business rule?
+
+**Finding shape:** two criteria that cannot both hold.
+
+### ac_testability
+
+**Question:** Could a test distinguish this criterion being met from its being
+unmet?
+
+**Finding shape:** a criterion whose outcome no observation would differ on.
+
+### gate_matrix
+
+**Question:** Does behavior described as depending on several inputs enumerate
+every **reachable** combination of them, under the evaluation order the document
+states?
+
+**Finding shape:** a described gate with a reachable combination unmentioned, or
+with an evaluation order it never states.
+
+A gate that short-circuits and **states that order** must not produce a finding
+for combinations the order makes unreachable. A gate that short-circuits and
+does **not** state the order must produce a finding: the unmentioned
+combinations are indistinguishable from forgotten ones.
+
+### opt_out_source
+
+**Question:** Does each way of disabling or bypassing behavior name exactly one
+source of truth?
+
+**Finding shape:** an opt-out named in two places, or in none.
+
+### trigger_semantics
+
+**Question:** Does each condition that starts behavior say what happens when its
+inputs are absent, empty or malformed?
+
+**Finding shape:** a trigger with no stated behavior for a missing input.
+
+### example_contradiction
+
+**Question:** Does each worked example do what the rule beside it requires?
+
+**Finding shape:** an example demonstrating what its rule forbids.
+
+### parser_surface
+
+**Question:** Is each statement about how input is recognised consistent with
+the syntax the document requires elsewhere, and with the stated tooling?
+
+**Finding shape:** a matching rule the stated tool cannot express.
+
+### ambiguous_phrase
+
+**Question:** Does any phrase whose meaning is unsettled — *next update*,
+*absence of evidence*, *as needed*, *where appropriate* — determine behavior?
+
+**Finding shape:** an unsettled phrase load-bearing in a rule.
+
+The same phrase appearing only in a rationale, aside, or any passage that
+determines no behavior is **not** a finding.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/ac_consistency.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/ac_consistency.md
@@ -1,0 +1,5 @@
+# Spec fixture: ac_consistency
+
+## Acceptance Criteria
+- [ ] AC-A. The flag must always be true.
+- [ ] AC-B. The flag must always be false.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/ac_testability.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/ac_testability.md
@@ -1,0 +1,4 @@
+# Spec fixture: ac_testability
+
+## Acceptance Criteria
+- [ ] AC-A. The system feels appropriately responsive.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/ambiguous_phrase.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/ambiguous_phrase.md
@@ -1,0 +1,4 @@
+# Spec fixture: ambiguous_phrase
+
+## Business Rules
+Re-run the checks on the next update.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/ambiguous_phrase_rationale.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/ambiguous_phrase_rationale.md
@@ -1,0 +1,7 @@
+# Spec fixture: ambiguous_phrase negative (AC-13)
+
+## Rationale
+As needed, future work may tighten these checks. That phrase is not load-bearing.
+
+## Business Rules
+Strict findings never change the verdict.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/example_contradiction.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/example_contradiction.md
@@ -1,0 +1,5 @@
+# Spec fixture: example_contradiction
+
+Rule: never emit COUNT=0 outside applied.
+
+Example: for unavailable, emit STRICT_SPEC_COUNT=0.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_complete.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_complete.md
@@ -1,0 +1,9 @@
+# Spec fixture: gate_matrix negative (AC-7)
+
+## Decision Matrix
+| Stage resolves | Stage | Checklist | Outcome |
+| --- | --- | --- | --- |
+| No | — | — | unavailable |
+| Yes | not spec | — | not_applicable |
+| Yes | spec | No | unavailable |
+| Yes | spec | Yes | applied |

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_complete.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_complete.md
@@ -1,9 +1,12 @@
 # Spec fixture: gate_matrix negative (AC-7)
 
 ## Decision Matrix
-| Stage resolves | Stage | Checklist | Outcome |
-| --- | --- | --- | --- |
-| No | — | — | unavailable |
-| Yes | not spec | — | not_applicable |
-| Yes | spec | No | unavailable |
-| Yes | spec | Yes | applied |
+Every reachable combination of stage and checklist is listed. No short-circuit;
+both inputs are always evaluated.
+
+| Stage | Checklist | Outcome |
+| --- | --- | --- |
+| spec | present | apply |
+| spec | absent | unavailable |
+| plan | present | skip |
+| plan | absent | skip |

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_order_stated.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_order_stated.md
@@ -1,0 +1,13 @@
+# Spec fixture: gate_matrix negative (AC-6a)
+
+## Decision Matrix
+Inputs are evaluated in this order: (1) stage resolved?, (2) stage is spec?,
+(3) checklist available?. Later inputs are not evaluated when an earlier answer
+makes them unreachable.
+
+| Stage resolves | Stage | Checklist | Outcome |
+| --- | --- | --- | --- |
+| No | — | — | unavailable |
+| Yes | not spec | — | not_applicable |
+| Yes | spec | No | unavailable |
+| Yes | spec | Yes | applied |

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_order_unstated.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_order_unstated.md
@@ -1,0 +1,5 @@
+# Spec fixture: gate_matrix (AC-6b)
+
+## Decision Matrix
+If stage is unresolved, or stage is not spec, or checklist is missing, skip.
+Otherwise apply. Evaluation order is not stated.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_reachable.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_reachable.md
@@ -1,0 +1,11 @@
+# Spec fixture: gate_matrix (AC-6)
+
+## Decision Matrix
+Behavior depends on stage and checklist.
+
+| Stage | Checklist | Outcome |
+| --- | --- | --- |
+| spec | present | apply |
+| plan | present | skip |
+
+Missing: stage=spec with checklist absent.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/opt_out_source.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/opt_out_source.md
@@ -1,0 +1,3 @@
+# Spec fixture: opt_out_source
+
+Disable via LOCAL_FLAG=1 or via --disable. Two sources of truth.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/parser_surface.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/parser_surface.md
@@ -1,0 +1,4 @@
+# Spec fixture: parser_surface
+
+Identifiers are extracted with grep -E '^### ' and must match [A-Z][a-z]+.
+Elsewhere the document requires identifiers matching [a-z][a-z0-9_]*.

--- a/scripts/development-workflow/tests/fixtures/strict-spec-specs/trigger_semantics.md
+++ b/scripts/development-workflow/tests/fixtures/strict-spec-specs/trigger_semantics.md
@@ -1,0 +1,4 @@
+# Spec fixture: trigger_semantics
+
+When HEAD_BRANCH matches spec/*, run the checks. Behavior when HEAD_BRANCH is
+absent is not stated.

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -26,7 +26,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for _cmd in awk bash cat dirname git grep jq mktemp perl rm sh sleep tr; do
+for _cmd in awk bash cat date dirname git grep jq mktemp perl rm sed sh sleep tr; do
   _cmd_path="$(command -v "$_cmd")"
   [ -n "$_cmd_path" ] || continue
   ln -sf "$_cmd_path" "$NO_GRAPH_BIN/$_cmd"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Unit tests for local-ai-reviewer.sh.
 # covers: scripts/development-workflow/local-ai-reviewer.sh
+# shellcheck disable=SC2089,SC2090
 
 set -euo pipefail
 
@@ -441,9 +442,9 @@ run_test "s13d_shipped_ids_match_spec" "$(printf '%s\n' "$EXPECTED_IDS" | jq -c 
 
 # Scenario 9d: no second timeout setting
 run_test "s9d_no_strict_timeout_name" "yes" \
-  "$(rg -n 'LOCAL_AI_REVIEWER_STRICT_TIMEOUT|STRICT_SPEC_TIMEOUT' "$REVIEWER" >/dev/null && echo no || echo yes)"
+  "$(grep -Eq 'LOCAL_AI_REVIEWER_STRICT_TIMEOUT|STRICT_SPEC_TIMEOUT' "$REVIEWER" >/dev/null && echo no || echo yes)"
 run_test "s9d_help_no_second_timeout_knob" "yes" \
-  "$(bash "$REVIEWER" --help 2>&1 | rg -q 'LOCAL_AI_REVIEWER_STRICT_TIMEOUT|STRICT_SPEC_TIMEOUT' && echo no || echo yes)"
+  "$(bash "$REVIEWER" --help 2>&1 | grep -Eq 'LOCAL_AI_REVIEWER_STRICT_TIMEOUT|STRICT_SPEC_TIMEOUT' && echo no || echo yes)"
 
 # --- Matrix rows via full runs ---
 install_recording_two_pass_mock
@@ -892,9 +893,9 @@ run_test "s12_na_evidence_no_count" "false" "$(jq -r 'if .strict_spec | has("cou
 # Scenario 11a prompt overrides (codex preset source check)
 CODEX_CMD="$REPO_ROOT/scripts/development-workflow/local-codex-review-command.sh"
 run_test "s11a_codex_reads_mode" "yes" \
-  "$(rg -q 'LOCAL_AI_REVIEWER_MODE' "$CODEX_CMD" && echo yes || echo no)"
+  "$(grep -Fq 'LOCAL_AI_REVIEWER_MODE' "$CODEX_CMD" && echo yes || echo no)"
 run_test "s11a_codex_strict_prompt_override" "yes" \
-  "$(rg -q 'LOCAL_CODEX_REVIEWER_STRICT_PROMPT' "$CODEX_CMD" && echo yes || echo no)"
+  "$(grep -Fq 'LOCAL_CODEX_REVIEWER_STRICT_PROMPT' "$CODEX_CMD" && echo yes || echo no)"
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -60,7 +60,8 @@ case "$*" in
     elif ! mock_head_sha="$(git rev-parse HEAD 2>/dev/null)"; then
       mock_head_sha=""
     fi
-    printf '{"baseRefName":"develop","headRefName":"feature/test","headRefOid":"%s"}\n' "$mock_head_sha"
+    mock_head_branch="${MOCK_PR_HEAD_BRANCH:-feature/test}"
+    printf '{"baseRefName":"develop","headRefName":"%s","headRefOid":"%s"}\n' "$mock_head_branch" "$mock_head_sha"
     exit 0
     ;;
   *"pr diff 123"*"--name-only"*)
@@ -106,10 +107,12 @@ reset_mocks() {
   install_local_reviewer_mock
   unset MOCK_PR_HEAD_SHA MOCK_PR_DIFF_EXIT MOCK_LOCAL_REVIEWER_STDOUT MOCK_LOCAL_REVIEWER_STDERR
   unset MOCK_LOCAL_REVIEWER_EXIT MOCK_LOCAL_REVIEWER_SLEEP
-  unset MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE
+  unset MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE MOCK_PR_HEAD_BRANCH
   unset LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_DISABLED LOCAL_AI_REVIEWER_TIMEOUT
   unset LOCAL_AI_REVIEWER_EVIDENCE_FILE LOCAL_AI_REVIEWER_GRAPH_STRATEGY
   unset LOCAL_AI_REVIEWER_DISABLE_DEFAULT
+  unset MOCK_STRICT_STDOUT MOCK_ORDINARY_STDOUT MOCK_STRICT_EXIT MOCK_ORDINARY_SLEEP
+  unset MOCK_RECORD_FILE MOCK_ORDINARY_EXIT
 }
 
 set_mock_stdout() {
@@ -358,6 +361,540 @@ export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT MOCK_PR_HEAD_SHA
 run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
 run_test "head_mismatch_result" "RESULT=escalate" "$(line_for RESULT)"
 run_test "head_mismatch_reason" "REASON=head_mismatch" "$(line_for REASON)"
+
+# ---------------------------------------------------------------------------
+# Strict spec contract checks (#1650) — scenarios 1–13
+# ---------------------------------------------------------------------------
+
+FIXTURES="$REPO_ROOT/scripts/development-workflow/tests/fixtures"
+CHECKLIST_FIXTURES="$FIXTURES/strict-spec-checks"
+SHIPPED_CHECKLIST="$REPO_ROOT/docs/workflow/development-workflow/strict-spec-checks.md"
+
+key_present() {
+  grep -q "^${1}=" "$OUTPUT_FILE" && echo yes || echo no
+}
+
+install_checklist_into_repo() {
+  local src="$1"
+  mkdir -p "$VALID_REPO_ROOT/docs/workflow/development-workflow"
+  cp "$src" "$VALID_REPO_ROOT/docs/workflow/development-workflow/strict-spec-checks.md"
+  git -C "$VALID_REPO_ROOT" add docs/workflow/development-workflow/strict-spec-checks.md >/dev/null 2>&1 || true
+}
+
+remove_checklist_from_repo() {
+  rm -f "$VALID_REPO_ROOT/docs/workflow/development-workflow/strict-spec-checks.md"
+}
+
+install_recording_two_pass_mock() {
+  cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+mode="${LOCAL_AI_REVIEWER_MODE:-ordinary}"
+if [ -n "${MOCK_RECORD_FILE:-}" ]; then
+  {
+    printf 'mode=%s\n' "$mode"
+    if [ -n "${CONTEXT_BUNDLE_PATH:-}" ] && [ -f "${CONTEXT_BUNDLE_PATH}" ]; then
+      printf 'bundle_keys=%s\n' "$(jq -r 'keys | join(",")' "$CONTEXT_BUNDLE_PATH")"
+      printf 'has_strict_spec_checks=%s\n' "$(jq -r 'has("strict_spec_checks")' "$CONTEXT_BUNDLE_PATH")"
+    fi
+  } >> "$MOCK_RECORD_FILE"
+fi
+if [ "$mode" = "strict" ]; then
+  if [ -n "${MOCK_ORDINARY_SLEEP:-}" ] && [ "${MOCK_STRICT_SLEEP_EXTRA:-0}" != "0" ]; then
+    sleep "${MOCK_STRICT_SLEEP_EXTRA}"
+  fi
+  if [ -n "${MOCK_STRICT_STDOUT:-}" ]; then
+    printf '%s\n' "$MOCK_STRICT_STDOUT"
+  fi
+  exit "${MOCK_STRICT_EXIT:-0}"
+fi
+if [ -n "${MOCK_ORDINARY_SLEEP:-}" ]; then
+  sleep "$MOCK_ORDINARY_SLEEP"
+fi
+if [ -n "${MOCK_ORDINARY_STDOUT:-}" ]; then
+  printf '%s\n' "$MOCK_ORDINARY_STDOUT"
+elif [ -n "${MOCK_LOCAL_REVIEWER_STDOUT:-}" ]; then
+  printf '%s\n' "$MOCK_LOCAL_REVIEWER_STDOUT"
+fi
+exit "${MOCK_ORDINARY_EXIT:-0}"
+MOCK_REVIEWER
+  chmod +x "$MOCK_BIN/local-reviewer-mock"
+}
+
+run_spec_review() {
+  MOCK_PR_HEAD_BRANCH="${MOCK_PR_HEAD_BRANCH:-spec/1650-test}"
+  MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+  export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+  LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+  export LOCAL_AI_REVIEWER_COMMAND
+  run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT" "$@"
+}
+
+# Scenario 13d: shipped identifiers match the spec set
+EXPECTED_IDS='["ac_consistency","ac_testability","gate_matrix","opt_out_source","trigger_semantics","example_contradiction","parser_surface","ambiguous_phrase"]'
+EXTRACTED_IDS="$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    extract_strict_spec_known_checks "'"$SHIPPED_CHECKLIST"'"
+  ' | jq -c 'sort'
+)"
+run_test "s13d_shipped_ids_match_spec" "$(printf '%s\n' "$EXPECTED_IDS" | jq -c 'sort')" "$EXTRACTED_IDS"
+
+# Scenario 9d: no second timeout setting
+run_test "s9d_no_strict_timeout_name" "yes" \
+  "$(rg -n 'LOCAL_AI_REVIEWER_STRICT_TIMEOUT|STRICT_SPEC_TIMEOUT' "$REVIEWER" >/dev/null && echo no || echo yes)"
+run_test "s9d_help_no_second_timeout_knob" "yes" \
+  "$(bash "$REVIEWER" --help 2>&1 | rg -q 'LOCAL_AI_REVIEWER_STRICT_TIMEOUT|STRICT_SPEC_TIMEOUT' && echo no || echo yes)"
+
+# --- Matrix rows via full runs ---
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+
+# Row 2: not_applicable (feature branch) — exactly 1 invocation
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_PR_HEAD_BRANCH="feature/test"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "s1_row2_state" "STRICT_SPEC_STATE=not_applicable" "$(line_for STRICT_SPEC_STATE)"
+run_test "s1a_row2_no_reason" "no" "$(key_present STRICT_SPEC_REASON)"
+run_test "s2_row2_no_count" "no" "$(key_present STRICT_SPEC_COUNT)"
+run_test "s2_row2_no_checks" "no" "$(key_present STRICT_SPEC_CHECKS)"
+run_test "s9b_row2_invocations" "1" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+run_test "s11a_row2_mode_ordinary" "mode=ordinary" "$(grep '^mode=' "$MOCK_RECORD_FILE" | head -1)"
+rm -f "$MOCK_RECORD_FILE"
+
+# Row 1: stage_unresolved (empty HEAD_BRANCH)
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_PR_HEAD_BRANCH=""
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+# Empty headRefName in gh mock
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"","headRefOid":"%s"}\n' "${MOCK_PR_HEAD_SHA}"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf 'scripts/example.sh\n'
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "s1_row1_state" "STRICT_SPEC_STATE=unavailable" "$(line_for STRICT_SPEC_STATE)"
+run_test "s1a_row1_reason" "STRICT_SPEC_REASON=stage_unresolved" "$(line_for STRICT_SPEC_REASON)"
+run_test "s2_row1_no_count" "no" "$(key_present STRICT_SPEC_COUNT)"
+run_test "s9b_row1_invocations" "1" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+rm -f "$MOCK_RECORD_FILE"
+
+# Row 3: checklist_unreadable
+reset_mocks
+install_recording_two_pass_mock
+remove_checklist_from_repo
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT
+run_spec_review
+run_test "s1_row3_state" "STRICT_SPEC_STATE=unavailable" "$(line_for STRICT_SPEC_STATE)"
+run_test "s1a_row3_reason" "STRICT_SPEC_REASON=checklist_unreadable" "$(line_for STRICT_SPEC_REASON)"
+run_test "s2_row3_no_count" "no" "$(key_present STRICT_SPEC_COUNT)"
+run_test "s9b_row3_invocations" "1" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+rm -f "$MOCK_RECORD_FILE"
+
+# Row 5: applied count 0
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[]}'
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s1_row5_state" "STRICT_SPEC_STATE=applied" "$(line_for STRICT_SPEC_STATE)"
+run_test "s1_row5_count0" "STRICT_SPEC_COUNT=0" "$(line_for STRICT_SPEC_COUNT)"
+run_test "s1_row5_checks_empty" "STRICT_SPEC_CHECKS=" "$(line_for STRICT_SPEC_CHECKS)"
+run_test "s1a_row5_no_reason" "no" "$(key_present STRICT_SPEC_REASON)"
+run_test "s3_applied0_vs_unavailable" "applied" "$(grep '^STRICT_SPEC_STATE=' "$OUTPUT_FILE" | cut -d= -f2)"
+run_test "s9b_row5_invocations" "2" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+run_test "s11a_modes" "ordinary,strict" "$(awk -F= '/^mode=/{printf "%s%s", (n++?",":""), $2} END{print ""}' "$MOCK_RECORD_FILE")"
+run_test "s11_ordinary_bundle_no_strict_key" "false" \
+  "$(awk -F= '/^has_strict_spec_checks=/{print $2; exit}' "$MOCK_RECORD_FILE")"
+run_test "s11_strict_bundle_has_key" "true" \
+  "$(awk -F= '/^has_strict_spec_checks=/{print $2}' "$MOCK_RECORD_FILE" | tail -1)"
+rm -f "$MOCK_RECORD_FILE"
+
+# Scenario 5a / row 6 / scenarios 4,8,9: findings
+THREE_STRICT='{"mode":"strict_spec_checks","findings":[{"check":"ac_consistency","path":"spec.md","line":1,"body":"contradiction A"},{"check":"gate_matrix","path":"spec.md","line":2,"body":"missing combo"},{"check":"ac_consistency","path":"spec.md","line":3,"body":"contradiction B"}]}'
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT="$THREE_STRICT"
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s9_clean_with_strict_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "s9_blocking_zero" "BLOCKING_COUNT=0" "$(line_for BLOCKING_COUNT)"
+run_test "s9_strict_count3" "STRICT_SPEC_COUNT=3" "$(line_for STRICT_SPEC_COUNT)"
+run_test "s4_no_blocking_detail" "no" "$(key_present BLOCKING_1_PATH)"
+run_test "s4_strict_detail_check" "STRICT_1_CHECK=ac_consistency" "$(line_for STRICT_1_CHECK)"
+run_test "s10_distinct_checks" "STRICT_SPEC_CHECKS=ac_consistency,gate_matrix" "$(line_for STRICT_SPEC_CHECKS)"
+
+# Scenario 5a: same ordinary output with checklist removed
+ORDINARY_WITH_STRICT="$(grep -E '^(RESULT|COMMENT_COUNT|BLOCKING_COUNT|SUGGESTION_COUNT|BLOCKING_[0-9]+_)' "$OUTPUT_FILE" || true)"
+reset_mocks
+install_recording_two_pass_mock
+remove_checklist_from_repo
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT="$THREE_STRICT"
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+ORDINARY_WITHOUT="$(grep -E '^(RESULT|COMMENT_COUNT|BLOCKING_COUNT|SUGGESTION_COUNT|BLOCKING_[0-9]+_)' "$OUTPUT_FILE" || true)"
+run_test "s5a_ordinary_identical" "$ORDINARY_WITH_STRICT" "$ORDINARY_WITHOUT"
+run_test "s5a_unavailable" "STRICT_SPEC_STATE=unavailable" "$(line_for STRICT_SPEC_STATE)"
+
+# Scenario 8: mixed blocking + strict
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"needs_fixes","findings":[{"severity":"important","path":"a.sh","line":1,"message":"b1"},{"severity":"important","path":"b.sh","line":2,"message":"b2"}]}'
+MOCK_STRICT_STDOUT="$THREE_STRICT"
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s8_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "s8_blocking" "BLOCKING_COUNT=2" "$(line_for BLOCKING_COUNT)"
+run_test "s8_strict" "STRICT_SPEC_COUNT=3" "$(line_for STRICT_SPEC_COUNT)"
+
+# Scenario 8a: strict result ignored
+FIXED_ORDINARY='{"result":"clean","findings":[]}'
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT="$FIXED_ORDINARY"
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","result":"needs_fixes","findings":[{"check":"ac_consistency","path":"s.md","line":1,"body":"x"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+R1="$(line_for RESULT)"
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT="$FIXED_ORDINARY"
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","result":"clean","findings":[{"check":"ac_consistency","path":"s.md","line":1,"body":"x"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+R2="$(line_for RESULT)"
+run_test "s8a_result_identical" "$R1" "$R2"
+run_test "s8a_result_clean" "RESULT=clean" "$R1"
+
+# Scenario 6: unknown identifier
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[{"check":"not_a_real_check","path":"s.md","line":1,"body":"x"},{"check":"ac_consistency","path":"s.md","line":2,"body":"y"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s6_count_excludes_unknown" "STRICT_SPEC_COUNT=1" "$(line_for STRICT_SPEC_COUNT)"
+run_test "s6_unknown_count" "STRICT_SPEC_UNKNOWN_COUNT=1" "$(line_for STRICT_SPEC_UNKNOWN_COUNT)"
+run_test "s6_unknown_label" "STRICT_1_CHECK=unknown" "$(line_for STRICT_1_CHECK)"
+run_test "s6_not_blocking" "BLOCKING_COUNT=0" "$(line_for BLOCKING_COUNT)"
+run_test "s6_result_clean" "RESULT=clean" "$(line_for RESULT)"
+
+# Scenario 7: non-string / missing check
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[{"check":12,"path":"s.md","line":1,"body":"n"},{"check":{"x":1},"path":"s.md","line":2,"body":"o"},{"check":null,"path":"s.md","line":3,"body":"z"},{"path":"s.md","line":4,"body":"missing"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7_all_unknown" "STRICT_SPEC_UNKNOWN_COUNT=4" "$(line_for STRICT_SPEC_UNKNOWN_COUNT)"
+run_test "s7_count_zero" "STRICT_SPEC_COUNT=0" "$(line_for STRICT_SPEC_COUNT)"
+run_test "s7_applied" "STRICT_SPEC_STATE=applied" "$(line_for STRICT_SPEC_STATE)"
+
+# Scenario 7a: malformed findings shapes
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7a_empty_object" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":null}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7a_findings_null" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":{"a":1}}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7a_findings_object" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":"nope"}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7a_findings_string" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7a_empty_array_applied" "STRICT_SPEC_STATE=applied" "$(line_for STRICT_SPEC_STATE)"
+run_test "s7a_empty_array_count0" "STRICT_SPEC_COUNT=0" "$(line_for STRICT_SPEC_COUNT)"
+
+# Scenario 7b: missing mode / ordinary review as strict response
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"findings":[{"check":"ac_consistency","path":"s.md","line":1,"body":"x"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7b_missing_mode" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"result":"needs_fixes","findings":[{"severity":"important","message":"blocker"},{"severity":"important","message":"blocker2"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s7b_ordinary_as_strict" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+run_test "s7b_not_applied_unknown" "no" "$(key_present STRICT_SPEC_UNKNOWN_COUNT)"
+run_test "s7b_ordinary_still_clean" "RESULT=clean" "$(line_for RESULT)"
+
+# Scenario 9a: five failure shapes
+# 1) non-zero exit
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_EXIT=1
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT MOCK_STRICT_EXIT
+run_spec_review
+run_test "s9a_nonzero_state" "STRICT_SPEC_STATE=unavailable" "$(line_for STRICT_SPEC_STATE)"
+run_test "s9a_nonzero_reason" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+run_test "s9a_nonzero_clean" "RESULT=clean" "$(line_for RESULT)"
+run_test "s9b_nonzero_invocations" "2" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+rm -f "$MOCK_RECORD_FILE"
+unset MOCK_STRICT_EXIT
+
+# 2) empty response
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT=''
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s9a_empty_reason" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+# 3) unparseable
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='not-json'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s9a_unparseable_reason" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+
+# 4) timeout on strict pass
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[]}'
+# Make strict sleep past remaining budget: ordinary ~0, timeout 1, strict sleeps 2
+LOCAL_AI_REVIEWER_TIMEOUT=1
+# Override mock to sleep on strict only
+cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+mode="${LOCAL_AI_REVIEWER_MODE:-ordinary}"
+if [ -n "${MOCK_RECORD_FILE:-}" ]; then
+  printf 'mode=%s\n' "$mode" >> "$MOCK_RECORD_FILE"
+fi
+if [ "$mode" = "strict" ]; then
+  sleep 3
+  printf '%s\n' '{"mode":"strict_spec_checks","findings":[]}'
+  exit 0
+fi
+printf '%s\n' "${MOCK_ORDINARY_STDOUT}"
+exit 0
+MOCK_REVIEWER
+chmod +x "$MOCK_BIN/local-reviewer-mock"
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT LOCAL_AI_REVIEWER_TIMEOUT
+START_TS=$(date +%s)
+run_spec_review --timeout 2
+END_TS=$(date +%s)
+ELAPSED=$((END_TS - START_TS))
+run_test "s9a_timeout_reason" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+run_test "s9a_timeout_clean" "RESULT=clean" "$(line_for RESULT)"
+run_test "s9c_within_budget" "yes" "$([ "$ELAPSED" -le 4 ] && echo yes || echo no)"
+run_test "s9b_timeout_invocations" "2" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+rm -f "$MOCK_RECORD_FILE"
+unset LOCAL_AI_REVIEWER_TIMEOUT
+
+# 5) exhausted budget: ordinary consumes whole timeout (date stub advances clock)
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+MOCK_RECORD_FILE="$(mktemp)"
+# Stub date so elapsed >= TIMEOUT after the ordinary pass records round_start.
+cat > "$MOCK_BIN/date" <<'MOCK_DATE'
+#!/usr/bin/env bash
+# First call (round start) -> 1000; later calls -> 1000+TIMEOUT
+if [ ! -f "${MOCK_DATE_STATE:-/tmp/1650-date-state}" ]; then
+  echo 1000 > "${MOCK_DATE_STATE:-/tmp/1650-date-state}"
+  echo 1000
+  exit 0
+fi
+echo $((1000 + ${MOCK_DATE_TIMEOUT:-1}))
+MOCK_DATE
+chmod +x "$MOCK_BIN/date"
+MOCK_DATE_STATE="$(mktemp)"
+rm -f "$MOCK_DATE_STATE"
+MOCK_DATE_TIMEOUT=1
+cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+mode="${LOCAL_AI_REVIEWER_MODE:-ordinary}"
+if [ -n "${MOCK_RECORD_FILE:-}" ]; then
+  printf 'mode=%s\n' "$mode" >> "$MOCK_RECORD_FILE"
+fi
+if [ "$mode" = "ordinary" ]; then
+  printf '%s\n' '{"result":"clean","findings":[]}'
+  exit 0
+fi
+printf '%s\n' '{"mode":"strict_spec_checks","findings":[]}'
+exit 0
+MOCK_REVIEWER
+chmod +x "$MOCK_BIN/local-reviewer-mock"
+export MOCK_RECORD_FILE MOCK_DATE_STATE MOCK_DATE_TIMEOUT
+run_spec_review --timeout 1
+run_test "s9a_exhausted_reason" "STRICT_SPEC_REASON=strict_pass_failed" "$(line_for STRICT_SPEC_REASON)"
+run_test "s9b_exhausted_invocations" "1" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+run_test "s9a_exhausted_clean" "RESULT=clean" "$(line_for RESULT)"
+rm -f "$MOCK_RECORD_FILE" "$MOCK_DATE_STATE"
+unset MOCK_DATE_STATE MOCK_DATE_TIMEOUT
+
+# Scenario 13: ninth check counted from checklist
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/nine-section.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[{"check":"ninth_check","path":"s.md","line":1,"body":"n"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s13_ninth_counted" "STRICT_SPEC_COUNT=1" "$(line_for STRICT_SPEC_COUNT)"
+run_test "s13_ninth_checks" "STRICT_SPEC_CHECKS=ninth_check" "$(line_for STRICT_SPEC_CHECKS)"
+run_test "s13_no_unknown" "no" "$(key_present STRICT_SPEC_UNKNOWN_COUNT)"
+
+# Scenario 13a: malformed heading
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/malformed-heading.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s13a_unreadable" "STRICT_SPEC_REASON=checklist_unreadable" "$(line_for STRICT_SPEC_REASON)"
+run_test "s13a_no_count" "no" "$(key_present STRICT_SPEC_COUNT)"
+
+# Scenario 13b: duplicate id
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/duplicate-id.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_ORDINARY_STDOUT
+run_spec_review
+run_test "s13b_duplicate" "STRICT_SPEC_REASON=checklist_unreadable" "$(line_for STRICT_SPEC_REASON)"
+
+# Scenario 13c: no headings / empty
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/no-headings.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_ORDINARY_STDOUT
+run_spec_review
+run_test "s13c_no_headings" "STRICT_SPEC_REASON=checklist_unreadable" "$(line_for STRICT_SPEC_REASON)"
+run_test "s13c_no_headings_has_result" "RESULT=clean" "$(line_for RESULT)"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/empty.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_ORDINARY_STDOUT
+run_spec_review
+run_test "s13c_empty" "STRICT_SPEC_REASON=checklist_unreadable" "$(line_for STRICT_SPEC_REASON)"
+run_test "s13c_empty_has_result" "RESULT=clean" "$(line_for RESULT)"
+
+# Scenario 12 (reviewer-output half): evidence mirrors output
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$EVIDENCE_FILE"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT="$THREE_STRICT"
+export LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "s12_evidence_has_state" "applied" "$(jq -r '.strict_spec.state' "$EVIDENCE_FILE")"
+run_test "s12_evidence_has_count" "3" "$(jq -r '.strict_spec.count' "$EVIDENCE_FILE")"
+run_test "s12_evidence_no_reason" "false" "$(jq -r 'if .strict_spec | has("reason") then "true" else "false" end' "$EVIDENCE_FILE")"
+
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$EVIDENCE_FILE"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_PR_HEAD_BRANCH="feature/test"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_ORDINARY_STDOUT MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "s12_na_evidence_state" "not_applicable" "$(jq -r '.strict_spec.state' "$EVIDENCE_FILE")"
+run_test "s12_na_evidence_no_count" "false" "$(jq -r 'if .strict_spec | has("count") then "true" else "false" end' "$EVIDENCE_FILE")"
+
+# Scenario 11a prompt overrides (codex preset source check)
+CODEX_CMD="$REPO_ROOT/scripts/development-workflow/local-codex-review-command.sh"
+run_test "s11a_codex_reads_mode" "yes" \
+  "$(rg -q 'LOCAL_AI_REVIEWER_MODE' "$CODEX_CMD" && echo yes || echo no)"
+run_test "s11a_codex_strict_prompt_override" "yes" \
+  "$(rg -q 'LOCAL_CODEX_REVIEWER_STRICT_PROMPT' "$CODEX_CMD" && echo yes || echo no)"
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -379,7 +379,7 @@ install_checklist_into_repo() {
   local src="$1"
   mkdir -p "$VALID_REPO_ROOT/docs/workflow/development-workflow"
   cp "$src" "$VALID_REPO_ROOT/docs/workflow/development-workflow/strict-spec-checks.md"
-  git -C "$VALID_REPO_ROOT" add docs/workflow/development-workflow/strict-spec-checks.md >/dev/null 2>&1 || true
+  git -C "$VALID_REPO_ROOT" add docs/workflow/development-workflow/strict-spec-checks.md >/dev/null 2>&1 || true # workflow-shell-guard: allow SH001 - fixture add is best-effort for spec-stage tests
 }
 
 remove_checklist_from_repo() {

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16590,6 +16590,75 @@ unset _orig_cfg _orig_hc
 echo "=== Area 1649 complete ==="
 
 # ---------------------------------------------------------------------------
+# Area 1650: strict_spec ledger object (#1650 scenario 12)
+# ---------------------------------------------------------------------------
+echo "=== Area 1650: strict_spec ledger object ==="
+
+pr_number=""
+current_run_id="1650-ledger"
+unresolved_thread_count=0
+late_thread_count=0
+expensive_gate_last_result=""
+
+# Applied: state + count + checks present; reason absent
+strict_spec_recorded=1
+strict_spec_state="applied"
+strict_spec_count="3"
+strict_spec_checks="ac_consistency,gate_matrix"
+strict_spec_unknown_count=""
+strict_spec_reason=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+run_test "1650_ledger_applied_state" "applied" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec.state')"
+run_test "1650_ledger_applied_count" "3" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec.count')"
+run_test "1650_ledger_applied_has_checks" "true" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec | has("checks")')"
+run_test "1650_ledger_applied_no_reason" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec | has("reason")')"
+
+# not_applicable: only state; count/checks/reason absent
+strict_spec_state="not_applicable"
+strict_spec_count=""
+strict_spec_checks=""
+strict_spec_unknown_count=""
+strict_spec_reason=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+run_test "1650_ledger_na_state" "not_applicable" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec.state')"
+run_test "1650_ledger_na_no_count" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec | has("count")')"
+run_test "1650_ledger_na_no_checks" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec | has("checks")')"
+run_test "1650_ledger_na_no_reason" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec | has("reason")')"
+
+# No local reviewer: object itself absent
+strict_spec_recorded=0
+strict_spec_state=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "bugbot" 0 0 0 "" 0 0 "")"
+run_test "1650_ledger_absent_object" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r 'has("strict_spec")')"
+
+# unavailable carries reason only
+strict_spec_recorded=1
+strict_spec_state="unavailable"
+strict_spec_reason="checklist_unreadable"
+strict_spec_count=""
+strict_spec_checks=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+run_test "1650_ledger_unavail_reason" "checklist_unreadable" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec.reason')"
+run_test "1650_ledger_unavail_no_count" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_spec | has("count")')"
+
+unset strict_spec_recorded strict_spec_state strict_spec_count strict_spec_checks
+unset strict_spec_unknown_count strict_spec_reason _entry current_run_id
+unset unresolved_thread_count late_thread_count pr_number
+
+echo "=== Area 1650 complete ==="
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary
- Add the closed-set strict-spec checklist (`docs/workflow/development-workflow/strict-spec-checks.md`) and planted-violation fixtures.
- Run a second, non-blocking local-reviewer pass on `spec/*` branches (`LOCAL_AI_REVIEWER_MODE=strict`) that shares `--timeout`, never merges into blocking findings, and emits `STRICT_*` / `STRICT_SPEC_*` keys plus a mirroring `strict_spec` ledger object.
- Forward those keys through `pr-review-loop.sh`, document the contract, lint the checklist path, and add changelog fragment `1650.added.strict-spec-contract-review.md`.

Closes #1650

## Cross-cutting assumption re-verification (implementation start)
| Assumption | Result |
| --- | --- |
| Approved base `develop-internal-reviewer-effectiveness` | Still valid |
| #1653 full stage resolution | Still Conflict — implemented **minimal** stage detection only (`spec/*` → spec; empty `HEAD_BRANCH` → `stage_unresolved`; else `not_applicable`) per handoff |
| Parser residue-is-blocking | Still valid — ordinary parser unchanged |
| #1677/#1678 AC-16a–d / matrix row 4 | Still valid in merged spec text |
| #1648/#1649 reuse | Still valid — reused, not reimplemented |

## Pre-Submission Self-Review Pass
- Ordinary `jq -n` bundle site untouched; strict bundle derived via `jq --rawfile`.
- Ordinary parser untouched; strict findings never enter `BLOCKING_<n>_*`.
- `STRICT_SPEC_COUNT` / `CHECKS` absent outside `applied`; `REASON` only when `unavailable`.
- No second timeout knob (`LOCAL_AI_REVIEWER_STRICT_TIMEOUT` / similar absent).
- Harness `HARNESS_MODE` guard allows sourcing extract/parser helpers.
- Sibling docs updated: integration guide, Protocol 93, `--help`, markdown-lint paths.
- AC-7 fixture `gate_matrix_complete.md` reworked to full enumeration without unstated short-circuit (avoids false AC-6b on the negative control).

## Test plan
- [x] `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh` — **134 passed**
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area strict_spec` — **11 passed**
- [x] Smoke runbook scenarios 14–15 / proofs P10–P17 (real Codex) — documented below

## Notes
- #1654 not implemented (intentional).
- Full #1653 prompt splitting not implemented (intentional; minimal stage detection only).

## Planted-Violation Proofs

Harness: mock `gh` with `HEAD_BRANCH=spec/1650-smoke`; ordinary pass stubbed clean; strict pass via `LOCAL_AI_REVIEWER_COMMAND=scripts/development-workflow/local-codex-review-command.sh` (`LOCAL_CODEX_REVIEWER_BIN=/opt/homebrew/bin/codex`). Fixture copied to `docs/specs/smoke-fixture.md` in an ephemeral checkout.

### Blocking / measurement (P1–P9) — automated suite

| Proof | Plant | Evidence |
| --- | --- | --- |
| P1 | Merge strict findings into ordinary array | `test-local-ai-reviewer.sh` s9: ordinary clean + 3 strict → `RESULT=clean`, `BLOCKING_COUNT=0`, `STRICT_SPEC_COUNT=3` |
| P2 | Drop unknown identifiers | s6: `STRICT_SPEC_UNKNOWN_COUNT=1`, `STRICT_1_CHECK=unknown`, not blocking |
| P3 | Emit strict in `BLOCKING_*` | s4: no `BLOCKING_1_PATH`; `STRICT_1_CHECK=ac_consistency` |
| P4 | Read strict `result` into verdict | s8a: identical `RESULT=clean` across strict `needs_fixes` vs `clean` |
| P5 | Emit `COUNT=0` outside applied | s1 rows 2–3 / s12: count absent for `not_applicable`/`unavailable` |
| P6 | Hard-code eight IDs | s13: ninth checklist ID counted in `STRICT_SPEC_CHECKS` |
| P7 | `unavailable` without reason | s1a / s13a–c: distinct `STRICT_SPEC_REASON` values |
| P8 | Dispatch strict unconditionally | s1 row2 feature branch: one invocation, `not_applicable` |
| P9 | Failed strict takes review | s9a: five failure shapes → `strict_pass_failed`, ordinary untouched |

### Detection (P10–P17) — smoke scenarios 14–15

| Proof | Check | Planted fixture | Line | Plant | With checklist (fired?) | Violation removed (fired?) |
| --- | --- | --- | --- | --- | --- | --- |
| P10 | `ac_consistency` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/ac_consistency.md` | 4 | AC-A true vs AC-B false | **yes** — checks=`ac_consistency`, reported line=4 | **no** — state=`applied`, count=`0` |
| P11 | `ac_testability` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/ac_testability.md` | 4 | "feels appropriately responsive" untestable | **yes** — checks=`ac_testability`, reported line=4 | **no** — state=`applied`, count=`0` |
| P12a | `gate_matrix` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_reachable.md` | 6 | missing reachable combo stage=spec/checklist=absent (AC-6) | **yes** — checks=`gate_matrix`, reported line=6 | **no** — state=`applied`, count=`0` |
| P12b | `gate_matrix` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/gate_matrix_order_unstated.md` | 4 | short-circuit gate without stated evaluation order (AC-6b); cleaned = order_stated | **yes** — checks=`gate_matrix`, reported line=4 | **no** — state=`applied`, count=`0` |
| P13 | `opt_out_source` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/opt_out_source.md` | 3 | LOCAL_FLAG=1 and --disable dual sources | **yes** — checks=`opt_out_source`, reported line=3 | **no** — state=`applied`, count=`0` |
| P14 | `trigger_semantics` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/trigger_semantics.md` | 3 | HEAD_BRANCH absent behavior unstated | **yes** — checks=`trigger_semantics`, reported line=3 | **no** — state=`applied`, count=`0` |
| P15 | `example_contradiction` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/example_contradiction.md` | 5 | example emits COUNT=0 outside applied | **yes** — checks=`example_contradiction`, reported line=5 | **no** — state=`applied`, count=`0` |
| P16 | `parser_surface` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/parser_surface.md` | 3 | [A-Z][a-z]+ vs [a-z][a-z0-9_]* mismatch | **yes** — checks=`parser_surface`, reported line=3 | **no** — state=`applied`, count=`0` |
| P17 | `ambiguous_phrase` | `scripts/development-workflow/tests/fixtures/strict-spec-specs/ambiguous_phrase.md` | 4 | "next update" load-bearing; cleaned = rationale-only fixture | **yes** — checks=`ambiguous_phrase`, reported line=4 | **no** — state=`applied`, count=`0` |

### Scenario 14 negatives (must not fire)

| Fixture | Expected | Result |
| --- | --- | --- |
| `s14_gate_matrix_complete` (AC-7 full enumeration) | count=0 | **pass** count=`0` checks=`` |
| `s14_gate_matrix_order_stated` (AC-6a order stated) | count=0 | **pass** count=`0` checks=`` |
| `s14_ambiguous_phrase_rationale` (AC-13 rationale only) | count=0 | **pass** count=`0` checks=`` |

### Scenario 15 (checklist absent)

All twelve fixtures: `STRICT_SPEC_STATE=unavailable`, `STRICT_SPEC_REASON=checklist_unreadable`, no `STRICT_SPEC_COUNT` / no `STRICT_*` findings. Confirms detections in scenario 14 are checklist-caused.

Command template:
```bash
LOCAL_AI_REVIEWER_COMMAND=scripts/development-workflow/local-codex-review-command.sh \
LOCAL_CODEX_REVIEWER_BIN=/opt/homebrew/bin/codex \
# + mock gh HEAD_BRANCH=spec/1650-smoke + fixture as changed file
bash scripts/development-workflow/local-ai-reviewer.sh 123 lhpaul ai-dev-framework-template --timeout 420 --repo-root "$REPO"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the automated reviewer loop and local AI harness on every `spec/*` PR, but strict output is explicitly non-blocking and the ordinary review path is left structurally intact.
> 
> **Overview**
> Adds a **second local AI reviewer pass** on `spec/*` branches that runs after the ordinary review with `LOCAL_AI_REVIEWER_MODE=strict`, shares the existing `--timeout` budget, and never affects `RESULT` or `BLOCKING_*`.
> 
> The pass is driven by a new closed-set checklist (`strict-spec-checks.md`, eight identifiers parsed from `###` headings). It returns `mode: strict_spec_checks` JSON, which is surfaced as `STRICT_SPEC_*` / `STRICT_<n>_*` keys, a `strict_spec` block in evidence and reviewer-loop history, and an optional **non-blocking** section in the loop summary when findings exist.
> 
> `pr-review-loop.sh` forwards and records that telemetry; the bundled Codex command gains separate ordinary vs strict prompts (`LOCAL_CODEX_REVIEWER_STRICT_PROMPT`). CI markdown lint now includes the checklist path. Documentation and Protocol 93 describe the contract; changelog fragment and broad unit/fixture coverage exercise stage matrix, parser edge cases, and isolation from blocking verdicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51c078464ce7ac1f1dd6b2d58a299e758bbe75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->