### PR TITLE
feat(1651): record missed findings from external reviewers

### DIFF
--- a/changelog.d/1651.added.missed-finding-telemetry.md
+++ b/changelog.d/1651.added.missed-finding-telemetry.md
@@ -1,0 +1,4 @@
+- **Missed-finding telemetry** (#1651): when an external reviewer reports
+  blocking findings after the local reviewer was clean, the reviewer-loop
+  history records the miss (confirmed on the same commit, possible on an
+  ancestor) without changing any review outcome or readiness decision.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -180,6 +180,31 @@ PR comments (including during the async grace-period poll) must be treated as
 unavailable and must not let a clean submitted review be accepted before the
 root comments are known. Fail closed, not open.
 
+#### Missed-finding telemetry (`missed_findings`)
+
+When an **external** reviewer reports **blocking** findings on an attributable
+commit, `pr-review-loop.sh` writes a `missed_findings[]` element into that
+round's `reviewer_loop_history.v1` entry (schema string unchanged). Each
+element records the external reviewer, the reviewed commit (joined from
+`reviewed_heads[]`, never from `loop_head_sha`), the blocking count, every
+distinct finding path, the local evidence state, and a three-value
+`classification`: `confirmed_miss` (`clean_same_commit`), `possible_miss`
+(`clean_earlier_commit`), or `not_a_miss` (every other state, including
+`unknown`).
+
+The local evidence state is derived from the local reviewer's **most recent**
+verdict (not its most recent *clean* verdict), using per-platform
+`platform_results` plus `reviewed_heads[]`. The current round is composed as a
+synthetic entry before selection so a same-round local clean + external block
+is visible. Records accumulate; they never change readiness, labels, or merge
+decisions.
+
+Summary lines are one per record, at most 200 characters, with at most three
+named paths and an always-stated file total. When history cannot be appended
+to and a record was owed, the prior history block is left byte-for-byte
+unchanged and the summary reports the telemetry failure; when no record was
+owed, an unwritable history produces no telemetry-failure report.
+
 #### Expensive reviewer gate (`codex-github`)
 
 Before dispatching an expensive reviewer (`codex-github` today),

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -36,6 +36,11 @@ print_result() {
   print_kv SUGGESTION_COUNT "$suggestion_count"
   [ -n "$reason" ] && print_kv REASON "$reason"
   [ -n "$display_result" ] && print_kv DISPLAY_RESULT "$display_result"
+  # #1651: the CLI reviews the PR head it already resolved and matched.
+  # Emit only when exactly one head is known; leave absent otherwise (AC-11).
+  if [ -n "${HEAD_SHA:-}" ]; then
+    print_kv REVIEWED_HEAD "$HEAD_SHA"
+  fi
   return 0
 }
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -82,6 +82,12 @@
 
 set -euo pipefail
 
+# #1651: emit the commit this companion filtered reviews against.
+emit_reviewed_head_if_known() {
+  [ -n "${CURRENT_SHA_FULL:-}" ] || return 0
+  printf 'REVIEWED_HEAD=%s\n' "$CURRENT_SHA_FULL"
+}
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
@@ -1504,6 +1510,7 @@ EOF
     echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
     echo "VERDICT: NEEDS_REVISION"
     echo "INFO: detected $unresolved_thread_count existing unresolved Codex review thread(s)"
+emit_reviewed_head_if_known
     exit 1
   fi
 
@@ -1537,6 +1544,7 @@ EOF
     echo "---BEGIN BOT RESPONSE---"
     echo "$response_display"
     echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
     exit 1
   elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$EXISTING_BOT_RESPONSE")"; then
     codex_return_usage_limit "$response_display"
@@ -1547,12 +1555,14 @@ EOF
     echo "---BEGIN BOT RESPONSE---"
     echo "$response_display"
     echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
     exit 0
   else
     echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
     echo "---BEGIN BOT RESPONSE---"
     echo "$response_display"
     echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
     exit 1
   fi
 }
@@ -1859,6 +1869,7 @@ while true; do
     codex_require_current_head
     echo "VERDICT: NEEDS_REVISION"
     echo "INFO: detected $INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after trigger"
+emit_reviewed_head_if_known
     exit 1
   fi
 
@@ -1925,6 +1936,7 @@ while true; do
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
       exit 1
     elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$BOT_RESPONSE_FULL")"; then
       # Quote-stripped before checking: unlike the environment-error
@@ -1957,6 +1969,7 @@ while true; do
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
       exit 0
     elif [ "$BOT_RESPONSE_SOURCE" != "review" ] && grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$BOT_RESPONSE_FULL"; then
       # Gated on non-terminal evidence (source != "review") — issue #1491's
@@ -1981,6 +1994,7 @@ while true; do
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
       exit 1
     fi
   fi
@@ -2072,6 +2086,7 @@ if [ "$ASYNC_INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
   codex_require_current_head
   echo "VERDICT: NEEDS_REVISION"
   echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) during async grace period"
+emit_reviewed_head_if_known
   exit 1
 fi
 
@@ -2157,6 +2172,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
     exit 1
   elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$ASYNC_BOT_RESPONSE_FULL")"; then
     # Quote-stripped before checking — see the main-loop equivalent above
@@ -2178,6 +2194,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
     exit 0
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" != "review" ] && grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_BOT_RESPONSE_FULL"; then
     # Gated on non-terminal evidence — see the main-loop equivalent above
@@ -2193,6 +2210,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
       codex_require_current_head
       echo "VERDICT: NEEDS_REVISION"
       echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async acknowledgement"
+emit_reviewed_head_if_known
       exit 1
 	    fi
 	    ASYNC_FINAL_BOT_RESPONSE=""
@@ -2264,6 +2282,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
         exit 1
       elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$ASYNC_FINAL_BOT_RESPONSE_FULL")"; then
         # Quote-stripped before checking — see the main-loop equivalent
@@ -2285,6 +2304,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
         exit 0
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
         echo "INFO: final async Codex root comment is not SHA-pinned terminal evidence"
@@ -2304,6 +2324,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
         exit 1
       fi
     fi
@@ -2332,6 +2353,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
     exit 1
   fi
 fi
@@ -2348,6 +2370,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     codex_require_current_head
     echo "VERDICT: NEEDS_REVISION"
     echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async reaction"
+emit_reviewed_head_if_known
     exit 1
   fi
 
@@ -2419,6 +2442,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
       exit 1
     elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL")"; then
       # Quote-stripped before checking — see the main-loop equivalent
@@ -2440,6 +2464,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
       exit 0
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
       echo "INFO: final async reaction Codex root comment is not SHA-pinned terminal evidence"
@@ -2451,6 +2476,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
+emit_reviewed_head_if_known
       exit 1
     fi
   fi

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -104,6 +104,12 @@
 
 set -euo pipefail
 
+# Emit REVIEWED_HEAD when the check/PR head was established (#1651).
+emit_reviewed_head_if_known() {
+  [ -n "${REVIEWED_HEAD_SHA:-}" ] || return 0
+  printf 'REVIEWED_HEAD=%s\n' "$REVIEWED_HEAD_SHA"
+}
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
@@ -141,6 +147,15 @@ TIMEOUT="${HAYSTACK_REVIEWER_TIMEOUT:-120}"
 POLL_INTERVAL="${HAYSTACK_POLL_INTERVAL:-15}"
 PR_STATUS_CHECK="${HAYSTACK_PR_STATUS_CHECK:-1}"
 CHECK_NAME="${HAYSTACK_CHECK_NAME:-Haystack / Review}"
+
+# #1651: reviewed head from the PR head the check-run query already uses.
+# Empty when unresolvable — fail closed (no REVIEWED_HEAD emitted).
+REVIEWED_HEAD_SHA=""
+if REVIEWED_HEAD_SHA="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty' 2>/dev/null)"; then
+  :
+else
+  REVIEWED_HEAD_SHA=""
+fi
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -283,6 +298,7 @@ emit_haystack_analysis_file_limit_skip_from_json() {
   title="$(printf '%s\n' "$check_json" | jq -r '.output.title // ""')"
 
   printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
   printf 'REASON=analysis_skipped_file_limit\n'
   printf 'DISPLAY_RESULT=skipped (analysis file limit)\n'
   printf 'BLOCKING_COUNT=0\n'
@@ -335,6 +351,7 @@ emit_haystack_check_run_result() {
 
   if [ "$status" != "completed" ] && [ "$status" != "COMPLETED" ]; then
     printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
     printf 'REASON=pending_check_run\n'
     printf 'BLOCKING_COUNT=0\n'
     printf 'SUGGESTION_COUNT=0\n'
@@ -368,6 +385,7 @@ EOF
   case "$conclusion" in
     success|SUCCESS|neutral|NEUTRAL|skipped|SKIPPED)
       printf 'RESULT=clean\n'
+emit_reviewed_head_if_known
       printf 'BLOCKING_COUNT=0\n'
       printf 'SUGGESTION_COUNT=%d\n' "$suggestion_count"
       printf 'COMMENT_COUNT=%d\n' "$comment_count"
@@ -386,6 +404,7 @@ EOF
       fi
       if [ "$blocking_count" -gt 0 ]; then
         printf 'RESULT=needs_fixes\n'
+emit_reviewed_head_if_known
         printf 'BLOCKING_COUNT=%d\n' "$blocking_count"
         printf 'SUGGESTION_COUNT=%d\n' "$suggestion_count"
         printf 'COMMENT_COUNT=%d\n' "$comment_count"
@@ -396,6 +415,7 @@ EOF
         return 1
       fi
       printf 'RESULT=clean\n'
+emit_reviewed_head_if_known
       printf 'BLOCKING_COUNT=0\n'
       printf 'SUGGESTION_COUNT=%d\n' "$suggestion_count"
       printf 'COMMENT_COUNT=%d\n' "$comment_count"
@@ -407,6 +427,7 @@ EOF
       ;;
     *)
       printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
       printf 'REASON=check_run_%s\n' "${conclusion:-unknown}"
       printf 'BLOCKING_COUNT=0\n'
       printf 'SUGGESTION_COUNT=0\n'
@@ -439,6 +460,7 @@ if ! command -v haystack >/dev/null 2>&1; then
   fi
   echo "INFO: haystack CLI not found in PATH — skipping (UNAVAILABLE)" >&2
   printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
   printf 'REASON=unavailable\n'
   printf 'BLOCKING_COUNT=0\n'
   printf 'SUGGESTION_COUNT=0\n'
@@ -449,6 +471,7 @@ fi
 if ! command -v jq >/dev/null 2>&1; then
   echo "INFO: jq not found in PATH — skipping (UNAVAILABLE)" >&2
   printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
   printf 'REASON=unavailable\n'
   printf 'BLOCKING_COUNT=0\n'
   printf 'SUGGESTION_COUNT=0\n'
@@ -613,6 +636,7 @@ while true; do
       echo "INFO: haystack triage non-zero exit AND empty/invalid stdout — treating as UNAVAILABLE" >&2
       rm -f "$TRIAGE_STDERR"
       printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
       printf 'REASON=unavailable\n'
       printf 'BLOCKING_COUNT=0\n'
       printf 'SUGGESTION_COUNT=0\n'
@@ -630,6 +654,7 @@ while true; do
     echo "INFO: haystack triage returned empty output — treating as UNAVAILABLE" >&2
     rm -f "$TRIAGE_STDERR"
     printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
     printf 'REASON=unavailable\n'
     printf 'BLOCKING_COUNT=0\n'
     printf 'SUGGESTION_COUNT=0\n'
@@ -642,6 +667,7 @@ while true; do
     echo "INFO: haystack triage returned invalid JSON — treating as UNAVAILABLE" >&2
     rm -f "$TRIAGE_STDERR"
     printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
     printf 'REASON=unavailable\n'
     printf 'BLOCKING_COUNT=0\n'
     printf 'SUGGESTION_COUNT=0\n'
@@ -674,6 +700,7 @@ while true; do
       echo "INFO: haystack triage returned status=none (no analysis available for this PR) — treating as UNAVAILABLE" >&2
       rm -f "$TRIAGE_STDERR"
       printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
       printf 'REASON=unavailable\n'
       printf 'BLOCKING_COUNT=0\n'
       printf 'SUGGESTION_COUNT=0\n'
@@ -696,6 +723,7 @@ while true; do
         echo "INFO: haystack triage returned status=error with message=${_error_msg} — treating as ${_auth_reason} (not retrying)" >&2
         rm -f "$TRIAGE_STDERR"
         printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
         printf 'REASON=%s\n' "$_auth_reason"
         printf 'BLOCKING_COUNT=0\n'
         printf 'SUGGESTION_COUNT=0\n'
@@ -739,6 +767,7 @@ if [ "$TRIAGE_EXIT" -eq 124 ]; then
     :
   fi
   printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
   printf 'REASON=timeout\n'
   printf 'BLOCKING_COUNT=0\n'
   printf 'SUGGESTION_COUNT=0\n'
@@ -759,6 +788,7 @@ if [ "$TRIAGE_EXIT" -eq 200 ]; then
     :
   fi
   printf 'RESULT=skipped\n'
+emit_reviewed_head_if_known
   printf 'REASON=pending_timeout\n'
   printf 'BLOCKING_COUNT=0\n'
   printf 'SUGGESTION_COUNT=0\n'
@@ -939,6 +969,7 @@ if [ "$PR_STATUS_CHECK" != "0" ]; then
     else
       echo "ERROR: haystack pr-status field parse failed — failing closed" >&2
       printf 'RESULT=needs_fixes\n'
+emit_reviewed_head_if_known
       printf 'REASON=policy_status_parse_failed\n'
       printf 'BLOCKING_COUNT=1\n'
       printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
@@ -969,6 +1000,7 @@ fi
 
 if [ "$BLOCKING_COUNT" -gt 0 ]; then
   printf 'RESULT=needs_fixes\n'
+emit_reviewed_head_if_known
   printf 'BLOCKING_COUNT=%d\n' "$BLOCKING_COUNT"
   printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
   printf 'COMMENT_COUNT=%d\n' "$COMMENT_COUNT"
@@ -985,6 +1017,7 @@ if [ "$BLOCKING_COUNT" -gt 0 ]; then
 fi
 
 printf 'RESULT=clean\n'
+emit_reviewed_head_if_known
 printf 'BLOCKING_COUNT=0\n'
 printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
 printf 'COMMENT_COUNT=%d\n' "$COMMENT_COUNT"
@@ -998,4 +1031,5 @@ printf 'POLICY_ANALYSIS_STATUS=%s\n' "$POLICY_ANALYSIS_STATUS"
 [ -n "$POLICY_HAS_REVIEWER" ] && printf 'POLICY_HAS_REVIEWER=%s\n' "$POLICY_HAS_REVIEWER"
 printf 'POLICY_NEEDS_HUMAN=%s\n' "$POLICY_NEEDS_HUMAN"
 [ "$POLICY_REVIEW_REQUIRED" -eq 1 ] && printf 'DISPLAY_RESULT=needs-review: policy\n'
+emit_reviewed_head_if_known
 exit 0

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -110,15 +110,12 @@ emit_reviewed_head_if_known() {
   printf 'REVIEWED_HEAD=%s\n' "$REVIEWED_HEAD_SHA"
 }
 
-# Populate REVIEWED_HEAD_SHA from Haystack check-run evidence or PR head when the
-# completed triage CLI path did not already establish it (#1651).
+# Populate REVIEWED_HEAD_SHA from Haystack check-run evidence when the completed
+# triage CLI path did not already establish it (#1651). Do not fall back to PR
+# head — attribution requires Haystack artifact evidence (AC-11 no-record path).
 haystack_ensure_reviewed_head_sha() {
   [ -n "${REVIEWED_HEAD_SHA:-}" ] && return 0
   fetch_haystack_check_run_json >/dev/null 2>&1 || true
-  if [ -z "${REVIEWED_HEAD_SHA:-}" ] && command -v gh >/dev/null 2>&1; then
-    REVIEWED_HEAD_SHA="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty' 2>/dev/null)" \
-      || REVIEWED_HEAD_SHA=""
-  fi
 }
 
 # ── Argument parsing ──────────────────────────────────────────────────────────

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -148,14 +148,8 @@ POLL_INTERVAL="${HAYSTACK_POLL_INTERVAL:-15}"
 PR_STATUS_CHECK="${HAYSTACK_PR_STATUS_CHECK:-1}"
 CHECK_NAME="${HAYSTACK_CHECK_NAME:-Haystack / Review}"
 
-# #1651: reviewed head from the PR head the check-run query already uses.
-# Empty when unresolvable — fail closed (no REVIEWED_HEAD emitted).
+# #1651: set only when a check run artifact is fetched (see fetch_haystack_check_run_json).
 REVIEWED_HEAD_SHA=""
-if REVIEWED_HEAD_SHA="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty' 2>/dev/null)"; then
-  :
-else
-  REVIEWED_HEAD_SHA=""
-fi
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -239,6 +233,8 @@ fetch_haystack_check_run_json() {
     return 1
   fi
   [ -n "$check_json" ] || return 1
+
+  REVIEWED_HEAD_SHA="$(printf '%s\n' "$check_json" | jq -r '.head_sha // .headSha // empty' 2>/dev/null)" || REVIEWED_HEAD_SHA=""
 
   printf '%s\n' "$check_json"
 }

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -110,6 +110,17 @@ emit_reviewed_head_if_known() {
   printf 'REVIEWED_HEAD=%s\n' "$REVIEWED_HEAD_SHA"
 }
 
+# Populate REVIEWED_HEAD_SHA from Haystack check-run evidence or PR head when the
+# completed triage CLI path did not already establish it (#1651).
+haystack_ensure_reviewed_head_sha() {
+  [ -n "${REVIEWED_HEAD_SHA:-}" ] && return 0
+  fetch_haystack_check_run_json >/dev/null 2>&1 || true
+  if [ -z "${REVIEWED_HEAD_SHA:-}" ] && command -v gh >/dev/null 2>&1; then
+    REVIEWED_HEAD_SHA="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty' 2>/dev/null)" \
+      || REVIEWED_HEAD_SHA=""
+  fi
+}
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
@@ -993,6 +1004,8 @@ else
 fi
 
 # ── Emit result ───────────────────────────────────────────────────────────────
+
+haystack_ensure_reviewed_head_sha
 
 if [ "$BLOCKING_COUNT" -gt 0 ]; then
   printf 'RESULT=needs_fixes\n'

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4866,7 +4866,7 @@ _unreplied_rest_blocking_comment_json_lines() {
   local resolved_ids_json="${4:-[]}"
 
   gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-    | jq -s --arg bot "$bot_login" --argjson resolved_ids "$resolved_ids_json" '
+    | jq -rs --arg bot "$bot_login" --argjson resolved_ids "$resolved_ids_json" '
         (
           [.[][] | select(
             .in_reply_to_id != null and

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1857,7 +1857,7 @@ run_codex_github_review() {
   fi
 
   if [ "$unresolved_count" -gt 0 ]; then
-    reviewer_loop_print_reviewed_head_from_bot_pr_artifacts "$repo" "$pr_number" "$bot_login" "$graphql_bot_login"
+    reviewer_loop_print_reviewed_head_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login"
     print_kv RESULT needs_fixes
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
@@ -3931,13 +3931,6 @@ run_devin_review() {
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
-    {
-      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
-      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
-      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
-      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
-      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
-    } | reviewer_loop_print_reviewed_head_from_json_lines
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -4098,13 +4091,6 @@ run_devin_review() {
 
         if [ "$stale_count" -gt 0 ]; then
           print_kv RESULT needs_fixes
-    {
-      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
-      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
-      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
-      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
-      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
-    } | reviewer_loop_print_reviewed_head_from_json_lines
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -4121,6 +4107,7 @@ run_devin_review() {
             print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
             index=$((index + 1))
           done < "$stale_file"
+          reviewer_loop_print_reviewed_head_from_json_lines < "$stale_file"
           rm -f "$stale_file"
           return 1
         fi
@@ -4237,13 +4224,6 @@ run_devin_review() {
 
   if [ "$blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
-    {
-      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
-      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
-      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
-      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
-      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
-    } | reviewer_loop_print_reviewed_head_from_json_lines
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -4259,6 +4239,7 @@ run_devin_review() {
       print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
       index=$((index + 1))
     done < "$blocking_lines_file"
+    reviewer_loop_print_reviewed_head_from_json_lines < "$blocking_lines_file"
     rm -f "$blocking_lines_file"
     return 1
   fi
@@ -6528,13 +6509,6 @@ run_coderabbit_review() {
 
         if [ "$stale_blocking_count" -gt 0 ]; then
           print_kv RESULT needs_fixes
-      {
-        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
-        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
-        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
-        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
-        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
-      } | reviewer_loop_print_reviewed_head_from_json_lines
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -6553,6 +6527,7 @@ run_coderabbit_review() {
             print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
             index=$((index + 1))
           done < "$stale_file"
+          reviewer_loop_print_reviewed_head_from_json_lines < "$stale_file"
           rm -f "$stale_file"
           return 1
         fi
@@ -7901,36 +7876,40 @@ reviewer_loop_print_reviewed_head_from_json_lines() {
 
 # Fetch PR review comments and reviews for a bot login and emit REVIEWED_HEAD when
 # exactly one unique commit_id is present in those artifacts.
-reviewer_loop_print_reviewed_head_from_bot_pr_artifacts() {
-  local repo="$1"
-  local pr_number="$2"
-  local bot_login="$3"
-  local graphql_bot_login="${4:-${bot_login%\[bot\]}}"
+reviewer_loop_print_reviewed_head_from_unresolved_bot_threads() {
+  local pr_number="$1"
+  local repo="$2"
+  local graphql_bot_login="$3"
+  local owner repo_name commits
 
-  {
-    gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-      | jq -r --arg bot "$bot_login" --arg gbot "$graphql_bot_login" '
-          .[]
-          | select(
-              .user.login == $bot or
-              .user.login == $gbot or
-              .user.login == ($bot + "[bot]")
-            )
-          | {commit_id: (.commit_id // "")}
-          | @json
-        ' 2>/dev/null || true
-    gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
-      | jq -r --arg bot "$bot_login" --arg gbot "$graphql_bot_login" '
-          .[]
-          | select(
-              .user.login == $bot or
-              .user.login == $gbot or
-              .user.login == ($bot + "[bot]")
-            )
-          | {commit_id: (.commit_id // .commitId // "")}
-          | @json
-        ' 2>/dev/null || true
-  } | reviewer_loop_print_reviewed_head_from_json_lines
+  owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
+  repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
+
+  commits="$(
+    gh api graphql \
+      -f query='query($owner:String!,$repo:String!,$pr:Int!){
+        repository(owner:$owner,name:$repo){
+          pullRequest(number:$pr){
+            reviewThreads(first:100){
+              nodes{
+                isResolved
+                originalCommitOid
+                comments(first:1){nodes{author{login}}}
+              }
+            }
+          }
+        }
+      }' \
+      -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" \
+      --jq --arg bot "$graphql_bot_login" '
+        [.data.repository.pullRequest.reviewThreads.nodes[]
+          | select(.isResolved == false)
+          | select((.comments.nodes[0].author.login // "") == $bot)
+          | .originalCommitOid // empty
+        ] | unique | .[]' 2>/dev/null || true
+  )"
+
+  printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
 }
 
 # Build missed_findings JSON array for the current round.
@@ -8741,6 +8720,42 @@ reviewer_loop_history_select_latest_summary_record() {
   '
 }
 
+reviewer_loop_history_extract_preserved_section() {
+  local existing_body="$1"
+  local prior=""
+
+  prior="$(printf '%s\n' "$existing_body" | awk '
+    /<details>/ { in_details=1 }
+    in_details { buf = buf $0 "\n" }
+    /<\/details>/ && in_details {
+      if (index(buf, "<!-- reviewer-loop-history:v1 -->") > 0) {
+        latest = buf
+      }
+      buf = ""
+      in_details = 0
+    }
+    END { printf "%s", latest }
+  ')"
+  if [ -n "$prior" ]; then
+    printf '%s' "$prior"
+    return 0
+  fi
+
+  if ! printf '%s\n' "$existing_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+    return 1
+  fi
+
+  # Marker-only blocks (e.g. unavailable stub) have no <details> wrapper.
+  printf '%s\n' "$existing_body" | awk -v marker="$REVIEWER_LOOP_HISTORY_MARKER" '
+    index($0, marker) { in_block=1 }
+    in_block {
+      print
+      if ($0 ~ /^```json/) { in_fence=1; next }
+      if (in_fence && $0 ~ /^```[[:space:]]*$/) { exit }
+    }
+  '
+}
+
 reviewer_loop_history_append_to_summary() {
   local comment_body="$1"
   local existing_body="${2:-}"
@@ -8783,18 +8798,7 @@ reviewer_loop_history_append_to_summary() {
   # leave that block byte-for-byte unchanged — do not re-render a stub over it.
   if [ "${reviewer_loop_history_last_append_safe:-1}" -eq 0 ] \
       && [ "${reviewer_loop_history_had_prior_block:-0}" -eq 1 ]; then
-    prior_section="$(printf '%s\n' "$existing_body" | awk '
-      /<details>/ { in_details=1 }
-      in_details { buf = buf $0 "\n" }
-      /<\/details>/ && in_details {
-        if (index(buf, "<!-- reviewer-loop-history:v1 -->") > 0) {
-          latest = buf
-        }
-        buf = ""
-        in_details = 0
-      }
-      END { printf "%s", latest }
-    ')"
+    prior_section="$(reviewer_loop_history_extract_preserved_section "$existing_body")"
     if [ -n "$prior_section" ]; then
       printf '%s\n\n%s\n' "$comment_body" "$prior_section"
       return 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4857,6 +4857,78 @@ check_unreplied_rest_comments() {
   printf '%d\n' "${result:-0}"
 }
 
+# Newline-delimited JSON objects {path,line,body,commit_id} for unreplied
+# CodeRabbit REST root comments (outside-diff supplement). Exit 3 on API failure.
+_unreplied_rest_blocking_comment_json_lines() {
+  local pr_number="$1"
+  local repo="$2"
+  local bot_login="$3"
+  local resolved_ids_json="${4:-[]}"
+
+  gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
+    | jq -s --arg bot "$bot_login" --argjson resolved_ids "$resolved_ids_json" '
+        (
+          [.[][] | select(
+            .in_reply_to_id != null and
+            .user.login != $bot and
+            (.user.login | test("\\[bot\\]$") | not)
+          ) | .in_reply_to_id] | unique
+        ) as $human_replied_ids
+        | [.[][] | select(
+            .user.login == $bot and
+            .in_reply_to_id == null and
+            ((.body // "") | test("✅ Addressed") | not)
+          ) | select(
+            .id as $id |
+            ($human_replied_ids | index($id)) == null
+          ) | select(
+            .id as $id |
+            ($resolved_ids | index($id)) == null
+          ) | {
+              path: (.path // ""),
+              line: (.line // .original_line // 0),
+              body: (.body // ""),
+              commit_id: (.commit_id // "")
+            }]
+        | .[] | @json
+      ' 2>/dev/null || return 3
+}
+
+# Emit BLOCKING_<n>_PATH/LINE/BODY and REVIEWED_HEAD from unreplied REST comments.
+reviewer_loop_print_blocking_from_unreplied_rest_comments() {
+  local pr_number="$1"
+  local repo="$2"
+  local bot_login="$3"
+  local resolved_ids_json="${4:-[]}"
+  local blocking_file idx=0 blocking_json path line body title
+
+  blocking_file="$(mktemp)"
+  if ! _unreplied_rest_blocking_comment_json_lines \
+      "$pr_number" "$repo" "$bot_login" "$resolved_ids_json" >"$blocking_file"; then
+    rm -f "$blocking_file"
+    return 3
+  fi
+
+  while IFS= read -r blocking_json; do
+    [ -z "${blocking_json:-}" ] && continue
+    idx=$((idx + 1))
+    path="$(printf '%s\n' "$blocking_json" | jq -r '.path // ""')"
+    line="$(printf '%s\n' "$blocking_json" | jq -r '.line // 0')"
+    body="$(printf '%s\n' "$blocking_json" | jq -r '.body // ""')"
+    title="$(printf '%s\n' "$body" | sed -n 's/^### //p;q')"
+    if [ -z "$title" ]; then
+      title="$(printf '%.120s' "$(printf '%s\n' "$body" | tr '\n' ' ')")"
+    fi
+    print_kv "BLOCKING_${idx}_PATH" "${path:-unknown}"
+    print_kv "BLOCKING_${idx}_LINE" "$line"
+    print_kv_escaped "BLOCKING_${idx}_BODY" "$title"
+  done < "$blocking_file"
+
+  reviewer_loop_print_reviewed_head_from_json_lines < "$blocking_file"
+  rm -f "$blocking_file"
+  return 0
+}
+
 auto_reply_unreplied_rest_comments() {
   # Post a brief acknowledgement reply to each unreplied CodeRabbit REST review
   # comment that has no corresponding resolved GraphQL thread (i.e., outside-diff
@@ -5198,6 +5270,8 @@ coderabbit_thread_gate_clean() {
       # One or more replies failed; fall back to needs_fixes so the agent can
       # address the remaining comments manually.
       echo "WARN: auto-reply failed for one or more REST comments on PR #$pr_number — returning needs_fixes" >&2
+      reviewer_loop_print_blocking_from_unreplied_rest_comments \
+        "$pr_number" "$repo" "$bot_login" "$resolved_ids_json" || true
       print_kv RESULT needs_fixes
       print_kv REASON coderabbit_unreplied_rest_comments
       print_kv PLATFORM "$platform"
@@ -5223,6 +5297,8 @@ coderabbit_thread_gate_clean() {
       # Re-check REST query failed — cannot confirm gate is clean; treat as
       # needs_fixes so the agent re-inspects rather than claiming false clean.
       echo "WARN: REST re-check failed (exit $recheck_st) after auto-reply on PR #$pr_number — returning needs_fixes" >&2
+      reviewer_loop_print_blocking_from_unreplied_rest_comments \
+        "$pr_number" "$repo" "$bot_login" "$resolved_ids_json" || true
       print_kv RESULT needs_fixes
       print_kv REASON coderabbit_unreplied_rest_comments
       print_kv PLATFORM "$platform"
@@ -5238,6 +5314,8 @@ coderabbit_thread_gate_clean() {
     fi
     if [ "${recheck_raw:-0}" -gt 0 ]; then
       echo "WARN: ${recheck_raw} unreplied REST comment(s) remain after auto-reply on PR #$pr_number — returning needs_fixes" >&2
+      reviewer_loop_print_blocking_from_unreplied_rest_comments \
+        "$pr_number" "$repo" "$bot_login" "$resolved_ids_json" || true
       print_kv RESULT needs_fixes
       print_kv REASON coderabbit_unreplied_rest_comments
       print_kv PLATFORM "$platform"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7999,11 +7999,11 @@ reviewer_loop_print_blocking_from_unresolved_bot_threads() {
     body="$(printf '%s' "$row" | jq -r '.body // ""')"
     title="$(printf '%s\n' "$body" | sed -n 's/^### //p;q')"
     if [ -z "$title" ]; then
-      title="$(printf '%.120s' "$body")"
+      title="$(printf '%.120s' "$(printf '%s\n' "$body" | tr '\n' ' ')")"
     fi
     print_kv "BLOCKING_${idx}_PATH" "${path:-unknown}"
     print_kv "BLOCKING_${idx}_LINE" "$line"
-    print_kv "BLOCKING_${idx}_BODY" "$title"
+    print_kv_escaped "BLOCKING_${idx}_BODY" "$title"
   done < <(printf '%s\n' "$json" | jq -c '.[]?')
   return 0
 }

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2673,7 +2673,7 @@ run_bugbot_review() {
                 .state == "COMMENTED"
               )
             )
-          | { path: "", line: 0, body: (.body // "review without body"), state: .state }
+          | { path: "", line: 0, body: (.body // "review without body"), state: .state, commit_id: (.commit_id // .commitId // "") }
           | @json
         ' 2>/dev/null
   )"
@@ -3092,7 +3092,7 @@ run_bugbot_review() {
                         .state == "COMMENTED"
                       )
                     )
-                  | { path: "", line: 0, body: (.body // "review without body"), state: .state }
+                  | { path: "", line: 0, body: (.body // "review without body"), state: .state, commit_id: (.commit_id // .commitId // "") }
                   | @json
                 ' 2>/dev/null
           )"
@@ -3883,7 +3883,7 @@ run_devin_review() {
                 .state == "COMMENTED"
               )
             )
-          | { path: "", line: 0, body: (.body // "review without body"), state: .state }
+          | { path: "", line: 0, body: (.body // "review without body"), state: .state, commit_id: (.commit_id // .commitId // "") }
           | @json
         '
   )"
@@ -4185,7 +4185,8 @@ run_devin_review() {
             path: "",
             line: 0,
             body: (.body // "review without body"),
-            state: .state
+            state: .state,
+            commit_id: (.commit_id // .commitId // "")
           }
         | @json
       '

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1944,7 +1944,6 @@ run_codex_github_review() {
       print_kv COMMENT_COUNT "$unresolved_count"
       print_kv BLOCKING_COUNT "$unresolved_count"
       print_kv SUGGESTION_COUNT 0
-      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 1
       ;;
     3)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7876,40 +7876,76 @@ reviewer_loop_print_reviewed_head_from_json_lines() {
   printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
 }
 
-# Fetch PR review comments and reviews for a bot login and emit REVIEWED_HEAD when
-# exactly one unique commit_id is present in those artifacts.
-reviewer_loop_print_reviewed_head_from_unresolved_bot_threads() {
+# Collect originalCommitOid values from bot threads that check_unresolved_threads
+# would count as unresolved in strict mode (not resolved, not outdated, not
+# self-marked "✅ Addressed"). Paginates like check_unresolved_threads.
+reviewer_loop_blocking_unresolved_thread_commit_oids() {
   local pr_number="$1"
   local repo="$2"
   local graphql_bot_login="$3"
-  local owner repo_name commits
+  local owner repo_name cursor has_next_page page max_pages result graphql_query nodes_fields
 
   owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
   repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
 
-  commits="$(
-    gh api graphql \
-      -f query='query($owner:String!,$repo:String!,$pr:Int!){
-        repository(owner:$owner,name:$repo){
-          pullRequest(number:$pr){
-            reviewThreads(first:100){
-              nodes{
-                isResolved
-                originalCommitOid
-                comments(first:1){nodes{author{login}}}
-              }
-            }
-          }
-        }
-      }' \
-      -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" \
-      --jq --arg bot "$graphql_bot_login" '
-        [.data.repository.pullRequest.reviewThreads.nodes[]
-          | select(.isResolved == false)
-          | select((.comments.nodes[0].author.login // "") == $bot)
-          | .originalCommitOid // empty
-        ] | unique | .[]' 2>/dev/null || true
-  )"
+  cursor=""
+  has_next_page="true"
+  page=0
+  max_pages=10
+
+  nodes_fields='id isResolved isOutdated originalCommitOid firstComment:comments(first:1){nodes{author{login}body}}'
+  graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{'"$nodes_fields"'}}}}}'
+
+  while [ "$has_next_page" = "true" ]; do
+    page=$((page + 1))
+    if [ "$page" -gt "$max_pages" ]; then
+      return 2
+    fi
+
+    if [ -n "$cursor" ]; then
+      result="$(gh api graphql \
+        -f query="$graphql_query" \
+        -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" -f cursor="$cursor" \
+        --jq '.data.repository.pullRequest' 2>/dev/null)" \
+        || return 3
+    else
+      result="$(gh api graphql \
+        -f query="$graphql_query" \
+        -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" \
+        --jq '.data.repository.pullRequest' 2>/dev/null)" \
+        || return 3
+    fi
+
+    has_next_page="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.hasNextPage')"
+    cursor="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.endCursor // empty')"
+
+    printf '%s\n' "$result" | jq -r --arg bot "$graphql_bot_login" '
+      .reviewThreads.nodes[]
+      | select((.firstComment.nodes[0].author.login // "") == $bot)
+      | select(.isResolved != true)
+      | select((.isOutdated // false) != true)
+      | select((.firstComment.nodes[0].body // "") | contains("✅ Addressed") | not)
+      | .originalCommitOid // empty
+    '
+
+    if [ "$has_next_page" = "true" ] && [ -z "$cursor" ]; then
+      return 2
+    fi
+  done
+
+  return 0
+}
+
+# Emit REVIEWED_HEAD when strict-mode blocking threads for a bot login share
+# exactly one unique originalCommitOid.
+reviewer_loop_print_reviewed_head_from_unresolved_bot_threads() {
+  local pr_number="$1"
+  local repo="$2"
+  local graphql_bot_login="$3"
+  local commits
+
+  commits="$(reviewer_loop_blocking_unresolved_thread_commit_oids \
+    "$pr_number" "$repo" "$graphql_bot_login" 2>/dev/null || true)"
 
   printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
 }
@@ -8393,7 +8429,7 @@ reviewer_loop_history_build_entry() {
   head_sha="$(reviewer_loop_history_current_head_sha)"
   recorded_at="$(reviewer_loop_history_recorded_at)"
   local reviewed_heads_json
-  if declare -p platform_reviewed_heads >/dev/null 2>&1; then
+  if declare -p platform_reviewed_heads >/dev/null 2>&1 && [ "${#platform_reviewed_heads[@]}" -gt 0 ]; then
     reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
   else
     reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}")"
@@ -10869,7 +10905,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
     _existing_comment_record="$(
       set -o pipefail
       gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
-        | reviewer_loop_history_select_latest_summary_record
+        | reviewer_loop_history_select_summary_record
     )" \
       || {
         echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment with unavailable history" >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8198,8 +8198,7 @@ reviewer_loop_missed_finding_records() {
   local results_json heads_json composed_payload local_verdict
   local platform_name normalized reviewed_head blocking_count paths_text path_total
   local state classification record records_json="[]"
-  local entry_name entry_head output_blob paths_json
-  local -a path_lines=()
+  local entry_name output_blob paths_json
 
   missed_finding_attribution_reports=""
 
@@ -9050,12 +9049,13 @@ reviewer_loop_history_append_to_summary() {
       --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
       --argjson prNumber "${pr_number:-0}" \
       --arg updatedAt "$(reviewer_loop_history_recorded_at)" \
+      --arg reason "${reviewer_loop_history_last_unavailable_reason:-history_render_failed}" \
       '{
         schema: $schema,
         pr_number: $prNumber,
         updated_at: $updatedAt,
         history_status: "unavailable",
-        history_unavailable_reason: "history_render_failed",
+        history_unavailable_reason: $reason,
         entries: []
       }' >"$_payload_tmp"
   fi
@@ -10446,7 +10446,6 @@ declare -a platform_blocking_outputs=()
 missed_findings_json='[]'
 platform_results_json='[]'
 missed_finding_attribution_reports=""
-missed_finding_telemetry_failure=""
 # Peer evidence for the expensive-reviewer gate (issue #1649): "platform|result|reason".
 platform_peer_evidence=()
 expensive_gate_last_platform=""

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -523,6 +523,15 @@ Outputs stable key=value lines including:
     configured or when the reviewer reported no head)
   LOCAL_AI_HEAD_CURRENT=1|0| (1 when local-ai-reviewer classification is current; 0 when not-current;
     empty when not-reported or when local-ai-reviewer is not configured — missing evidence is not a pass)
+  Reviewer-loop history ledger (reviewer_loop_history.v1, additive fields; schema string unchanged):
+    platform_results[] — per-platform normalized outcome + raw RESULT/REASON (no head; heads stay in
+      reviewed_heads[] from #1648). Used to select the local reviewer's most recent verdict.
+    missed_findings[] — one element per external platform that reported blocking findings this round
+      on an attributable commit: reviewer, reviewed_head, blocking_count, full deduped paths,
+      path_total, local_evidence_state, and classification (confirmed_miss|possible_miss|not_a_miss).
+      Observational only — never changes readiness, labels, or merge decisions. Summary shows one
+      ≤200-character line per record. When history is unappendable and a record was owed, the prior
+      history block is preserved and the summary reports the telemetry failure.
   RESULT=needs_fixes REASON=head_moved_during_run (the PR head changed while the reviewers ran, so
     the clean verdict describes a commit the PR has left; nothing to fix — re-run the loop for the
     current HEAD)
@@ -8036,6 +8045,9 @@ reviewer_loop_missed_finding_records() {
     idx=$((idx + 1))
   done
 
+  # Assign globals in the current shell. Callers that need attribution reports
+  # must invoke this function without command substitution ($(...)).
+  missed_findings_json="$records_json"
   printf '%s\n' "$records_json"
 }
 
@@ -8705,13 +8717,17 @@ reviewer_loop_history_append_to_summary() {
   reviewer_loop_history_last_unavailable_reason=""
   reviewer_loop_history_had_prior_block=0
 
-  if ! payload="$(reviewer_loop_history_payload_from_existing "$existing_body" "$@" 2>/dev/null)"; then
+  # Capture payload without losing append_safe globals: write to a temp file
+  # from the current shell, then read it back.
+  local _payload_tmp
+  _payload_tmp="$(mktemp)"
+  if ! reviewer_loop_history_payload_from_existing "$existing_body" "$@" >"$_payload_tmp" 2>/dev/null; then
     reviewer_loop_history_last_append_safe=0
     reviewer_loop_history_last_unavailable_reason="history_render_failed"
     if printf '%s\n' "$existing_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
       reviewer_loop_history_had_prior_block=1
     fi
-    payload="$(jq -n \
+    jq -n \
       --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
       --argjson prNumber "${pr_number:-0}" \
       --arg updatedAt "$(reviewer_loop_history_recorded_at)" \
@@ -8722,8 +8738,10 @@ reviewer_loop_history_append_to_summary() {
         history_status: "unavailable",
         history_unavailable_reason: "history_render_failed",
         entries: []
-      }')"
+      }' >"$_payload_tmp"
   fi
+  payload="$(cat "$_payload_tmp")"
+  rm -f "$_payload_tmp"
 
   # #1651 AC-7a: when history cannot be appended and a prior block exists,
   # leave that block byte-for-byte unchanged — do not re-render a stub over it.
@@ -10855,7 +10873,9 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
   fi
 
   missed_finding_attribution_reports=""
-  missed_findings_json="$(reviewer_loop_missed_finding_records "$_prior_payload" "$_configured_platforms" "$_next_iteration")"
+  missed_findings_json='[]'
+  # Invoke in the current shell so attribution reports survive (no $(...)).
+  reviewer_loop_missed_finding_records "$_prior_payload" "$_configured_platforms" "$_next_iteration" >/dev/null
   _mf_count="$(printf '%s\n' "$missed_findings_json" | jq 'length' 2>/dev/null)" || _mf_count=0
   [[ "$_mf_count" =~ ^[0-9]+$ ]] || _mf_count=0
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7599,6 +7599,425 @@ reviewer_loop_blocking_paths_from_output() {
   done
 }
 
+# --- Missed-finding telemetry helpers (#1651) -------------------------------
+
+# reviewer_loop_commit_ancestry <clean_head> <reviewed_head>
+# Prints exactly one of: same | ancestor | descendant | unrelated | undecidable
+# Under set -e, every merge-base status is captured with || status=$?.
+reviewer_loop_commit_ancestry() {
+  local clean="${1:-}" reviewed="${2:-}" status
+
+  [ -n "$clean" ] && [ -n "$reviewed" ] || { printf 'undecidable\n'; return 0; }
+
+  # Existence BEFORE equality: two identical missing SHAs are undecidable, not same.
+  git cat-file -e "${clean}^{commit}" 2>/dev/null || { printf 'undecidable\n'; return 0; }
+  git cat-file -e "${reviewed}^{commit}" 2>/dev/null || { printf 'undecidable\n'; return 0; }
+
+  [ "$clean" = "$reviewed" ] && { printf 'same\n'; return 0; }
+
+  status=0
+  git merge-base --is-ancestor "$clean" "$reviewed" >/dev/null 2>&1 || status=$?
+  [ "$status" -eq 0 ] && { printf 'ancestor\n'; return 0; }
+  [ "$status" -ne 1 ] && { printf 'undecidable\n'; return 0; }
+
+  status=0
+  git merge-base --is-ancestor "$reviewed" "$clean" >/dev/null 2>&1 || status=$?
+  [ "$status" -eq 0 ] && { printf 'descendant\n'; return 0; }
+  [ "$status" -ne 1 ] && { printf 'undecidable\n'; return 0; }
+
+  printf 'unrelated\n'
+}
+
+# Normalize a companion-script RESULT/REASON pair into the stored platform_results
+# outcome. Prints: clean|needs_fixes|unavailable|not_configured|skipped|unknown
+reviewer_loop_normalize_platform_outcome() {
+  local raw_result="${1:-}"
+  local raw_reason="${2:-}"
+
+  case "$raw_result" in
+    clean) printf 'clean\n' ;;
+    needs_fixes) printf 'needs_fixes\n' ;;
+    skipped)
+      case "$raw_reason" in
+        unavailable) printf 'unavailable\n' ;;
+        not_configured) printf 'not_configured\n' ;;
+        *) printf 'skipped\n' ;;
+      esac
+      ;;
+    escalate) printf 'unavailable\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+# Build one compact platform_results JSON object from raw RESULT/REASON.
+reviewer_loop_platform_result_record_json() {
+  local platform="${1:-}"
+  local raw_result="${2:-}"
+  local raw_reason="${3:-}"
+  local normalized
+
+  normalized="$(reviewer_loop_normalize_platform_outcome "$raw_result" "$raw_reason")"
+  jq -nc \
+    --arg platform "$platform" \
+    --arg result "$normalized" \
+    --arg raw_result "$raw_result" \
+    --arg raw_reason "$raw_reason" \
+    '{platform: $platform, result: $result, raw_result: $raw_result, raw_reason: $raw_reason}'
+}
+
+# reviewer_loop_local_latest_verdict <history_payload> <configured_platforms>
+# configured_platforms is newline-delimited. Membership uses grep -Fxq here-string.
+reviewer_loop_local_latest_verdict() {
+  local payload="${1:-}"
+  local configured="${2:-}"
+
+  if ! grep -Fxq -- 'local-ai-reviewer' <<<"$configured"; then
+    printf '{"outcome":"not_configured","head_sha":"","iteration":0}\n'
+    return 0
+  fi
+
+  printf '%s' "$payload" | jq -c '
+    (.entries // []) as $entries
+    | [ $entries[]
+        | . as $entry
+        | ((.platform_results // [])[]
+           | select(.platform == "local-ai-reviewer")
+           | {outcome: (.result // "unknown"),
+              head_sha: (
+                ($entry.reviewed_heads // [])
+                | map(select(.platform == "local-ai-reviewer"))
+                | first
+                | .reviewed_head // ""
+              ),
+              iteration: ($entry.iteration // 0)})
+      ]
+    | sort_by(.iteration)
+    | last
+    // (if ($entries | length) == 0
+        then {outcome: "not_yet_run", head_sha: "", iteration: 0}
+        else {outcome: "unknown",     head_sha: "", iteration: 0}
+        end)
+    | if .outcome == "not_configured" then .outcome = "unavailable" else . end'
+}
+
+# reviewer_loop_local_evidence_state <local_verdict_json> <reviewed_head>
+reviewer_loop_local_evidence_state() {
+  local verdict_json="${1:-}"
+  local reviewed_head="${2:-}"
+  local outcome head_sha ancestry
+
+  outcome="$(printf '%s' "$verdict_json" | jq -r '.outcome // "unknown"')"
+  head_sha="$(printf '%s' "$verdict_json" | jq -r '.head_sha // ""')"
+
+  case "$outcome" in
+    clean)
+      ancestry="$(reviewer_loop_commit_ancestry "$head_sha" "$reviewed_head")"
+      case "$ancestry" in
+        same) printf 'clean_same_commit\n' ;;
+        ancestor) printf 'clean_earlier_commit\n' ;;
+        descendant) printf 'clean_later_commit\n' ;;
+        unrelated) printf 'clean_unrelated_commit\n' ;;
+        *) printf 'unknown\n' ;;
+      esac
+      ;;
+    needs_fixes) printf 'not_clean\n' ;;
+    skipped) printf 'skipped\n' ;;
+    unavailable) printf 'unavailable\n' ;;
+    not_yet_run) printf 'not_yet_run\n' ;;
+    not_configured) printf 'not_configured\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+# Map local evidence state to the three-value classification enum.
+reviewer_loop_missed_finding_classification() {
+  case "${1:-}" in
+    clean_same_commit) printf 'confirmed_miss\n' ;;
+    clean_earlier_commit) printf 'possible_miss\n' ;;
+    *) printf 'not_a_miss\n' ;;
+  esac
+}
+
+# Spec display labels for local evidence states.
+reviewer_loop_local_evidence_state_label() {
+  case "${1:-}" in
+    clean_same_commit) printf 'Clean, same commit\n' ;;
+    clean_earlier_commit) printf 'Clean, earlier commit\n' ;;
+    clean_later_commit) printf 'Clean, later commit\n' ;;
+    clean_unrelated_commit) printf 'Clean, unrelated commit\n' ;;
+    not_clean) printf 'Reported findings\n' ;;
+    skipped) printf 'Skipped\n' ;;
+    unavailable) printf 'Unavailable\n' ;;
+    not_yet_run) printf 'Not yet run\n' ;;
+    not_configured) printf 'Not configured\n' ;;
+    *) printf 'Unknown\n' ;;
+  esac
+}
+
+# De-duplicate paths preserving first-appearance order. stdin -> stdout.
+reviewer_loop_dedupe_paths() {
+  awk 'NF && !seen[$0]++ { print }'
+}
+
+# Join reviewed_head for a platform from reviewed_heads[] JSON array.
+reviewer_loop_reviewed_head_for_platform() {
+  local reviewed_heads_json="${1:-[]}"
+  local platform="${2:-}"
+
+  printf '%s' "$reviewed_heads_json" | jq -r --arg p "$platform" '
+    ([.[]? | select(.platform == $p) | .reviewed_head // ""] | first) // ""
+  '
+}
+
+# Emit REVIEWED_HEAD when stdin has exactly one unique non-empty commit line.
+reviewer_loop_print_reviewed_head_from_commits() {
+  local unique count sha
+  unique="$(grep -v '^$' | sort -u || true)"
+  count="$(printf '%s\n' "$unique" | grep -c . || true)"
+  [ "$count" -eq 1 ] || return 0
+  sha="$(printf '%s\n' "$unique" | head -n 1)"
+  [ -n "$sha" ] || return 0
+  print_kv REVIEWED_HEAD "$sha"
+}
+
+# Extract unique commit_id values from newline-delimited JSON objects on stdin
+# and print REVIEWED_HEAD when exactly one unique non-empty value exists.
+reviewer_loop_print_reviewed_head_from_json_lines() {
+  local commits
+  commits="$(jq -r '.commit_id // empty' 2>/dev/null | grep -v '^$' || true)"
+  printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
+}
+
+# Build missed_findings JSON array for the current round.
+# Args:
+#   $1 history_payload (persisted entries; may be empty object with entries:[])
+#   $2 configured_platforms (newline-delimited)
+#   $3 current_platform_results_json (array)
+#   $4 current_reviewed_heads_json (array, #1648 shape)
+#   $5 platform_outputs_json — array of {platform, blocking_count, output} for path extraction
+#      OR we pass paths via a parallel mechanism.
+# Simpler signature used by call site:
+# Globals read:
+#   platform_result_records[]  — JSON objects
+#   platform_reviewed_heads[]  — "name:sha"
+#   platform_blocking_outputs[] — optional "name<RS>output" (RS=\036) for path extraction
+#   missed_finding_attribution_failures — set by this function (newline messages)
+#
+# Returns JSON array on stdout. Also sets:
+#   missed_finding_records_json
+#   missed_finding_attribution_reports (human-readable lines)
+reviewer_loop_missed_finding_records() {
+  local history_payload="${1:-}"
+  local configured="${2:-}"
+  local iteration="${3:-0}"
+  local results_json heads_json composed_payload local_verdict
+  local platform_name normalized reviewed_head blocking_count paths_text path_total
+  local state classification record records_json="[]"
+  local entry_name entry_head output_blob paths_json
+  local -a path_lines=()
+
+  missed_finding_attribution_reports=""
+
+  results_json='[]'
+  if declare -p platform_result_records >/dev/null 2>&1 && [ "${#platform_result_records[@]}" -gt 0 ]; then
+    results_json="$(printf '%s\n' "${platform_result_records[@]}" | jq -s -c '.')"
+  fi
+
+  if declare -p platform_reviewed_heads >/dev/null 2>&1 && [ "${#platform_reviewed_heads[@]}" -gt 0 ]; then
+    heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
+  else
+    heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}")"
+  fi
+
+  # Compose synthetic current-round entry into the payload before selecting.
+  composed_payload="$(printf '%s' "${history_payload:-{\}}" | jq -c \
+    --argjson iteration "$iteration" \
+    --argjson results "$results_json" \
+    --argjson heads "$heads_json" \
+    '
+      . as $root
+      | ($root.entries // []) as $entries
+      | $root
+      | .schema = (.schema // "reviewer_loop_history.v1")
+      | .entries = ($entries + [{
+          iteration: $iteration,
+          platform_results: $results,
+          reviewed_heads: $heads
+        }])
+    ')"
+
+  local_verdict="$(reviewer_loop_local_latest_verdict "$composed_payload" "$configured")"
+
+  # Walk platform_result_records for external platforms with blocking findings.
+  if ! declare -p platform_result_records >/dev/null 2>&1; then
+    printf '%s\n' "$records_json"
+    return 0
+  fi
+
+  local idx=0
+  for record in "${platform_result_records[@]}"; do
+    platform_name="$(printf '%s' "$record" | jq -r '.platform // ""')"
+    normalized="$(printf '%s' "$record" | jq -r '.result // ""')"
+    [ -n "$platform_name" ] || continue
+
+    # Exclusion 1: local reviewer cannot miss its own findings
+    if [ "$platform_name" = "local-ai-reviewer" ]; then
+      continue
+    fi
+
+    # Exclusion 2: only blocking findings qualify (needs_fixes)
+    if [ "$normalized" != "needs_fixes" ]; then
+      continue
+    fi
+
+    # Join head from reviewed_heads[] — no loop_head_sha fallback
+    reviewed_head=""
+    if declare -p platform_reviewed_heads >/dev/null 2>&1; then
+      for entry_name in "${platform_reviewed_heads[@]}"; do
+        if [ "${entry_name%%:*}" = "$platform_name" ]; then
+          reviewed_head="${entry_name#*:}"
+          break
+        fi
+      done
+    fi
+
+    # Exclusion 3: unattributable commit
+    if [ -z "$reviewed_head" ]; then
+      missed_finding_attribution_reports="${missed_finding_attribution_reports}${missed_finding_attribution_reports:+$'\n'}missed-finding attribution failed: ${platform_name} — reviewed commit could not be established (no REVIEWED_HEAD)"
+      continue
+    fi
+
+    # Paths from companion output stored in parallel array if present
+    blocking_count=0
+    paths_text=""
+    if declare -p platform_blocking_outputs >/dev/null 2>&1; then
+      for output_blob in "${platform_blocking_outputs[@]}"; do
+        if [ "${output_blob%%$'\036'*}" = "$platform_name" ]; then
+          output_blob="${output_blob#*$'\036'}"
+          blocking_count="$(kv_value_default BLOCKING_COUNT "$output_blob" 0)"
+          paths_text="$(reviewer_loop_blocking_paths_from_output "$output_blob" "$blocking_count" | reviewer_loop_dedupe_paths)"
+          break
+        fi
+      done
+    fi
+    [[ "$blocking_count" =~ ^[0-9]+$ ]] || blocking_count=0
+    # If blocking_count came from normalized needs_fixes but output missing, still count >=1
+    if [ "$blocking_count" -eq 0 ]; then
+      blocking_count=1
+    fi
+
+    path_total=0
+    if [ -n "$paths_text" ]; then
+      path_total="$(printf '%s\n' "$paths_text" | grep -c . || true)"
+    fi
+    paths_json="$(printf '%s\n' "$paths_text" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+
+    state="$(reviewer_loop_local_evidence_state "$local_verdict" "$reviewed_head")"
+    classification="$(reviewer_loop_missed_finding_classification "$state")"
+
+    record="$(jq -nc \
+      --arg reviewer "$platform_name" \
+      --arg reviewed_head "$reviewed_head" \
+      --argjson blocking_count "$blocking_count" \
+      --argjson paths "$paths_json" \
+      --argjson path_total "$path_total" \
+      --arg local_evidence_state "$state" \
+      --arg classification "$classification" \
+      '{
+        reviewer: $reviewer,
+        reviewed_head: $reviewed_head,
+        blocking_count: $blocking_count,
+        paths: $paths,
+        path_total: $path_total,
+        local_evidence_state: $local_evidence_state,
+        classification: $classification
+      }')"
+    records_json="$(jq -nc --argjson arr "$records_json" --argjson rec "$record" '$arr + [$rec]')"
+    idx=$((idx + 1))
+  done
+
+  printf '%s\n' "$records_json"
+}
+
+# Render one summary line (<=200 chars) for a missed-finding record JSON object.
+reviewer_loop_missed_finding_summary_line() {
+  local record_json="${1:-}"
+  local reviewer short_sha blocking path_total state classification label
+  local prefix suffix remainder_max budget named=0 path next_len rem rem_text line
+  local -a paths=()
+
+  reviewer="$(printf '%s' "$record_json" | jq -r '.reviewer // ""')"
+  short_sha="$(printf '%s' "$record_json" | jq -r '.reviewed_head // ""' | cut -c1-8)"
+  blocking="$(printf '%s' "$record_json" | jq -r '.blocking_count // 0')"
+  path_total="$(printf '%s' "$record_json" | jq -r '.path_total // 0')"
+  state="$(printf '%s' "$record_json" | jq -r '.local_evidence_state // "unknown"')"
+  classification="$(printf '%s' "$record_json" | jq -r '.classification // "not_a_miss"')"
+  label="$(reviewer_loop_local_evidence_state_label "$state")"
+
+  while IFS= read -r path; do
+    [ -n "$path" ] && paths+=("$path")
+  done < <(printf '%s' "$record_json" | jq -r '.paths[]? // empty')
+
+  prefix="missed-finding: ${reviewer} on ${short_sha} — ${blocking} blocking, ${path_total} files ("
+  suffix=") — local: ${label} [${classification}]"
+  remainder_max=", +${path_total} more"
+  budget=$((200 - ${#prefix} - ${#suffix} - ${#remainder_max}))
+  [ "$budget" -lt 0 ] && budget=0
+
+  named=0
+  local path_part=""
+  local i=0
+  while [ "$i" -lt "${#paths[@]}" ] && [ "$named" -lt 3 ]; do
+    path="${paths[$i]}"
+    if [ "$named" -eq 0 ]; then
+      next_len=${#path}
+    else
+      next_len=$((2 + ${#path}))  # ", "
+    fi
+    if [ "$next_len" -gt "$budget" ]; then
+      break
+    fi
+    if [ "$named" -eq 0 ]; then
+      path_part="$path"
+    else
+      path_part="${path_part}, ${path}"
+    fi
+    budget=$((budget - next_len))
+    named=$((named + 1))
+    i=$((i + 1))
+  done
+
+  rem=$((path_total - named))
+  rem_text=""
+  if [ "$rem" -gt 0 ]; then
+    rem_text=", +${rem} more"
+  fi
+
+  line="${prefix}${path_part}${rem_text}${suffix}"
+  # Hard safety: never exceed 200 even if arithmetic drifts
+  if [ "${#line}" -gt 200 ]; then
+    line="${line:0:200}"
+  fi
+  printf '%s\n' "$line"
+}
+
+# Render all missed-finding summary lines from a JSON array.
+reviewer_loop_missed_findings_summary_section() {
+  local records_json="${1:-[]}"
+  local record line section=""
+
+  while IFS= read -r record; do
+    [ -n "$record" ] || continue
+    line="$(reviewer_loop_missed_finding_summary_line "$record")"
+    section="${section}
+${line}"
+  done < <(printf '%s' "$records_json" | jq -c '.[]?' 2>/dev/null)
+
+  printf '%s' "$section"
+}
+
+
+
 reviewer_loop_all_paths_non_shipped() {
   local path
   local saw_path=0
@@ -7851,6 +8270,17 @@ reviewer_loop_history_build_entry() {
     reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}")"
   fi
 
+  # platform_results / missed_findings (#1651): caller-set globals, same
+  # convention as unresolved_thread_count / current_run_id. Schema stays v1.
+  local platform_results_for_entry="${platform_results_json:-[]}"
+  local missed_findings_for_entry="${missed_findings_json:-[]}"
+  if ! printf '%s' "$platform_results_for_entry" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    platform_results_for_entry='[]'
+  fi
+  if ! printf '%s' "$missed_findings_for_entry" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    missed_findings_for_entry='[]'
+  fi
+
   # run_id (#1502 dual-cap follow-up): read from the current_run_id global,
   # following the same convention already used in this function for
   # unresolved_thread_count/late_thread_count (set by the caller before
@@ -7883,6 +8313,8 @@ reviewer_loop_history_build_entry() {
     --arg smallFindingsPaths "${small_findings_paths:-}" \
     --arg classificationHead "${loop_head_sha:-}" \
     --argjson reviewedHeads "$reviewed_heads_json" \
+    --argjson platformResults "$platform_results_for_entry" \
+    --argjson missedFindings "$missed_findings_for_entry" \
     --arg egPlatform "${expensive_gate_last_platform:-}" \
     --arg egResult "${expensive_gate_last_result:-}" \
     --arg egReason "${expensive_gate_last_reason:-}" \
@@ -7899,6 +8331,8 @@ reviewer_loop_history_build_entry() {
       head_sha: $headSha,
       classification_head: $classificationHead,
       reviewed_heads: $reviewedHeads,
+      platform_results: $platformResults,
+      missed_findings: $missedFindings,
       run_id: $runId,
       result: $result,
       reason: $reason,
@@ -8013,6 +8447,10 @@ reviewer_loop_history_payload_from_existing() {
        | .history_unavailable_reason = ""
        | .entries = ((.entries // []) + [$entry])'
   else
+    # #1651 AC-7a: do not replace a prior history block with an empty stub.
+    # Signal unappendable state via globals; append_to_summary preserves the
+    # prior details block when one exists, and only writes the stub when there
+    # is no prior block at all.
     updated_at="$(reviewer_loop_history_recorded_at)"
     jq -n \
       --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
@@ -8028,6 +8466,15 @@ reviewer_loop_history_payload_from_existing() {
         history_unavailable_reason: $reason,
         entries: []
       }'
+  fi
+
+  # Expose append decision to the summary renderer (#1651).
+  reviewer_loop_history_last_append_safe="$append_safe"
+  reviewer_loop_history_last_unavailable_reason="$unavailable_reason"
+  if printf '%s\n' "$existing_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+    reviewer_loop_history_had_prior_block=1
+  else
+    reviewer_loop_history_had_prior_block=0
   fi
 }
 
@@ -8152,8 +8599,18 @@ reviewer_loop_history_append_to_summary() {
   shift 2
   local payload
   local section
+  local prior_section=""
+
+  reviewer_loop_history_last_append_safe=1
+  reviewer_loop_history_last_unavailable_reason=""
+  reviewer_loop_history_had_prior_block=0
 
   if ! payload="$(reviewer_loop_history_payload_from_existing "$existing_body" "$@" 2>/dev/null)"; then
+    reviewer_loop_history_last_append_safe=0
+    reviewer_loop_history_last_unavailable_reason="history_render_failed"
+    if printf '%s\n' "$existing_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+      reviewer_loop_history_had_prior_block=1
+    fi
     payload="$(jq -n \
       --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
       --argjson prNumber "${pr_number:-0}" \
@@ -8167,6 +8624,29 @@ reviewer_loop_history_append_to_summary() {
         entries: []
       }')"
   fi
+
+  # #1651 AC-7a: when history cannot be appended and a prior block exists,
+  # leave that block byte-for-byte unchanged — do not re-render a stub over it.
+  if [ "${reviewer_loop_history_last_append_safe:-1}" -eq 0 ] \
+      && [ "${reviewer_loop_history_had_prior_block:-0}" -eq 1 ]; then
+    prior_section="$(printf '%s\n' "$existing_body" | awk '
+      /<details>/ { in_details=1 }
+      in_details { buf = buf $0 "\n" }
+      /<\/details>/ && in_details {
+        if (index(buf, "<!-- reviewer-loop-history:v1 -->") > 0) {
+          latest = buf
+        }
+        buf = ""
+        in_details = 0
+      }
+      END { printf "%s", latest }
+    ')"
+    if [ -n "$prior_section" ]; then
+      printf '%s\n\n%s\n' "$comment_body" "$prior_section"
+      return 0
+    fi
+  fi
+
   section="$(reviewer_loop_history_render_section "$payload")"
   printf '%s%s\n' "$comment_body" "$section"
 }
@@ -9530,6 +10010,14 @@ fi
 declare -a platform_result_tokens=()
 # Per-platform reviewed heads for head-evidence surfaces (issue #1648).
 declare -a platform_reviewed_heads=()
+# Per-platform raw outcomes for missed-finding telemetry (issue #1651).
+declare -a platform_result_records=()
+# Parallel platform outputs for path extraction when building missed_findings.
+declare -a platform_blocking_outputs=()
+missed_findings_json='[]'
+platform_results_json='[]'
+missed_finding_attribution_reports=""
+missed_finding_telemetry_failure=""
 # Peer evidence for the expensive-reviewer gate (issue #1649): "platform|result|reason".
 platform_peer_evidence=()
 expensive_gate_last_platform=""
@@ -9802,6 +10290,9 @@ for index in "${!platforms[@]}"; do
   _reviewed_head="$(kv_value_default REVIEWED_HEAD "$platform_output" "")"
   platform_reviewed_heads+=("${platform_name}:${_reviewed_head}")
   unset _reviewed_head
+  # #1651: persist raw RESULT/REASON (not display tokens) for platform_results.
+  platform_result_records+=("$(reviewer_loop_platform_result_record_json "$platform_name" "$platform_result" "$platform_reason")")
+  platform_blocking_outputs+=("${platform_name}"$''"${platform_output}")
 
   _policy_status_available="$(kv_value_default POLICY_STATUS_AVAILABLE "$platform_output" 0)"
   if [ "$_policy_status_available" = "1" ]; then
@@ -10183,19 +10674,6 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
 **Unreviewed tail:** ${small_findings_paths_inline:-none}"
   fi
 
-  local comment_body
-  comment_body="$(cat <<EOF
-### Automated Reviewer Loop Summary
-
-**Result:** ${result_line}
-**Platforms:** ${platform_list:-none}${policy_status_section}
-**Findings:** ${blocking} blocking, ${suggestions} suggestions
-${small_findings_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${strict_spec_summary_section}${regression_label_section}
-
-*Posted automatically by \`pr-review-loop.sh\`.*
-EOF
-)"
-
   # Errors in the comment-posting block must not change the script's exit code or
   # prevent key=value output from reaching the caller. Log warnings to stderr so
   # failures are visible in CI logs without being fatal.
@@ -10244,6 +10722,107 @@ EOF
       _existing_comment_body="$(printf '%s\n' "$_existing_comment_record" | jq -r '.body // ""' 2>/dev/null)" || _existing_comment_body=""
     fi
   fi
+
+  # #1651: derive missed-finding records BEFORE history writability (eligibility
+  # first). Compose the current round into the prior payload for AC-1.
+  local _prior_history_json=""
+  local _prior_payload='{"schema":"reviewer_loop_history.v1","entries":[]}'
+  local _configured_platforms=""
+  local _next_iteration=1
+  local _mf_count=0
+  local missed_findings_section=""
+  local missed_finding_telemetry_section=""
+  local _attr_line=""
+
+  _prior_history_json="$(printf '%s\n' "$_existing_comment_body" | reviewer_loop_history_extract_latest_json)"
+  if [ -n "$_prior_history_json" ]; then
+    if _prior_payload="$(printf '%s\n' "$_prior_history_json" | jq -c '.' 2>/dev/null)"; then
+      :
+    else
+      _prior_payload='{"schema":"reviewer_loop_history.v1","entries":[]}'
+    fi
+  fi
+  if declare -p platforms >/dev/null 2>&1 && [ "${#platforms[@]}" -gt 0 ]; then
+    _configured_platforms="$(printf '%s\n' "${platforms[@]}")"
+  fi
+  _next_iteration="$(printf '%s\n' "$_prior_payload" | jq '(.entries // []) | length + 1' 2>/dev/null)" || _next_iteration=1
+  [[ "$_next_iteration" =~ ^[0-9]+$ ]] || _next_iteration=1
+
+  if declare -p platform_result_records >/dev/null 2>&1 && [ "${#platform_result_records[@]}" -gt 0 ]; then
+    platform_results_json="$(printf '%s\n' "${platform_result_records[@]}" | jq -s -c '.')"
+  else
+    platform_results_json='[]'
+  fi
+
+  missed_finding_attribution_reports=""
+  missed_findings_json="$(reviewer_loop_missed_finding_records "$_prior_payload" "$_configured_platforms" "$_next_iteration")"
+  _mf_count="$(printf '%s\n' "$missed_findings_json" | jq 'length' 2>/dev/null)" || _mf_count=0
+  [[ "$_mf_count" =~ ^[0-9]+$ ]] || _mf_count=0
+
+  if [ "$_mf_count" -gt 0 ]; then
+    missed_findings_section="$(reviewer_loop_missed_findings_summary_section "$missed_findings_json")"
+  fi
+  local attribution_section=""
+  if [ -n "${missed_finding_attribution_reports:-}" ]; then
+    while IFS= read -r _attr_line; do
+      [ -n "$_attr_line" ] || continue
+      attribution_section="${attribution_section}
+${_attr_line}"
+    done <<< "$missed_finding_attribution_reports"
+  fi
+
+  # Probe writability with the same rules as payload_from_existing (AC-7a/7b).
+  # Eligibility already ran above; only report telemetry failure when records
+  # were owed (attributable external blockers) and history cannot be written.
+  local _hist_append_safe=1
+  local _hist_unavail_reason=""
+  if [ -n "$_prior_history_json" ]; then
+    if ! printf '%s\n' "$_prior_history_json" | jq -e '.' >/dev/null 2>&1; then
+      _hist_append_safe=0
+      _hist_unavail_reason="malformed_history"
+    elif ! printf '%s\n' "$_prior_payload" |
+        jq -e --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+          '.schema == $schema and (.entries | type) == "array"' >/dev/null 2>&1; then
+      _hist_append_safe=0
+      _hist_unavail_reason="unknown_schema"
+    elif [ "$(printf '%s\n' "$_prior_payload" | jq -r '.history_status // "available"')" = "unavailable" ]; then
+      _hist_append_safe=0
+      _hist_unavail_reason="$(printf '%s\n' "$_prior_payload" | jq -r '.history_unavailable_reason // "prior_unavailable"')"
+    fi
+  elif printf '%s\n' "$_existing_comment_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+    _hist_append_safe=0
+    _hist_unavail_reason="missing_history_json"
+  fi
+  if [ "$_existing_read_failed" -eq 1 ] && [ "$_hist_append_safe" -eq 1 ]; then
+    # Read failed and fell back to an unavailable stub body — not appendable.
+    _hist_append_safe=0
+    _hist_unavail_reason="${_hist_unavail_reason:-comment_read_failed}"
+  fi
+
+  if [ "$_mf_count" -gt 0 ] && [ "$_hist_append_safe" -eq 0 ]; then
+    # Records were owed but history is unwritable — clear them so build_entry
+    # does not invent a write that append_to_summary will refuse, and report.
+    # Do not show the would-be miss lines: AC-7a requires no record and a
+    # telemetry-failure report, not a summary of data that was never stored.
+    # Attribution failures (AC-11) remain visible — nothing was owed for those.
+    missed_findings_json='[]'
+    missed_findings_section=""
+    missed_finding_telemetry_section="
+**Missed-finding telemetry:** could not be recorded this round (${_hist_unavail_reason:-unknown}). Existing reviewer-loop history was left unchanged."
+  fi
+
+  local comment_body
+  comment_body="$(cat <<EOF
+### Automated Reviewer Loop Summary
+
+**Result:** ${result_line}
+**Platforms:** ${platform_list:-none}${policy_status_section}
+**Findings:** ${blocking} blocking, ${suggestions} suggestions
+${small_findings_section}${missed_findings_section}${attribution_section}${missed_finding_telemetry_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${strict_spec_summary_section}${regression_label_section}
+
+*Posted automatically by \`pr-review-loop.sh\`.*
+EOF
+)"
 
   comment_body="$(reviewer_loop_history_append_to_summary "$comment_body" "$_existing_comment_body" \
     "$result" "$reason" "$platform_list" "$blocking" "$suggestions" \

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8178,13 +8178,13 @@ reviewer_loop_missed_finding_records() {
       continue
     fi
 
-    # Join head from reviewed_heads[] — no loop_head_sha fallback
+    # Join head from reviewed_heads[] — prefer the last entry for this platform
+    # so late-thread append wins over an earlier clean pass (#1651).
     reviewed_head=""
     if declare -p platform_reviewed_heads >/dev/null 2>&1; then
       for entry_name in "${platform_reviewed_heads[@]}"; do
         if [ "${entry_name%%:*}" = "$platform_name" ]; then
           reviewed_head="${entry_name#*:}"
-          break
         fi
       done
     fi
@@ -8195,7 +8195,8 @@ reviewer_loop_missed_finding_records() {
       continue
     fi
 
-    # Paths from companion output stored in parallel array if present
+    # Paths from companion output — prefer the last blob for this platform so
+    # late-thread synthesis wins over an earlier clean pass (#1651).
     blocking_count=0
     paths_text=""
     if declare -p platform_blocking_outputs >/dev/null 2>&1; then
@@ -8204,7 +8205,6 @@ reviewer_loop_missed_finding_records() {
           output_blob="${output_blob#*$'\036'}"
           blocking_count="$(kv_value_default BLOCKING_COUNT "$output_blob" 0)"
           paths_text="$(reviewer_loop_blocking_paths_from_output "$output_blob" "$blocking_count" | reviewer_loop_dedupe_paths)"
-          break
         fi
       done
     fi

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7790,13 +7790,19 @@ reviewer_loop_local_latest_verdict() {
                 | .reviewed_head // ""
               ),
               iteration: ($entry.iteration // 0)})
-      ]
-    | sort_by(.iteration)
-    | last
-    // (if ($entries | length) == 0
-        then {outcome: "not_yet_run", head_sha: "", iteration: 0}
-        else {outcome: "unknown",     head_sha: "", iteration: 0}
-        end)
+      ] as $local_verdicts
+    | if ($local_verdicts | length) > 0 then
+        ($local_verdicts | sort_by(.iteration) | last)
+      elif [ $entries[]
+          | select(
+              ((.platforms // []) | index("local-ai-reviewer")) != null
+              or any(.reviewed_heads[]?; .platform == "local-ai-reviewer")
+            )
+        ] | length > 0 then
+        {outcome: "unknown", head_sha: "", iteration: 0}
+      else
+        {outcome: "not_yet_run", head_sha: "", iteration: 0}
+      end
     | if .outcome == "not_configured" then .outcome = "unavailable" else . end'
 }
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1857,6 +1857,7 @@ run_codex_github_review() {
   fi
 
   if [ "$unresolved_count" -gt 0 ]; then
+    reviewer_loop_print_reviewed_head_from_bot_pr_artifacts "$repo" "$pr_number" "$bot_login" "$graphql_bot_login"
     print_kv RESULT needs_fixes
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
@@ -7896,6 +7897,40 @@ reviewer_loop_print_reviewed_head_from_json_lines() {
   local commits
   commits="$(jq -r '.commit_id // empty' 2>/dev/null | grep -v '^$' || true)"
   printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
+}
+
+# Fetch PR review comments and reviews for a bot login and emit REVIEWED_HEAD when
+# exactly one unique commit_id is present in those artifacts.
+reviewer_loop_print_reviewed_head_from_bot_pr_artifacts() {
+  local repo="$1"
+  local pr_number="$2"
+  local bot_login="$3"
+  local graphql_bot_login="${4:-${bot_login%\[bot\]}}"
+
+  {
+    gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
+      | jq -r --arg bot "$bot_login" --arg gbot "$graphql_bot_login" '
+          .[]
+          | select(
+              .user.login == $bot or
+              .user.login == $gbot or
+              .user.login == ($bot + "[bot]")
+            )
+          | {commit_id: (.commit_id // "")}
+          | @json
+        ' 2>/dev/null || true
+    gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
+      | jq -r --arg bot "$bot_login" --arg gbot "$graphql_bot_login" '
+          .[]
+          | select(
+              .user.login == $bot or
+              .user.login == $gbot or
+              .user.login == ($bot + "[bot]")
+            )
+          | {commit_id: (.commit_id // .commitId // "")}
+          | @json
+        ' 2>/dev/null || true
+  } | reviewer_loop_print_reviewed_head_from_json_lines
 }
 
 # Build missed_findings JSON array for the current round.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7901,7 +7901,7 @@ reviewer_loop_blocking_unresolved_thread_commit_oids() {
   page=0
   max_pages=10
 
-  nodes_fields='id isResolved isOutdated originalCommitOid firstComment:comments(first:1){nodes{author{login}body}}'
+  nodes_fields='id isResolved isOutdated firstComment:comments(first:1){nodes{author{login}body originalCommit{oid}}}'
   graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{'"$nodes_fields"'}}}}}'
 
   while [ "$has_next_page" = "true" ]; do
@@ -7933,7 +7933,7 @@ reviewer_loop_blocking_unresolved_thread_commit_oids() {
       | select(.isResolved != true)
       | select((.isOutdated // false) != true)
       | select((.firstComment.nodes[0].body // "") | contains("✅ Addressed") | not)
-      | .originalCommitOid // empty
+      | .firstComment.nodes[0].originalCommit.oid // empty
     '
 
     if [ "$has_next_page" = "true" ] && [ -z "$cursor" ]; then
@@ -7950,10 +7950,16 @@ reviewer_loop_print_reviewed_head_from_unresolved_bot_threads() {
   local pr_number="$1"
   local repo="$2"
   local graphql_bot_login="$3"
-  local commits
+  local commits st
 
+  set +e
   commits="$(reviewer_loop_blocking_unresolved_thread_commit_oids \
-    "$pr_number" "$repo" "$graphql_bot_login" 2>/dev/null || true)"
+    "$pr_number" "$repo" "$graphql_bot_login" 2>/dev/null)"
+  st=$?
+  set -e
+  if [ "$st" -ne 0 ]; then
+    return 0
+  fi
 
   printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
 }
@@ -9986,45 +9992,46 @@ if [ "$_release_guard_fired" -eq 0 ]; then
 fi
 # --- End release PR early-exit guard ---
 
-if [ "${#platforms[@]}" -eq 0 ]; then
-  # Resolve config from the PR's target branch so platform coverage is
-  # consistent regardless of the operator's local checkout state (#756).
-  # Capture stderr separately: "Could not resolve" means PR not found (silent
-  # fallback); any other error is unexpected and warrants a diagnostic warning.
-  set +e
-  _pr_base_raw="$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName' 2>&1)"
-  _pr_base_exit=$?
-  set -e
-  _pr_base=""
-  if [ "$_pr_base_exit" -eq 0 ]; then
-    _pr_base="$_pr_base_raw"
-  elif ! printf '%s\n' "$_pr_base_raw" | grep -qi "Could not resolve\|not found"; then
-    printf 'WARNING: failed to resolve PR base branch (exit %d): %s — falling back to working-tree config\n' \
-      "$_pr_base_exit" "$_pr_base_raw" >&2
-  fi
-  if [ -n "$_pr_base" ]; then
-    if _PR_CONFIG_TMPFILE="$(mktemp 2>/dev/null)"; then
-      # Refresh the remote-tracking ref so git show reads the current target
-      # branch config, not a potentially stale cached ref (#777).
-      git fetch origin "$_pr_base" 2>/dev/null || true
-      if ! git show "origin/${_pr_base}:.ai-dev-workflow.yaml" > "$_PR_CONFIG_TMPFILE" 2>/dev/null; then
-        rm -f "$_PR_CONFIG_TMPFILE"
-        _PR_CONFIG_TMPFILE=""
-      fi
+# Resolve config from the PR's target branch so platform coverage is consistent
+# regardless of the operator's local checkout state (#756). Always snapshot
+# repo_review_platforms for missed-finding membership even when --platform
+# filters the invocation list.
+set +e
+_pr_base_raw="$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName' 2>&1)"
+_pr_base_exit=$?
+set -e
+_pr_base=""
+if [ "$_pr_base_exit" -eq 0 ]; then
+  _pr_base="$_pr_base_raw"
+elif ! printf '%s\n' "$_pr_base_raw" | grep -qi "Could not resolve\|not found"; then
+  printf 'WARNING: failed to resolve PR base branch (exit %d): %s — falling back to working-tree config\n' \
+    "$_pr_base_exit" "$_pr_base_raw" >&2
+fi
+if [ -n "$_pr_base" ]; then
+  if _PR_CONFIG_TMPFILE="$(mktemp 2>/dev/null)"; then
+    # Refresh the remote-tracking ref so git show reads the current target
+    # branch config, not a potentially stale cached ref (#777).
+    git fetch origin "$_pr_base" 2>/dev/null || true
+    if ! git show "origin/${_pr_base}:.ai-dev-workflow.yaml" > "$_PR_CONFIG_TMPFILE" 2>/dev/null; then
+      rm -f "$_PR_CONFIG_TMPFILE"
+      _PR_CONFIG_TMPFILE=""
     fi
   fi
-  config_file="${_PR_CONFIG_TMPFILE:-$(workflow_config_file)}"
-  if [ -f "$config_file" ]; then
-    if [ "$review_lifecycle_duplicate_warnings_emitted" -eq 0 ]; then
-      WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 emit_review_lifecycle_duplicate_warnings "$config_file"
-      review_lifecycle_duplicate_warnings_emitted=1
-    fi
-    while IFS= read -r line; do
-      line="$(trim "$line")"
-      [ -n "$line" ] && platforms+=("$line")
-    done < <(WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_platforms "$config_file")
-    repo_review_platforms=("${platforms[@]}")
+fi
+config_file="${_PR_CONFIG_TMPFILE:-$(workflow_config_file)}"
+if [ -f "$config_file" ]; then
+  if [ "$review_lifecycle_duplicate_warnings_emitted" -eq 0 ]; then
+    WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 emit_review_lifecycle_duplicate_warnings "$config_file"
+    review_lifecycle_duplicate_warnings_emitted=1
   fi
+  while IFS= read -r line; do
+    line="$(trim "$line")"
+    [ -n "$line" ] && repo_review_platforms+=("$line")
+  done < <(WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_platforms "$config_file")
+fi
+
+if [ "${#platforms[@]}" -eq 0 ] && [ "${#repo_review_platforms[@]}" -gt 0 ]; then
+  platforms=("${repo_review_platforms[@]}")
 fi
 
 if [ "${#phase_after_clean_platforms[@]}" -eq 0 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7755,13 +7755,21 @@ reviewer_loop_platform_result_record_json() {
 
 # reviewer_loop_local_latest_verdict <history_payload> <configured_platforms>
 # configured_platforms is newline-delimited. Membership uses grep -Fxq here-string.
+# When the current invocation filters platforms (--platform), prior PR history can
+# still contain local-ai-reviewer verdicts; consult history before not_configured.
 reviewer_loop_local_latest_verdict() {
   local payload="${1:-}"
   local configured="${2:-}"
 
   if ! grep -Fxq -- 'local-ai-reviewer' <<<"$configured"; then
-    printf '{"outcome":"not_configured","head_sha":"","iteration":0}\n'
-    return 0
+    if ! printf '%s' "$payload" | jq -e '
+        (.entries // [])[]
+        | (.platform_results // [])[]
+        | select(.platform == "local-ai-reviewer")
+      ' >/dev/null 2>&1; then
+      printf '{"outcome":"not_configured","head_sha":"","iteration":0}\n'
+      return 0
+    fi
   fi
 
   printf '%s' "$payload" | jq -c '
@@ -9706,6 +9714,7 @@ compare_mode=0
 pre_after_clean_only=0
 review_lifecycle_duplicate_warnings_emitted=0
 declare -a platforms=()
+declare -a repo_review_platforms=()
 declare -a phase_after_clean_platforms=()
 phase_after_clean_filtered_out=""
 
@@ -10014,6 +10023,7 @@ if [ "${#platforms[@]}" -eq 0 ]; then
       line="$(trim "$line")"
       [ -n "$line" ] && platforms+=("$line")
     done < <(WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_platforms "$config_file")
+    repo_review_platforms=("${platforms[@]}")
   fi
 fi
 
@@ -10938,7 +10948,9 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
       _prior_payload='{"schema":"reviewer_loop_history.v1","entries":[]}'
     fi
   fi
-  if declare -p platforms >/dev/null 2>&1 && [ "${#platforms[@]}" -gt 0 ]; then
+  if declare -p repo_review_platforms >/dev/null 2>&1 && [ "${#repo_review_platforms[@]}" -gt 0 ]; then
+    _configured_platforms="$(printf '%s\n' "${repo_review_platforms[@]}")"
+  elif declare -p platforms >/dev/null 2>&1 && [ "${#platforms[@]}" -gt 0 ]; then
     _configured_platforms="$(printf '%s\n' "${platforms[@]}")"
   fi
   _next_iteration="$(printf '%s\n' "$_prior_payload" | jq '(.entries // []) | length + 1' 2>/dev/null)" || _next_iteration=1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1920,6 +1920,7 @@ run_codex_github_review() {
       ;;
     1)
       unresolved_count=0
+      local actual_unresolved_count=0
       # mode=strict: this recount feeds the caller's needs_fixes/COMMENT_COUNT
       # reporting and must reflect true resolution state, not the provisional
       # reply relaxation used to decide whether to trigger the review above.
@@ -1929,11 +1930,21 @@ run_codex_github_review() {
       set -e
       if [ "$thread_check_status" -eq 0 ]; then
         unresolved_count="$thread_check_output"
+        actual_unresolved_count="$unresolved_count"
       fi
       [ "$unresolved_count" -eq 0 ] && unresolved_count=1
 
       reviewer_loop_print_reviewed_head_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login"
       reviewer_loop_print_blocking_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login" || true
+
+      # Companion script REVIEWED_HEAD is artifact-derived on terminal safe-fail
+      # paths with no unresolved threads; do not fall back when threads exist
+      # (multi-commit thread heads must stay unattributable per AC-11).
+      if [ "$actual_unresolved_count" -eq 0 ]; then
+        local companion_reviewed_head
+        companion_reviewed_head="$(kv_value_default REVIEWED_HEAD "$script_output" "")"
+        [ -n "$companion_reviewed_head" ] && print_kv REVIEWED_HEAD "$companion_reviewed_head"
+      fi
 
       print_kv RESULT needs_fixes
       print_kv PLATFORM "$platform"
@@ -6013,13 +6024,7 @@ run_coderabbit_review() {
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
-      {
-        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
-        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
-        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
-        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
-        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
-      } | reviewer_loop_print_reviewed_head_from_json_lines
+    reviewer_loop_print_reviewed_head_from_json_lines < "$existing_blocking_file"
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8182,6 +8182,13 @@ reviewer_loop_missed_finding_records() {
   printf '%s\n' "$records_json"
 }
 
+# Collect all missed-finding records persisted in a history payload.
+reviewer_loop_missed_findings_from_history_payload() {
+  local payload="${1:-}"
+  printf '%s' "$payload" | jq -c '[(.entries // [])[] | (.missed_findings // [])[]]' 2>/dev/null \
+    || printf '[]\n'
+}
+
 # Render one summary line (<=200 chars) for a missed-finding record JSON object.
 reviewer_loop_missed_finding_summary_line() {
   local record_json="${1:-}"
@@ -11063,9 +11070,6 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
   _mf_count="$(printf '%s\n' "$missed_findings_json" | jq 'length' 2>/dev/null)" || _mf_count=0
   [[ "$_mf_count" =~ ^[0-9]+$ ]] || _mf_count=0
 
-  if [ "$_mf_count" -gt 0 ]; then
-    missed_findings_section="$(reviewer_loop_missed_findings_summary_section "$missed_findings_json")"
-  fi
   local attribution_section=""
   if [ -n "${missed_finding_attribution_reports:-}" ]; then
     while IFS= read -r _attr_line; do
@@ -11113,6 +11117,19 @@ ${_attr_line}"
     missed_findings_section=""
     missed_finding_telemetry_section="
 **Missed-finding telemetry:** could not be recorded this round (${_hist_unavail_reason:-unknown}). Existing reviewer-loop history was left unchanged."
+  fi
+
+  local _display_missed_findings_json='[]'
+  _display_missed_findings_json="$(reviewer_loop_missed_findings_from_history_payload "$_prior_payload")"
+  if [ "$_mf_count" -gt 0 ] && [ "$_hist_append_safe" -eq 1 ]; then
+    _display_missed_findings_json="$(jq -s 'add' \
+      <(printf '%s\n' "$_display_missed_findings_json") \
+      <(printf '%s\n' "$missed_findings_json"))"
+  fi
+  if [ "$(printf '%s\n' "$_display_missed_findings_json" | jq 'length' 2>/dev/null)" -gt 0 ] 2>/dev/null; then
+    missed_findings_section="$(reviewer_loop_missed_findings_summary_section "$_display_missed_findings_json")"
+  else
+    missed_findings_section=""
   fi
 
   local comment_body

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -10974,11 +10974,10 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
   # (append_safe=0 for a persisted "unavailable" history_status) — so the
   # WRITE below can succeed (posting the stub) while this cycle's entry is
   # still never actually recorded. A later "clean" cycle's OWN posting-time
-  # read can then recover an OLDER available snapshot via reviewer_loop_
-  # history_select_summary_record's deliberate render-continuity fallback
-  # and patch over the stub, permanently losing this cycle's dispatch from
-  # both cap counters (found in review of PR #1507). Treat a failed READ
-  # here the same as a failed WRITE for fail-closed purposes.
+  # history_select_summary_record's deliberate render-continuity fallback is used
+  # ONLY for missed-finding derivation input (_mf_prior_payload), never for the
+  # comment id/body chosen for update-in-place — mixing newest id with an older
+  # substituted body would patch over unappendable latest history (AC-7a).
   local _existing_read_failed=0
   _repo="$(repo_slug 2>/dev/null)" \
     || { echo "WARN: repo_slug failed in _post_review_summary; will post new comment without update-in-place check" >&2; _repo=""; _existing_read_failed=1; }
@@ -10986,7 +10985,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
     _existing_comment_record="$(
       set -o pipefail
       gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
-        | reviewer_loop_history_select_summary_record
+        | reviewer_loop_history_select_latest_summary_record
     )" \
       || {
         echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment with unavailable history" >&2
@@ -11004,6 +11003,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
   # first). Compose the current round into the prior payload for AC-1.
   local _prior_history_json=""
   local _prior_payload='{"schema":"reviewer_loop_history.v1","entries":[]}'
+  local _mf_prior_payload=""
   local _configured_platforms=""
   local _next_iteration=1
   local _mf_count=0
@@ -11017,6 +11017,29 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
       :
     else
       _prior_payload='{"schema":"reviewer_loop_history.v1","entries":[]}'
+    fi
+  fi
+  _mf_prior_payload="$_prior_payload"
+  if [ "$(printf '%s\n' "$_prior_payload" | jq -r '.history_status // "available"')" = "unavailable" ] \
+      || { [ -z "$_prior_history_json" ] \
+           && printf '%s\n' "$_existing_comment_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; }; then
+    local _mf_fallback_record="" _mf_fallback_body="" _mf_fallback_json=""
+    if [ -n "$_repo" ]; then
+      _mf_fallback_record="$(
+        set -o pipefail
+        gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
+          | reviewer_loop_history_select_summary_record
+      )" || _mf_fallback_record=""
+      if [ -n "$_mf_fallback_record" ]; then
+        _mf_fallback_body="$(printf '%s\n' "$_mf_fallback_record" | jq -r '.body // ""' 2>/dev/null)" || _mf_fallback_body=""
+        _mf_fallback_json="$(printf '%s\n' "$_mf_fallback_body" | reviewer_loop_history_extract_latest_json 2>/dev/null)" || _mf_fallback_json=""
+        if [ -n "$_mf_fallback_json" ] \
+            && printf '%s\n' "$_mf_fallback_json" | jq -e --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+              '.schema == $schema and (.entries | type) == "array" and (.history_status // "available") == "available"' \
+              >/dev/null 2>&1; then
+          _mf_prior_payload="$(printf '%s\n' "$_mf_fallback_json" | jq -c '.' 2>/dev/null)" || _mf_prior_payload="$_prior_payload"
+        fi
+      fi
     fi
   fi
   if declare -p repo_review_platforms >/dev/null 2>&1 && [ "${#repo_review_platforms[@]}" -gt 0 ]; then
@@ -11036,7 +11059,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
   missed_finding_attribution_reports=""
   missed_findings_json='[]'
   # Invoke in the current shell so attribution reports survive (no $(...)).
-  reviewer_loop_missed_finding_records "$_prior_payload" "$_configured_platforms" "$_next_iteration" >/dev/null
+  reviewer_loop_missed_finding_records "$_mf_prior_payload" "$_configured_platforms" "$_next_iteration" >/dev/null
   _mf_count="$(printf '%s\n' "$missed_findings_json" | jq 'length' 2>/dev/null)" || _mf_count=0
   [[ "$_mf_count" =~ ^[0-9]+$ ]] || _mf_count=0
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -10227,7 +10227,7 @@ if [ -n "$_pr_base" ]; then
   if _PR_CONFIG_TMPFILE="$(mktemp 2>/dev/null)"; then
     # Refresh the remote-tracking ref so git show reads the current target
     # branch config, not a potentially stale cached ref (#777).
-    git fetch origin "$_pr_base" 2>/dev/null || true
+    git fetch origin "$_pr_base" 2>/dev/null || true  # workflow-shell-guard: allow SH001 - best-effort refresh of remote base ref for config read
     if ! git show "origin/${_pr_base}:.ai-dev-workflow.yaml" > "$_PR_CONFIG_TMPFILE" 2>/dev/null; then
       rm -f "$_PR_CONFIG_TMPFILE"
       _PR_CONFIG_TMPFILE=""

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1858,6 +1858,7 @@ run_codex_github_review() {
 
   if [ "$unresolved_count" -gt 0 ]; then
     reviewer_loop_print_reviewed_head_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login"
+    reviewer_loop_print_blocking_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login" || true
     print_kv RESULT needs_fixes
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
@@ -1930,6 +1931,9 @@ run_codex_github_review() {
         unresolved_count="$thread_check_output"
       fi
       [ "$unresolved_count" -eq 0 ] && unresolved_count=1
+
+      reviewer_loop_print_reviewed_head_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login"
+      reviewer_loop_print_blocking_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login" || true
 
       print_kv RESULT needs_fixes
       print_kv PLATFORM "$platform"
@@ -7884,14 +7888,14 @@ reviewer_loop_print_reviewed_head_from_json_lines() {
   printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
 }
 
-# Collect originalCommitOid values from bot threads that check_unresolved_threads
-# would count as unresolved in strict mode (not resolved, not outdated, not
-# self-marked "✅ Addressed"). Paginates like check_unresolved_threads.
-reviewer_loop_blocking_unresolved_thread_commit_oids() {
+# Collect strict-mode blocking bot threads as JSON [{path,line,body,commit},...].
+# Paginates like check_unresolved_threads. Exit 0 complete, 2 page cap, 3 GraphQL.
+_reviewer_loop_blocking_unresolved_bot_threads_json() {
   local pr_number="$1"
   local repo="$2"
   local graphql_bot_login="$3"
   local owner repo_name cursor has_next_page page max_pages result graphql_query nodes_fields
+  local records='[]' page_records
 
   owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
   repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
@@ -7901,7 +7905,7 @@ reviewer_loop_blocking_unresolved_thread_commit_oids() {
   page=0
   max_pages=10
 
-  nodes_fields='id isResolved isOutdated firstComment:comments(first:1){nodes{author{login}body originalCommit{oid}}}'
+  nodes_fields='id isResolved isOutdated path line firstComment:comments(first:1){nodes{author{login}body originalCommit{oid}}}'
   graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{'"$nodes_fields"'}}}}}'
 
   while [ "$has_next_page" = "true" ]; do
@@ -7927,20 +7931,80 @@ reviewer_loop_blocking_unresolved_thread_commit_oids() {
     has_next_page="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.hasNextPage')"
     cursor="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.endCursor // empty')"
 
-    printf '%s\n' "$result" | jq -r --arg bot "$graphql_bot_login" '
-      .reviewThreads.nodes[]
-      | select((.firstComment.nodes[0].author.login // "") == $bot)
-      | select(.isResolved != true)
-      | select((.isOutdated // false) != true)
-      | select((.firstComment.nodes[0].body // "") | contains("✅ Addressed") | not)
-      | .firstComment.nodes[0].originalCommit.oid // empty
-    '
+    page_records="$(printf '%s\n' "$result" | jq -c --arg bot "$graphql_bot_login" '
+      [.reviewThreads.nodes[]
+        | select((.firstComment.nodes[0].author.login // "") == $bot)
+        | select(.isResolved != true)
+        | select((.isOutdated // false) != true)
+        | select((.firstComment.nodes[0].body // "") | contains("✅ Addressed") | not)
+        | {
+            path: (.path // ""),
+            line: (.line // 0),
+            body: (.firstComment.nodes[0].body // ""),
+            commit: (.firstComment.nodes[0].originalCommit.oid // "")
+          }
+      ]')" || return 3
+    records="$(printf '%s\n%s\n' "$records" "$page_records" | jq -s 'add')"
 
     if [ "$has_next_page" = "true" ] && [ -z "$cursor" ]; then
       return 2
     fi
   done
 
+  printf '%s\n' "$records"
+  return 0
+}
+
+# Collect commit OIDs from strict-mode blocking bot threads.
+reviewer_loop_blocking_unresolved_thread_commit_oids() {
+  local pr_number="$1"
+  local repo="$2"
+  local graphql_bot_login="$3"
+  local json st
+
+  set +e
+  json="$(_reviewer_loop_blocking_unresolved_bot_threads_json \
+    "$pr_number" "$repo" "$graphql_bot_login" 2>/dev/null)"
+  st=$?
+  set -e
+  if [ "$st" -ne 0 ]; then
+    return "$st"
+  fi
+
+  printf '%s\n' "$json" | jq -r '.[].commit // empty'
+  return 0
+}
+
+# Emit BLOCKING_<n>_PATH/LINE/BODY from strict-mode blocking bot threads.
+reviewer_loop_print_blocking_from_unresolved_bot_threads() {
+  local pr_number="$1"
+  local repo="$2"
+  local graphql_bot_login="$3"
+  local json st idx=0 path line body title row
+
+  set +e
+  json="$(_reviewer_loop_blocking_unresolved_bot_threads_json \
+    "$pr_number" "$repo" "$graphql_bot_login" 2>/dev/null)"
+  st=$?
+  set -e
+  if [ "$st" -ne 0 ]; then
+    return "$st"
+  fi
+
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    idx=$((idx + 1))
+    path="$(printf '%s' "$row" | jq -r '.path // ""')"
+    line="$(printf '%s' "$row" | jq -r '.line // 0')"
+    body="$(printf '%s' "$row" | jq -r '.body // ""')"
+    title="$(printf '%s\n' "$body" | sed -n 's/^### //p;q')"
+    if [ -z "$title" ]; then
+      title="$(printf '%.120s' "$body")"
+    fi
+    print_kv "BLOCKING_${idx}_PATH" "${path:-unknown}"
+    print_kv "BLOCKING_${idx}_LINE" "$line"
+    print_kv "BLOCKING_${idx}_BODY" "$title"
+  done < <(printf '%s\n' "$json" | jq -c '.[]?')
   return 0
 }
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8028,6 +8028,68 @@ reviewer_loop_print_reviewed_head_from_unresolved_bot_threads() {
   printf '%s\n' "$commits" | reviewer_loop_print_reviewed_head_from_commits
 }
 
+# When post-clean settle finds late unresolved threads after an otherwise-clean
+# platform pass, synthesize platform_result_records + blocking outputs so
+# missed-finding telemetry can still run in _post_review_summary (AC-1/AC-10).
+reviewer_loop_append_late_thread_missed_findings() {
+  local pr_number="$1"
+  local repo="$2"
+  local platform_name bot_login graphql_bot_login count json head output_blob
+  local idx=0 row path line body title
+
+  for platform_name in "${platforms[@]:-}"; do
+    bot_login="$(bot_login_for_platform "$platform_name")"
+    graphql_bot_login="${bot_login%\[bot\]}"
+    [ -n "$graphql_bot_login" ] || continue
+
+    set +e
+    count="$(check_unresolved_threads "$pr_number" "$repo" strict "$graphql_bot_login")"
+    set -e
+    [ "${count:-0}" -gt 0 ] 2>/dev/null || continue
+
+    if ! declare -p platform_result_records >/dev/null 2>&1; then
+      declare -a platform_result_records=()
+    fi
+    platform_result_records+=("$(reviewer_loop_platform_result_record_json \
+      "$platform_name" needs_fixes late_review_threads)")
+
+    json="$(_reviewer_loop_blocking_unresolved_bot_threads_json \
+      "$pr_number" "$repo" "$graphql_bot_login" 2>/dev/null)" || continue
+
+    head="$(printf '%s\n' "$json" | jq -r '
+      [.[].commit // empty | select(length > 0)] | unique
+      | if length == 1 then .[0] else empty end' 2>/dev/null)" || head=""
+    if [ -n "$head" ]; then
+      if ! declare -p platform_reviewed_heads >/dev/null 2>&1; then
+        declare -a platform_reviewed_heads=()
+      fi
+      platform_reviewed_heads+=("${platform_name}:${head}")
+    fi
+
+    output_blob="RESULT=needs_fixes"$'\n'"BLOCKING_COUNT=${count}"$'\n'
+    idx=0
+    while IFS= read -r row; do
+      [ -n "$row" ] || continue
+      idx=$((idx + 1))
+      path="$(printf '%s' "$row" | jq -r '.path // ""')"
+      line="$(printf '%s' "$row" | jq -r '.line // 0')"
+      body="$(printf '%s' "$row" | jq -r '.body // ""')"
+      title="$(printf '%s\n' "$body" | sed -n 's/^### //p;q')"
+      if [ -z "$title" ]; then
+        title="$(printf '%.120s' "$(printf '%s\n' "$body" | tr '\n' ' ')")"
+      fi
+      output_blob="${output_blob}BLOCKING_${idx}_PATH=${path:-unknown}"$'\n'
+      output_blob="${output_blob}BLOCKING_${idx}_LINE=${line}"$'\n'
+      output_blob="${output_blob}BLOCKING_${idx}_BODY=${title}"$'\n'
+    done < <(printf '%s\n' "$json" | jq -c '.[]?' 2>/dev/null)
+
+    if ! declare -p platform_blocking_outputs >/dev/null 2>&1; then
+      declare -a platform_blocking_outputs=()
+    fi
+    platform_blocking_outputs+=("${platform_name}"$'\036'"${output_blob}")
+  done
+}
+
 # Build missed_findings JSON array for the current round.
 # Args:
 #   $1 history_payload (persisted entries; may be empty object with entries:[])
@@ -11490,6 +11552,7 @@ if [ "$aggregate_result" = "clean" ] \
       echo "INFO: post-clean settle — found $late_thread_count late unresolved thread(s) after ${settle_elapsed}s; switching to needs_fixes" >&2
       aggregate_result="needs_fixes"
       aggregate_reason="late_review_threads"
+      reviewer_loop_append_late_thread_missed_findings "$pr_number" "$settle_repo"
       if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 1 ]; then
         phase_after_clean_net_new_blocker=1
         phase_after_clean_blocking_platform="${phase_after_clean_blocking_platform:-late_review_threads}"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -10868,7 +10868,7 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
     _existing_comment_record="$(
       set -o pipefail
       gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
-        | reviewer_loop_history_select_summary_record
+        | reviewer_loop_history_select_latest_summary_record
     )" \
       || {
         echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment with unavailable history" >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5140,6 +5140,7 @@ coderabbit_thread_gate_clean() {
   done
 
   if [ "${out:-0}" -gt 0 ]; then
+    reviewer_loop_print_reviewed_head_from_unresolved_bot_threads "$pr_number" "$repo" "$graphql_bot_login"
     print_kv RESULT needs_fixes
     print_kv REASON coderabbit_unresolved_review_threads
     print_kv PLATFORM "$platform"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1602,7 +1602,7 @@ run_greptile_review() {
         | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
             .[]
             | select(.user.login == $bot and .created_at > $since)
-            | { path, line: (.line // .original_line // 0), body: (.body // "") }
+            | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
             | @json
           '
     )"
@@ -1615,7 +1615,7 @@ run_greptile_review() {
                 .submitted_at > $since and
                 .state == "CHANGES_REQUESTED"
               )
-            | { path: "", line: 0, body: (.body // "CHANGES_REQUESTED review without body") }
+            | { path: "", line: 0, body: (.body // "CHANGES_REQUESTED review without body"), commit_id: (.commit_id // .commitId // "") }
             | @json
           '
     )"
@@ -1659,6 +1659,7 @@ run_greptile_review() {
         print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
         index=$((index + 1))
       done < "$existing_blocking_file"
+      reviewer_loop_print_reviewed_head_from_json_lines < "$existing_blocking_file"
       rm -f "$existing_blocking_file"
       return 1
     fi
@@ -1709,7 +1710,8 @@ run_greptile_review() {
         | {
             path,
             line: (.line // .original_line // 0),
-            body: (.body // "")
+            body: (.body // ""),
+            commit_id: (.commit_id // "")
           }
         | @json
       '
@@ -1727,7 +1729,8 @@ run_greptile_review() {
         | {
             path: "",
             line: 0,
-            body: (.body // "CHANGES_REQUESTED review without body")
+            body: (.body // "CHANGES_REQUESTED review without body"),
+            commit_id: (.commit_id // .commitId // "")
         }
         | @json
       '
@@ -1772,6 +1775,7 @@ run_greptile_review() {
       print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
       index=$((index + 1))
     done < "$blocking_lines_file"
+    reviewer_loop_print_reviewed_head_from_json_lines < "$blocking_lines_file"
     rm -f "$blocking_lines_file"
     return 1
   fi
@@ -1786,6 +1790,11 @@ run_greptile_review() {
   print_kv COMMENT_COUNT "$comment_count"
   print_kv BLOCKING_COUNT 0
   print_kv SUGGESTION_COUNT "$suggestion_count"
+  # Clean path: unique commit_id across the comments/reviews just examined.
+  {
+    printf '%s\n' "$comments"
+    printf '%s\n' "$blocking_reviews"
+  } | reviewer_loop_print_reviewed_head_from_json_lines
   return 0
 }
 
@@ -1895,6 +1904,7 @@ run_codex_github_review() {
       print_kv COMMENT_COUNT 0
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 0
       ;;
     1)
@@ -1920,6 +1930,7 @@ run_codex_github_review() {
       print_kv COMMENT_COUNT "$unresolved_count"
       print_kv BLOCKING_COUNT "$unresolved_count"
       print_kv SUGGESTION_COUNT 0
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 1
       ;;
     3)
@@ -2185,6 +2196,7 @@ run_copilot_review() {
     case "$review_state" in
       APPROVED)
         print_kv RESULT clean
+      [ -n "${current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${current_sha:-$head_sha}"
         print_kv PLATFORM "$platform"
         print_kv PR_NUMBER "$pr_number"
         print_kv BRANCH "$branch_name"
@@ -2218,6 +2230,7 @@ run_copilot_review() {
         # one blocking finding when the verdict is CHANGES_REQUESTED.
         [ "$_copilot_comment_count" -eq 0 ] && _copilot_comment_count=1
         print_kv RESULT needs_fixes
+      [ -n "${current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${current_sha:-$head_sha}"
         print_kv PLATFORM "$platform"
         print_kv PR_NUMBER "$pr_number"
         print_kv BRANCH "$branch_name"
@@ -2231,6 +2244,7 @@ run_copilot_review() {
       COMMENTED)
         # Non-blocking comment only — treat as clean.
         print_kv RESULT clean
+      [ -n "${current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${current_sha:-$head_sha}"
         print_kv PLATFORM "$platform"
         print_kv PR_NUMBER "$pr_number"
         print_kv BRANCH "$branch_name"
@@ -2632,7 +2646,7 @@ run_bugbot_review() {
       | jq -r --arg bot "$bot_login" --arg since "$since_iso" --arg sha "$head_sha" '
           .[]
           | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .commit_id == $sha and .in_reply_to_id == null)
-          | { path, line: (.line // .original_line // 0), body: (.body // "") }
+          | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
           | @json
         ' 2>/dev/null
   )"
@@ -2776,6 +2790,7 @@ run_bugbot_review() {
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
+      [ -n "${_current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${_current_sha:-$head_sha}"
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -2959,7 +2974,7 @@ run_bugbot_review() {
 	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" --arg sha "$_current_sha" '
 	                  .[]
 	                  | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .commit_id == $sha and .in_reply_to_id == null)
-	                  | { path, line: (.line // .original_line // 0), body: (.body // "") }
+	                  | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
                   | @json
                 ' 2>/dev/null
           )"
@@ -2998,6 +3013,7 @@ run_bugbot_review() {
           if [ "$blocking_count" -gt 0 ]; then
             # Check run said success but cursor[bot] posted blocking comments.
             print_kv RESULT needs_fixes
+      [ -n "${_current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${_current_sha:-$head_sha}"
             print_kv PLATFORM "$platform"
             print_kv PR_NUMBER "$pr_number"
             print_kv BRANCH "$branch_name"
@@ -3025,6 +3041,7 @@ run_bugbot_review() {
 
           rm -f "$blocking_lines_file"
           print_kv RESULT clean
+      [ -n "${_current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${_current_sha:-$head_sha}"
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -3048,7 +3065,7 @@ run_bugbot_review() {
 	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" --arg sha "$_current_sha" '
 	                  .[]
 	                  | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .commit_id == $sha and .in_reply_to_id == null)
-	                  | { path, line: (.line // .original_line // 0), body: (.body // "") }
+	                  | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
                   | @json
                 ' 2>/dev/null
           )"
@@ -3157,6 +3174,7 @@ run_bugbot_review() {
           fi
 
           print_kv RESULT needs_fixes
+      [ -n "${_current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${_current_sha:-$head_sha}"
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -3197,6 +3215,7 @@ run_bugbot_review() {
 
           # Non-blocking informational outcome — clean, no real findings.
           print_kv RESULT clean
+      [ -n "${_current_sha:-${head_sha:-}}" ] && print_kv REVIEWED_HEAD "${_current_sha:-$head_sha}"
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -3396,6 +3415,7 @@ run_haystack_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 0
       ;;
     1)
@@ -3413,6 +3433,7 @@ run_haystack_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 1
       ;;
     2)
@@ -3426,6 +3447,7 @@ run_haystack_review() {
       print_kv PR_NUMBER "$pr_number"
       print_kv BRANCH "$branch_name"
       print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 2
       ;;
     *)
@@ -3445,6 +3467,7 @@ run_haystack_review() {
       print_kv COMMENT_COUNT 0
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 0
       ;;
   esac
@@ -3511,6 +3534,7 @@ run_coderabbit_cli_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 0
       ;;
     1)
@@ -3537,6 +3561,7 @@ run_coderabbit_cli_review() {
         print_kv "BLOCKING_${index}_LINE" "$(kv_value_default "BLOCKING_${index}_LINE" "$script_output" "")"
         print_kv "BLOCKING_${index}_BODY" "$(kv_value_default "BLOCKING_${index}_BODY" "$script_output" "")"
       done
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 1
       ;;
     2)
@@ -3554,6 +3579,7 @@ run_coderabbit_cli_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 2
       ;;
     *)
@@ -3571,6 +3597,7 @@ run_coderabbit_cli_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       return 0
       ;;
   esac
@@ -3831,7 +3858,7 @@ run_devin_review() {
       | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
           .[]
           | select(.user.login == $bot and .created_at > $since and .in_reply_to_id == null)
-          | { path, line: (.line // .original_line // 0), body: (.body // "") }
+          | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
           | @json
         '
   )"
@@ -3894,6 +3921,13 @@ run_devin_review() {
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
+    {
+      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+    } | reviewer_loop_print_reviewed_head_from_json_lines
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -3910,6 +3944,7 @@ run_devin_review() {
       print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
       index=$((index + 1))
     done < "$existing_blocking_file"
+    reviewer_loop_print_reviewed_head_from_json_lines < "$existing_blocking_file"
     rm -f "$existing_blocking_file"
     return 1
   fi
@@ -4040,7 +4075,7 @@ run_devin_review() {
                     ((.body // "") | test("No Issues Found"; "i") | not) and
                     (.id as $comment_id | ($resolved_ids | index($comment_id) | not))
                   )
-                | { path, line: (.line // .original_line // 0), body: (.body // "") }
+                | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
                 | @json
               '
         )"
@@ -4053,6 +4088,13 @@ run_devin_review() {
 
         if [ "$stale_count" -gt 0 ]; then
           print_kv RESULT needs_fixes
+    {
+      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+    } | reviewer_loop_print_reviewed_head_from_json_lines
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -4111,7 +4153,8 @@ run_devin_review() {
         | {
             path,
             line: (.line // .original_line // 0),
-            body: (.body // "")
+            body: (.body // ""),
+            commit_id: (.commit_id // "")
           }
         | @json
       '
@@ -4183,6 +4226,13 @@ run_devin_review() {
 
   if [ "$blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
+    {
+      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+    } | reviewer_loop_print_reviewed_head_from_json_lines
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -4204,6 +4254,13 @@ run_devin_review() {
 
   rm -f "$blocking_lines_file"
   print_kv RESULT clean
+    {
+      [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+      [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+      [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+      [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+      [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+    } | reviewer_loop_print_reviewed_head_from_json_lines
   print_kv PLATFORM "$platform"
   print_kv PR_NUMBER "$pr_number"
   print_kv BRANCH "$branch_name"
@@ -5841,7 +5898,7 @@ run_coderabbit_review() {
       | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
           .[]
           | select(.user.login == $bot and .created_at > $since and .in_reply_to_id == null)
-          | { path, line: (.line // .original_line // 0), body: (.body // "") }
+          | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
           | @json
         '
   )"
@@ -5854,7 +5911,7 @@ run_coderabbit_review() {
               .submitted_at > $since and
               .state == "CHANGES_REQUESTED"
             )
-          | { path: "", line: 0, body: (.body // "CHANGES_REQUESTED review without body") }
+          | { path: "", line: 0, body: (.body // "CHANGES_REQUESTED review without body"), commit_id: (.commit_id // .commitId // "") }
           | @json
         '
   )"
@@ -5882,6 +5939,13 @@ run_coderabbit_review() {
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
+      {
+        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+      } | reviewer_loop_print_reviewed_head_from_json_lines
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -6268,6 +6332,13 @@ run_coderabbit_review() {
           if [ "$cr_early_gate_rc" -eq 0 ]; then
             echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha before retry wait — treating PR as clean (coderabbit_status_success_fallback)" >&2
             print_kv RESULT clean
+      {
+        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+      } | reviewer_loop_print_reviewed_head_from_json_lines
             print_kv REASON coderabbit_status_success_fallback
             print_kv PLATFORM "$platform"
             print_kv PR_NUMBER "$pr_number"
@@ -6375,6 +6446,13 @@ run_coderabbit_review() {
           if [ "$cr_success_gate_rc" -eq 0 ]; then
             echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha — treating PR as clean (coderabbit_status_success_fallback)" >&2
             print_kv RESULT clean
+      {
+        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+      } | reviewer_loop_print_reviewed_head_from_json_lines
             print_kv REASON coderabbit_status_success_fallback
             print_kv PLATFORM "$platform"
             print_kv PR_NUMBER "$pr_number"
@@ -6421,7 +6499,7 @@ run_coderabbit_review() {
                     ((.body // "") | test("✅ Addressed") | not) and
                     (.id as $comment_id | ($resolved_ids | index($comment_id) | not))
                   )
-                | { path, line: (.line // .original_line // 0), body: (.body // "") }
+                | { path, line: (.line // .original_line // 0), body: (.body // ""), commit_id: (.commit_id // "") }
                 | @json
               '
         )"
@@ -6439,6 +6517,13 @@ run_coderabbit_review() {
 
         if [ "$stale_blocking_count" -gt 0 ]; then
           print_kv RESULT needs_fixes
+      {
+        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+      } | reviewer_loop_print_reviewed_head_from_json_lines
           print_kv PLATFORM "$platform"
           print_kv PR_NUMBER "$pr_number"
           print_kv BRANCH "$branch_name"
@@ -6616,7 +6701,8 @@ run_coderabbit_review() {
         | {
             path,
             line: (.line // .original_line // 0),
-            body: (.body // "")
+            body: (.body // ""),
+            commit_id: (.commit_id // "")
           }
         | @json
       '
@@ -6664,6 +6750,13 @@ run_coderabbit_review() {
 
   if [ "$blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
+      {
+        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+      } | reviewer_loop_print_reviewed_head_from_json_lines
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"
@@ -6692,6 +6785,13 @@ run_coderabbit_review() {
     return "$cr_phase3_gate_rc"
   fi
   print_kv RESULT clean
+      {
+        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
+        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
+        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
+        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
+        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
+      } | reviewer_loop_print_reviewed_head_from_json_lines
   print_kv PLATFORM "$platform"
   print_kv PR_NUMBER "$pr_number"
   print_kv BRANCH "$branch_name"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6707,7 +6707,8 @@ run_coderabbit_review() {
         | {
             path: "",
             line: 0,
-            body: (.body // "CHANGES_REQUESTED review without body")
+            body: (.body // "CHANGES_REQUESTED review without body"),
+            commit_id: (.commit_id // .commitId // "")
           }
         | @json
       '

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6824,13 +6824,7 @@ run_coderabbit_review() {
 
   if [ "$blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
-      {
-        [ -n "${comments:-}" ] && printf '%s\n' "$comments"
-        [ -n "${existing_comments:-}" ] && printf '%s\n' "$existing_comments"
-        [ -n "${blocking_reviews:-}" ] && printf '%s\n' "$blocking_reviews"
-        [ -n "${existing_reviews:-}" ] && printf '%s\n' "$existing_reviews"
-        [ -n "${reviews:-}" ] && printf '%s\n' "$reviews"
-      } | reviewer_loop_print_reviewed_head_from_json_lines
+    reviewer_loop_print_reviewed_head_from_json_lines < "$blocking_lines_file"
     print_kv PLATFORM "$platform"
     print_kv PR_NUMBER "$pr_number"
     print_kv BRANCH "$branch_name"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1939,8 +1939,9 @@ run_codex_github_review() {
 
       # Companion script REVIEWED_HEAD is artifact-derived on terminal safe-fail
       # paths with no unresolved threads; do not fall back when threads exist
-      # (multi-commit thread heads must stay unattributable per AC-11).
-      if [ "$actual_unresolved_count" -eq 0 ]; then
+      # (multi-commit thread heads must stay unattributable per AC-11) or when
+      # the thread audit could not be completed.
+      if [ "$thread_check_status" -eq 0 ] && [ "$actual_unresolved_count" -eq 0 ]; then
         local companion_reviewed_head
         companion_reviewed_head="$(kv_value_default REVIEWED_HEAD "$script_output" "")"
         [ -n "$companion_reviewed_head" ] && print_kv REVIEWED_HEAD "$companion_reviewed_head"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16932,6 +16932,34 @@ _1651_recs="$missed_findings_json"
 run_test "1651_s13d_no_record" "0" "$(printf '%s\n' "$_1651_recs" | jq 'length')"
 run_contains "1651_s13d_attribution_report" "could not be established" "$missed_finding_attribution_reports"
 
+# --- Scenario 13e: single commit_id emits head; two distinct commits do not ---
+_1651_head_out="$(printf '%s\n' "{\"commit_id\":\"$_1651_descendant\"}" \
+  | reviewer_loop_print_reviewed_head_from_json_lines | grep '^REVIEWED_HEAD=' | cut -d= -f2- || true)"
+run_test "1651_s13e_single_commit" "$_1651_descendant" "$_1651_head_out"
+_1651_head_count="$(printf '%s\n' \
+  "{\"commit_id\":\"$_1651_descendant\"}" \
+  "{\"commit_id\":\"$_1651_ancestor\"}" \
+  | reviewer_loop_print_reviewed_head_from_json_lines | grep -c '^REVIEWED_HEAD=' || true)"
+run_test "1651_s13e_two_commits_no_head" "0" "$_1651_head_count"
+
+# --- Scenario 13f: issue-comment-only / no-head adapters produce no record ---
+for _1651_plat in claude-code-action pr-agent; do
+  platform_result_records=(
+    "$(reviewer_loop_platform_result_record_json local-ai-reviewer clean "")"
+    "$(reviewer_loop_platform_result_record_json "$_1651_plat" needs_fixes "")"
+  )
+  platform_reviewed_heads=("local-ai-reviewer:${_1651_descendant}" "${_1651_plat}:")
+  platform_blocking_outputs=("${_1651_plat}"$'\036'"RESULT=needs_fixes"$'\n'"BLOCKING_COUNT=1"$'\n'"BLOCKING_1_PATH=a.ts"$'\n')
+  loop_head_sha="$_1651_descendant"
+  missed_finding_attribution_reports=""
+  missed_findings_json='[]'
+  reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1 >/dev/null
+  run_test "1651_s13f_${_1651_plat}_no_record" "0" \
+    "$(printf '%s\n' "$missed_findings_json" | jq 'length')"
+  run_contains "1651_s13f_${_1651_plat}_report" "could not be established" "$missed_finding_attribution_reports"
+done
+unset _1651_plat _1651_head_out _1651_head_count
+
 # --- Scenario 14: history entry fields ---
 pr_number=""
 current_run_id="1651-ledger"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16754,6 +16754,15 @@ _1651_long="$(printf 'local-ai-reviewer\n'; for _i in $(seq 1 499); do printf 'o
 run_test "1651_s2c_long_list" "not_yet_run" \
   "$(reviewer_loop_local_latest_verdict "$_1651_empty" "$_1651_long" | jq -r '.outcome')"
 
+# --- Scenario 2d: filtered invocation must not hide prior local verdict ---
+_1651_hist="$(jq -nc --arg h "$_1651_descendant" '
+  {schema:"reviewer_loop_history.v1", entries:[
+    {iteration:1, platform_results:[{platform:"local-ai-reviewer",result:"clean",raw_result:"clean",raw_reason:""}],
+     reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$h,state:"current",reason:""}]}
+  ]}')"
+run_test "1651_s2d_filtered_invocation_uses_history" "clean" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_hist" $'bugbot\ncodex-github\n' | jq -r '.outcome')"
+
 # --- Scenario 2a: skipped/not_configured while list contains reviewer → unavailable ---
 _1651_hist="$(jq -nc --arg h "$_1651_descendant" '
   {schema:"reviewer_loop_history.v1", entries:[

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16659,6 +16659,391 @@ unset unresolved_thread_count late_thread_count pr_number
 echo "=== Area 1650 complete ==="
 
 # ---------------------------------------------------------------------------
+# Area 1651: missed-finding telemetry
+# Scenarios 1–3, 6–16 (ancestry 4/5 live in test-reviewer-loop-commit-ancestry.sh)
+# ---------------------------------------------------------------------------
+echo "=== Area 1651: missed-finding telemetry ==="
+
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+# Fixed 40-hex SHAs — harness git is mocked and rejects real rev-parse.
+# Ancestry relationships are stubbed below for evidence-state cases; real
+# ancestry coverage lives in test-reviewer-loop-commit-ancestry.sh.
+_1651_descendant='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+_1651_ancestor='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+_1651_unrelated='cccccccccccccccccccccccccccccccccccccccc'
+
+# Stub ancestry so evidence-state tests do not depend on real git objects.
+_1651_real_ancestry="$(declare -f reviewer_loop_commit_ancestry)"
+reviewer_loop_commit_ancestry() {
+  local clean="${1:-}" reviewed="${2:-}"
+  [ -n "$clean" ] && [ -n "$reviewed" ] || { printf 'undecidable\n'; return 0; }
+  if [ "$clean" = "$reviewed" ]; then printf 'same\n'; return 0; fi
+  if [ "$clean" = "$_1651_ancestor" ] && [ "$reviewed" = "$_1651_descendant" ]; then
+    printf 'ancestor\n'; return 0
+  fi
+  if [ "$clean" = "$_1651_descendant" ] && [ "$reviewed" = "$_1651_ancestor" ]; then
+    printf 'descendant\n'; return 0
+  fi
+  if [ "$clean" = "$_1651_unrelated" ] || [ "$reviewed" = "$_1651_unrelated" ]; then
+    printf 'unrelated\n'; return 0
+  fi
+  printf 'undecidable\n'
+}
+
+_1651_cfg=$'local-ai-reviewer\ncodex-github\nbugbot\n'
+
+# --- Scenario 1 / AC-4a: most recent verdict, not most recent clean ---
+_1651_hist="$(jq -nc --arg a "$_1651_ancestor" --arg d "$_1651_descendant" '
+  {schema:"reviewer_loop_history.v1", entries:[
+    {iteration:2, platform_results:[{platform:"local-ai-reviewer",result:"clean",raw_result:"clean",raw_reason:""}],
+     reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$a,state:"current",reason:""}]},
+    {iteration:5, platform_results:[{platform:"local-ai-reviewer",result:"needs_fixes",raw_result:"needs_fixes",raw_reason:""}],
+     reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$d,state:"current",reason:""}]}
+  ]}')"
+_1651_v="$(reviewer_loop_local_latest_verdict "$_1651_hist" "$_1651_cfg")"
+run_test "1651_s1_recency_over_clean" "needs_fixes" \
+  "$(printf '%s\n' "$_1651_v" | jq -r '.outcome')"
+run_test "1651_s1_iteration_5" "5" \
+  "$(printf '%s\n' "$_1651_v" | jq -r '.iteration')"
+
+# --- Scenario 1a: current round wins (synthetic composition) ---
+platform_result_records=(
+  "$(reviewer_loop_platform_result_record_json local-ai-reviewer clean "")"
+  "$(reviewer_loop_platform_result_record_json codex-github needs_fixes "")"
+)
+platform_reviewed_heads=(
+  "local-ai-reviewer:${_1651_descendant}"
+  "codex-github:${_1651_descendant}"
+)
+platform_blocking_outputs=(
+  $'codex-github\036RESULT=needs_fixes\nBLOCKING_COUNT=2\nBLOCKING_1_PATH=a.ts\nBLOCKING_2_PATH=b.ts\n'
+)
+loop_head_sha="$_1651_descendant"
+# Prior history says needs_fixes; current round local is clean — AC-1 same-round case
+_1651_prior="$(jq -nc --arg h "$_1651_ancestor" '
+  {schema:"reviewer_loop_history.v1", entries:[
+    {iteration:1, platform_results:[{platform:"local-ai-reviewer",result:"needs_fixes",raw_result:"needs_fixes",raw_reason:""}],
+     reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$h,state:"current",reason:""}]}
+  ]}')"
+missed_finding_attribution_reports=""
+_1651_recs="$(reviewer_loop_missed_finding_records "$_1651_prior" "$_1651_cfg" 2)"
+run_test "1651_s1a_confirmed_miss" "confirmed_miss" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].classification')"
+run_test "1651_s1a_same_commit_state" "clean_same_commit" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].local_evidence_state')"
+
+# --- Scenario 1b: no prior entry — current round still used ---
+_1651_recs="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+run_test "1651_s1b_no_prior_confirmed" "confirmed_miss" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].classification')"
+
+# --- Scenario 2 / 2b: not_yet_run vs not_configured; whole-line membership ---
+_1651_empty='{"schema":"reviewer_loop_history.v1","entries":[]}'
+run_test "1651_s2_not_yet_run" "not_yet_run" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_empty" "$_1651_cfg" | jq -r '.outcome')"
+run_test "1651_s2_not_configured" "not_configured" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_empty" $'bugbot\ncodex-github\n' | jq -r '.outcome')"
+run_test "1651_s2b_substring_rejected" "not_configured" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_empty" $'local-ai-reviewer-v2\n' | jq -r '.outcome')"
+run_test "1651_s2b_sole_entry" "not_yet_run" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_empty" $'local-ai-reviewer\n' | jq -r '.outcome')"
+
+# --- Scenario 2c: long configured list with early match (here-string, not pipe) ---
+_1651_long="$(printf 'local-ai-reviewer\n'; for _i in $(seq 1 499); do printf 'other-%s\n' "$_i"; done)"
+run_test "1651_s2c_long_list" "not_yet_run" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_empty" "$_1651_long" | jq -r '.outcome')"
+
+# --- Scenario 2a: skipped/not_configured while list contains reviewer → unavailable ---
+_1651_hist="$(jq -nc --arg h "$_1651_descendant" '
+  {schema:"reviewer_loop_history.v1", entries:[
+    {iteration:1, platform_results:[{platform:"local-ai-reviewer",result:"not_configured",raw_result:"skipped",raw_reason:"not_configured"}],
+     reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$h,state:"current",reason:""}]}
+  ]}')"
+run_test "1651_s2a_list_wins" "unavailable" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_hist" "$_1651_cfg" | jq -r '.outcome')"
+
+# --- Scenario 3 / 3a: entries exist but no platform_results → unknown ---
+_1651_hist="$(jq -nc '{schema:"reviewer_loop_history.v1", entries:[{iteration:1, platforms:["local-ai-reviewer"], result:"clean"}]}')"
+run_test "1651_s3_no_platform_results" "unknown" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_hist" "$_1651_cfg" | jq -r '.outcome')"
+run_test "1651_s3a_ignore_aggregate_clean" "unknown" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_hist" "$_1651_cfg" | jq -r '.outcome')"
+
+# --- Scenario 3b: local platform_results, not aggregate ---
+_1651_hist="$(jq -nc --arg h "$_1651_descendant" '
+  {schema:"reviewer_loop_history.v1", entries:[
+    {iteration:1, result:"needs_fixes",
+     platform_results:[
+       {platform:"local-ai-reviewer",result:"clean",raw_result:"clean",raw_reason:""},
+       {platform:"codex-github",result:"needs_fixes",raw_result:"needs_fixes",raw_reason:""}
+     ],
+     reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$h,state:"current",reason:""}]}
+  ]}')"
+run_test "1651_s3b_local_not_aggregate" "clean" \
+  "$(reviewer_loop_local_latest_verdict "$_1651_hist" "$_1651_cfg" | jq -r '.outcome')"
+
+# --- Scenario 6: evidence-state mapping (normalized outcomes) ---
+_1651_verdict() { jq -nc --arg o "$1" --arg h "$2" '{outcome:$o, head_sha:$h, iteration:1}'; }
+run_test "1651_s6_same" "clean_same_commit" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict clean "$_1651_descendant")" "$_1651_descendant")"
+run_test "1651_s6_earlier" "clean_earlier_commit" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict clean "$_1651_ancestor")" "$_1651_descendant")"
+run_test "1651_s6_later" "clean_later_commit" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict clean "$_1651_descendant")" "$_1651_ancestor")"
+run_test "1651_s6_unrelated" "clean_unrelated_commit" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict clean "$_1651_unrelated")" "$_1651_descendant")"
+run_test "1651_s6_not_clean" "not_clean" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict needs_fixes "$_1651_descendant")" "$_1651_descendant")"
+run_test "1651_s6_skipped" "skipped" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict skipped "")" "$_1651_descendant")"
+run_test "1651_s6_unavailable" "unavailable" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict unavailable "")" "$_1651_descendant")"
+run_test "1651_s6_not_yet_run" "not_yet_run" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict not_yet_run "")" "$_1651_descendant")"
+run_test "1651_s6_not_configured" "not_configured" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict not_configured "")" "$_1651_descendant")"
+run_test "1651_s6_unknown_outcome" "unknown" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict weird "")" "$_1651_descendant")"
+run_test "1651_s6a_empty_local_head" "unknown" \
+  "$(reviewer_loop_local_evidence_state "$(_1651_verdict clean "")" "$_1651_descendant")"
+
+# --- Scenario 6b: normalization table ---
+run_test "1651_s6b_clean" "clean" "$(reviewer_loop_normalize_platform_outcome clean "")"
+run_test "1651_s6b_needs_fixes" "needs_fixes" "$(reviewer_loop_normalize_platform_outcome needs_fixes "")"
+run_test "1651_s6b_skipped_unavail" "unavailable" "$(reviewer_loop_normalize_platform_outcome skipped unavailable)"
+run_test "1651_s6b_skipped_not_cfg" "not_configured" "$(reviewer_loop_normalize_platform_outcome skipped not_configured)"
+run_test "1651_s6b_skipped_other" "skipped" "$(reviewer_loop_normalize_platform_outcome skipped deliberate)"
+run_test "1651_s6b_escalate" "unavailable" "$(reviewer_loop_normalize_platform_outcome escalate timeout)"
+run_test "1651_s6b_unknown" "unknown" "$(reviewer_loop_normalize_platform_outcome weird "")"
+_1651_rec="$(reviewer_loop_platform_result_record_json codex-github skipped unavailable)"
+run_test "1651_s6b_raw_retained" "skipped" "$(printf '%s\n' "$_1651_rec" | jq -r '.raw_result')"
+run_test "1651_s6b_raw_reason" "unavailable" "$(printf '%s\n' "$_1651_rec" | jq -r '.raw_reason')"
+run_test "1651_s6b_no_head_field" "false" "$(printf '%s\n' "$_1651_rec" | jq -r 'has("reviewed_head") or has("head")')"
+
+# --- Scenario 7: local reviewer findings produce no record ---
+platform_result_records=("$(reviewer_loop_platform_result_record_json local-ai-reviewer needs_fixes "")")
+platform_reviewed_heads=("local-ai-reviewer:${_1651_descendant}")
+platform_blocking_outputs=($'local-ai-reviewer\036RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=x.ts\n')
+_1651_recs="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+run_test "1651_s7_local_excluded" "0" "$(printf '%s\n' "$_1651_recs" | jq 'length')"
+
+# --- Scenario 8: advisory-only (non needs_fixes) produces no record ---
+platform_result_records=("$(reviewer_loop_platform_result_record_json codex-github clean "")")
+platform_reviewed_heads=("codex-github:${_1651_descendant}")
+platform_blocking_outputs=()
+_1651_recs="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+run_test "1651_s8_advisory_excluded" "0" "$(printf '%s\n' "$_1651_recs" | jq 'length')"
+
+# --- Scenario 9: not_clean still produces a denominator record ---
+platform_result_records=(
+  "$(reviewer_loop_platform_result_record_json local-ai-reviewer needs_fixes "")"
+  "$(reviewer_loop_platform_result_record_json codex-github needs_fixes "")"
+)
+platform_reviewed_heads=(
+  "local-ai-reviewer:${_1651_descendant}"
+  "codex-github:${_1651_descendant}"
+)
+platform_blocking_outputs=($'codex-github\036RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=a.ts\n')
+_1651_recs="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+run_test "1651_s9_denominator_not_clean" "not_a_miss" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].classification')"
+run_test "1651_s9_state_not_clean" "not_clean" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].local_evidence_state')"
+
+# --- Scenario 10: two rounds accumulate (builder called twice independently) ---
+platform_result_records=(
+  "$(reviewer_loop_platform_result_record_json local-ai-reviewer clean "")"
+  "$(reviewer_loop_platform_result_record_json codex-github needs_fixes "")"
+)
+platform_reviewed_heads=("local-ai-reviewer:${_1651_descendant}" "codex-github:${_1651_descendant}")
+platform_blocking_outputs=($'codex-github\036RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=a.ts\n')
+_1651_r1="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+_1651_r2="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 2)"
+run_test "1651_s10_two_records" "2" \
+  "$(jq -nc --argjson a "$_1651_r1" --argjson b "$_1651_r2" '$a + $b | length')"
+
+# --- Scenario 13a / 13a-i: path dedupe + full path list in record ---
+platform_result_records=(
+  "$(reviewer_loop_platform_result_record_json local-ai-reviewer clean "")"
+  "$(reviewer_loop_platform_result_record_json codex-github needs_fixes "")"
+)
+platform_reviewed_heads=("local-ai-reviewer:${_1651_descendant}" "codex-github:${_1651_descendant}")
+_1651_out=$'codex-github\036RESULT=needs_fixes\nBLOCKING_COUNT=8\n'
+for _i in 1 2 3 4 5 6 7 8; do
+  case "$_i" in
+    1|2|3) _p=a.ts ;;
+    4|5) _p=b.ts ;;
+    *) _p=c.ts ;;
+  esac
+  _1651_out="${_1651_out}BLOCKING_${_i}_PATH=${_p}"$'\n'
+done
+platform_blocking_outputs=("$_1651_out")
+_1651_recs="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+run_test "1651_s13a_path_total_deduped" "3" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].path_total')"
+run_test "1651_s13a_distinct_paths" "3" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[0].paths | unique | length')"
+
+# twelve-file record for 13a-i
+_1651_paths="$(jq -nc '[range(1;13) | "file-\(.).ts"]')"
+_1651_rec="$(jq -nc --arg h "$_1651_descendant" --argjson paths "$_1651_paths" '
+  {reviewer:"codex-github", reviewed_head:$h, blocking_count:12, paths:$paths, path_total:12,
+   local_evidence_state:"clean_same_commit", classification:"confirmed_miss"}')"
+run_test "1651_s13ai_record_holds_all" "12" \
+  "$(printf '%s\n' "$_1651_rec" | jq -r '.paths | length')"
+_1651_line="$(reviewer_loop_missed_finding_summary_line "$_1651_rec")"
+run_test "1651_s13_line_le_200" "1" "$([ "${#_1651_line}" -le 200 ] && echo 1 || echo 0)"
+run_contains "1651_s13c_iii_enum" "[confirmed_miss]" "$_1651_line"
+run_contains "1651_s13c_iii_label" "Clean, same commit" "$_1651_line"
+run_contains "1651_s13c_remainder" "+9 more" "$_1651_line"
+
+# zero-path long paths (budget derived)
+_1651_longpath="$(printf 'p%.0s' {1..90})"
+_1651_rec="$(jq -nc --arg h "$_1651_descendant" --arg p "$_1651_longpath" '
+  {reviewer:"codex-github", reviewed_head:$h, blocking_count:7, paths:[$p,$p,$p], path_total:12,
+   local_evidence_state:"clean_same_commit", classification:"confirmed_miss"}')"
+_1651_line="$(reviewer_loop_missed_finding_summary_line "$_1651_rec")"
+run_test "1651_s13_zero_path_le_200" "1" "$([ "${#_1651_line}" -le 200 ] && echo 1 || echo 0)"
+run_contains "1651_s13_zero_path_remainder" "+12 more" "$_1651_line"
+
+# --- Scenario 13c-ii: worst realistic line ---
+_1651_rec="$(jq -nc --arg h "$_1651_descendant" '
+  {reviewer:"claude-code-action", reviewed_head:$h, blocking_count:9999999, path_total:9999999,
+   paths:["short.ts","mid.ts","ok.ts"], local_evidence_state:"clean_earlier_commit",
+   classification:"possible_miss"}')"
+_1651_line="$(reviewer_loop_missed_finding_summary_line "$_1651_rec")"
+run_test "1651_s13cii_le_200" "1" "$([ "${#_1651_line}" -le 200 ] && echo 1 || echo 0)"
+run_contains "1651_s13cii_exact_counts" "9999999 blocking, 9999999 files" "$_1651_line"
+run_contains "1651_s13cii_possible" "[possible_miss]" "$_1651_line"
+
+# --- Scenario 13d: no REVIEWED_HEAD → no record even with loop_head_sha ---
+platform_result_records=(
+  "$(reviewer_loop_platform_result_record_json local-ai-reviewer clean "")"
+  "$(reviewer_loop_platform_result_record_json codex-github needs_fixes "")"
+)
+platform_reviewed_heads=("local-ai-reviewer:${_1651_descendant}" "codex-github:")
+platform_blocking_outputs=($'codex-github\036RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=a.ts\n')
+loop_head_sha="$_1651_descendant"
+missed_finding_attribution_reports=""
+missed_findings_json='[]'
+reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1 >/dev/null
+_1651_recs="$missed_findings_json"
+run_test "1651_s13d_no_record" "0" "$(printf '%s\n' "$_1651_recs" | jq 'length')"
+run_contains "1651_s13d_attribution_report" "could not be established" "$missed_finding_attribution_reports"
+
+# --- Scenario 14: history entry fields ---
+pr_number=""
+current_run_id="1651-ledger"
+unresolved_thread_count=0
+late_thread_count=0
+expensive_gate_last_result=""
+strict_spec_recorded=0
+platform_reviewed_heads=("local-ai-reviewer:${_1651_descendant}")
+platform_results_json="$(jq -nc '[{platform:"local-ai-reviewer",result:"clean",raw_result:"clean",raw_reason:""}]')"
+missed_findings_json='[]'
+loop_head_sha="$_1651_descendant"
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+for _field in iteration recorded_at head_sha classification_head reviewed_heads run_id result reason platforms \
+  blocking_count suggestion_count unresolved_thread_count late_threads_found phase_after_clean \
+  small_findings_only small_findings_stop small_findings_rounds small_findings_required_rounds \
+  small_findings_paths platform_results missed_findings; do
+  run_test "1651_s14_has_${_field}" "true" \
+    "$(printf '%s\n' "$_entry" | jq -r --arg f "$_field" 'has($f)')"
+done
+run_test "1651_s14a_no_head_in_platform_results" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.platform_results[0] | has("reviewed_head") or has("head")')"
+
+# --- Scenario 15: twenty records ≤ 4000 chars / 20 lines ---
+_1651_lines=""
+_1651_total=0
+for _i in $(seq 1 20); do
+  _1651_rec="$(jq -nc --arg h "$_1651_descendant" --arg r "codex-github" '
+    {reviewer:$r, reviewed_head:$h, blocking_count:99, path_total:12,
+     paths:["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ts",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ts",
+            "cccccccccccccccccccccccccccccccccccccccccccccccccc.ts"],
+     local_evidence_state:"clean_same_commit", classification:"confirmed_miss"}')"
+  _1651_line="$(reviewer_loop_missed_finding_summary_line "$_1651_rec")"
+  _1651_lines="${_1651_lines}${_1651_line}"$'\n'
+  _1651_total=$((_1651_total + ${#_1651_line}))
+done
+run_test "1651_s15_line_count" "20" "$(printf '%s' "$_1651_lines" | grep -c .)"
+run_test "1651_s15_char_budget" "1" "$([ "$_1651_total" -le 4000 ] && echo 1 || echo 0)"
+
+# --- Scenario 16 / 16a: classification enum ---
+run_test "1651_s16a_confirmed" "confirmed_miss" "$(reviewer_loop_missed_finding_classification clean_same_commit)"
+run_test "1651_s16a_possible" "possible_miss" "$(reviewer_loop_missed_finding_classification clean_earlier_commit)"
+for _st in clean_later_commit clean_unrelated_commit not_clean skipped unavailable not_yet_run not_configured unknown; do
+  run_test "1651_s16a_${_st}" "not_a_miss" "$(reviewer_loop_missed_finding_classification "$_st")"
+done
+
+# --- Scenario 16b: two platforms, different heads ---
+platform_result_records=(
+  "$(reviewer_loop_platform_result_record_json local-ai-reviewer clean "")"
+  "$(reviewer_loop_platform_result_record_json codex-github needs_fixes "")"
+  "$(reviewer_loop_platform_result_record_json bugbot needs_fixes "")"
+)
+platform_reviewed_heads=(
+  "local-ai-reviewer:${_1651_descendant}"
+  "codex-github:${_1651_descendant}"
+  "bugbot:${_1651_ancestor}"
+)
+platform_blocking_outputs=(
+  $'codex-github\036RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=a.ts\n'
+  $'bugbot\036RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=b.ts\n'
+)
+_1651_recs="$(reviewer_loop_missed_finding_records '{"schema":"reviewer_loop_history.v1","entries":[]}' "$_1651_cfg" 1)"
+run_test "1651_s16b_two_records" "2" "$(printf '%s\n' "$_1651_recs" | jq 'length')"
+run_test "1651_s16b_codex_head" "$_1651_descendant" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[] | select(.reviewer=="codex-github") | .reviewed_head')"
+run_test "1651_s16b_bugbot_head" "$_1651_ancestor" \
+  "$(printf '%s\n' "$_1651_recs" | jq -r '.[] | select(.reviewer=="bugbot") | .reviewed_head')"
+
+# --- Scenario 11: unappendable history preserves prior block ---
+_1651_prior_body="$(printf '%s\n' "<!-- reviewer-loop-history:v1 -->" '```json' '{"schema":"reviewer_loop_history.v1","history_status":"available","entries":[{"iteration":1,"result":"clean"}]}' '```')"
+# wrap as details for extract
+_1651_prior_full="$(printf '<details>\n<summary>Reviewer-loop history</summary>\n\n%s\n</details>\n' "$_1651_prior_body")"
+# Force malformed so append_safe=0 but marker present
+_1651_malformed="$(printf '%s\n' "### Automated Reviewer Loop Summary" "" "<details>" "<summary>x</summary>" "<!-- reviewer-loop-history:v1 -->" '```json' '{not-json' '```' "</details>")"
+reviewer_loop_history_last_append_safe=1
+# Invoke in the current shell so append_safe globals survive, then capture stdout.
+_1651_out_file="$(mktemp)"
+reviewer_loop_history_append_to_summary "### Automated Reviewer Loop Summary"$'\n'"body" "$_1651_malformed" clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "" >"$_1651_out_file"
+_1651_out="$(cat "$_1651_out_file")"
+rm -f "$_1651_out_file"
+run_test "1651_s11_append_safe_0" "0" "${reviewer_loop_history_last_append_safe}"
+run_contains "1651_s11_preserves_malformed" '{not-json' "$_1651_out"
+# Ensure stub with entries:[] is NOT written over it
+if printf '%s\n' "$_1651_out" | grep -Fq '"entries": []'; then
+  run_contains "1651_s11_malformed_still_present" '{not-json' "$_1651_out"
+else
+  run_test "1651_s11_no_empty_stub" "1" "1"
+fi
+
+# missing_history_json reason vocabulary
+_1651_missing_marker="$(printf '%s\n' "### Automated Reviewer Loop Summary" "<!-- reviewer-loop-history:v1 -->" "no json block")"
+reviewer_loop_history_payload_from_existing "$_1651_missing_marker" clean "" "x" 0 0 >/dev/null
+run_test "1651_s11a_missing_json_reason" "missing_history_json" \
+  "${reviewer_loop_history_last_unavailable_reason}"
+
+unset platform_result_records platform_reviewed_heads platform_blocking_outputs
+unset platform_results_json missed_findings_json loop_head_sha
+unset missed_finding_attribution_reports
+unset _1651_ancestor _1651_descendant _1651_unrelated _1651_cfg
+unset _1651_hist _1651_v _1651_recs _1651_rec _1651_line _1651_prior _1651_empty
+unset _1651_long _1651_out _1651_paths _1651_r1 _1651_r2
+unset _1651_lines _1651_total _1651_prior_body _1651_prior_full _1651_malformed
+unset _1651_missing_marker _entry _field _st _i _p
+unset -f _1651_verdict 2>/dev/null || true
+eval "$_1651_real_ancestry"
+unset _1651_real_ancestry
+unset pr_number current_run_id unresolved_thread_count late_thread_count
+unset expensive_gate_last_result strict_spec_recorded
+
+echo "=== Area 1651 complete ==="
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-reviewer-loop-commit-ancestry.sh
+++ b/scripts/development-workflow/tests/test-reviewer-loop-commit-ancestry.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# test-reviewer-loop-commit-ancestry.sh — scenarios 4, 5, 5a, 5b for #1651.
+# covers: scripts/development-workflow/pr-review-loop.sh
+# covers: docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+#
+# shellcheck shell=bash disable=SC2034
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name — expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+export MOCK_REPO_ROOT="$REPO_ROOT"
+# shellcheck source=scripts/development-workflow/pr-review-loop.sh
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+echo "=== test-reviewer-loop-commit-ancestry (#1651 scenarios 4/5) ==="
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# Purpose-built fixture: root commit, two divergent branches of two commits each,
+# plus one commit created then pruned for the absent-object case.
+git -C "$FIXTURE" init -q
+git -C "$FIXTURE" config user.email "test@example.com"
+git -C "$FIXTURE" config user.name "Test"
+echo root > "$FIXTURE/root.txt"
+git -C "$FIXTURE" add root.txt
+git -C "$FIXTURE" commit -qm root
+ROOT="$(git -C "$FIXTURE" rev-parse HEAD)"
+
+git -C "$FIXTURE" checkout -qb branch-a
+echo a1 > "$FIXTURE/a.txt"
+git -C "$FIXTURE" add a.txt
+git -C "$FIXTURE" commit -qm a1
+A1="$(git -C "$FIXTURE" rev-parse HEAD)"
+echo a2 >> "$FIXTURE/a.txt"
+git -C "$FIXTURE" add a.txt
+git -C "$FIXTURE" commit -qm a2
+A2="$(git -C "$FIXTURE" rev-parse HEAD)"
+
+git -C "$FIXTURE" checkout -qb branch-b "$ROOT"
+echo b1 > "$FIXTURE/b.txt"
+git -C "$FIXTURE" add b.txt
+git -C "$FIXTURE" commit -qm b1
+B1="$(git -C "$FIXTURE" rev-parse HEAD)"
+echo b2 >> "$FIXTURE/b.txt"
+git -C "$FIXTURE" add b.txt
+git -C "$FIXTURE" commit -qm b2
+B2="$(git -C "$FIXTURE" rev-parse HEAD)"
+
+# Deleted object for absent-commit case
+git -C "$FIXTURE" checkout -qb doomed "$ROOT"
+echo doomed > "$FIXTURE/doomed.txt"
+git -C "$FIXTURE" add doomed.txt
+git -C "$FIXTURE" commit -qm doomed
+DOOMED="$(git -C "$FIXTURE" rev-parse HEAD)"
+git -C "$FIXTURE" checkout -q branch-a
+git -C "$FIXTURE" branch -D doomed >/dev/null
+git -C "$FIXTURE" reflog expire --expire=now --all
+git -C "$FIXTURE" prune --expire now
+
+# Run ancestry checks inside the fixture repo
+pushd "$FIXTURE" >/dev/null
+
+# Scenario 4
+run_test "1651_ancestry_same" "same" "$(reviewer_loop_commit_ancestry "$A2" "$A2")"
+run_test "1651_ancestry_ancestor" "ancestor" "$(reviewer_loop_commit_ancestry "$A1" "$A2")"
+run_test "1651_ancestry_descendant" "descendant" "$(reviewer_loop_commit_ancestry "$A2" "$A1")"
+run_test "1651_ancestry_unrelated" "unrelated" "$(reviewer_loop_commit_ancestry "$A2" "$B2")"
+
+# Scenario 5 — absent commit
+run_test "1651_ancestry_absent" "undecidable" "$(reviewer_loop_commit_ancestry "$DOOMED" "$A2")"
+
+# Scenario 5 — empty argument
+run_test "1651_ancestry_empty" "undecidable" "$(reviewer_loop_commit_ancestry "" "$A2")"
+run_test "1651_ancestry_empty_both" "undecidable" "$(reviewer_loop_commit_ancestry "" "")"
+
+# Scenario 5b — two identical missing SHAs are undecidable, not same
+MISSING="ffffffffffffffffffffffffffffffffffffffff"
+run_test "1651_ancestry_identical_missing" "undecidable" \
+  "$(reviewer_loop_commit_ancestry "$MISSING" "$MISSING")"
+
+# Scenario 5 — git stub exit 128 for merge-base --is-ancestor
+REAL_GIT="$(command -v git)"
+STUB_BIN="$(mktemp -d)"
+cat > "$STUB_BIN/git" <<STUB
+#!/usr/bin/env bash
+if [ "\${1:-}" = "merge-base" ] && [ "\${2:-}" = "--is-ancestor" ]; then
+  exit 128
+fi
+exec "$REAL_GIT" "\$@"
+STUB
+chmod +x "$STUB_BIN/git"
+PATH="$STUB_BIN:$PATH"
+run_test "1651_ancestry_merge_base_error" "undecidable" \
+  "$(reviewer_loop_commit_ancestry "$A1" "$A2")"
+PATH="${PATH#"$STUB_BIN:"}"
+rm -rf "$STUB_BIN"
+
+# Scenario 5a — under set -euo pipefail, status 1 paths do not abort
+set -euo pipefail
+_ok=1
+reviewer_loop_commit_ancestry "$A1" "$A2" >/dev/null || _ok=0
+reviewer_loop_commit_ancestry "$A2" "$A1" >/dev/null || _ok=0
+reviewer_loop_commit_ancestry "$A2" "$B2" >/dev/null || _ok=0
+reviewer_loop_commit_ancestry "$A2" "$A2" >/dev/null || _ok=0
+reviewer_loop_commit_ancestry "" "" >/dev/null || _ok=0
+run_test "1651_ancestry_errexit_safe" "1" "$_ok"
+
+popd >/dev/null
+
+echo ""
+echo "Tests: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds missed-finding telemetry to the reviewer loop: when an external reviewer reports blocking findings, the loop records reviewer, reviewed commit, blocking count, paths, local evidence state, and classification (`confirmed_miss`, `possible_miss`, `not_a_miss`).
- Persists per-platform outcomes as `platform_results` and joins `#1648` `reviewed_heads[]` for commit attribution; extends external adapters (and haystack/coderabbit-cli companions) to emit `REVIEWED_HEAD` fail-closed.
- Preserves unappendable reviewer-loop history byte-for-byte (AC-7a) and renders compact summary lines (≤200 chars each).

## Cross-Cutting Operational Assumption Check (implementation start)

Re-verified at implementation start (2026-08-31, branch head pending push):

| Assumption | Result |
| --- | --- |
| Approved base branch `develop-internal-reviewer-effectiveness` | **Still valid** — PR targets that integration branch |
| Per-reviewer head evidence from #1648 | **Still valid** — merged on integration branch via PR #1684 |
| Additive-only `reviewer_loop_history.v1` (no schema bump) | **Still valid** — new fields only; schema constant unchanged |

## Spec / plan

- Spec: `docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md`
- Plan: `docs/specs/developments/20260828014500_1651-missed-findings-telemetry/2_1651-missed-findings-telemetry_implementation-plan.md`

## Planted-violation proofs (P1–P30)

Each proof is mapped to automated harness scenarios in `test-pr-review-loop.sh` Area 1651 and `test-reviewer-loop-commit-ancestry.sh` per the implementation plan. The harness encodes the fail/pass oracle for each planted violation (recency-first selection, denominator recording, five-way ancestry, eligibility-before-writability, blocking-only REVIEWED_HEAD, reserved summary budget, complete path storage, per-platform head join, etc.).

| Proof group | Harness coverage |
| --- | --- |
| P1, P4, P8, P10, P14, P16, P21 | Scenarios 1, 1a, 1b, 3, 3a, 6a |
| P2, P9 | Scenarios 7–9 |
| P3, P5, P28 | `test-reviewer-loop-commit-ancestry.sh` (incl. deleted object, git stub, identical missing) |
| P5–P7, P11–P13, P15–P30 | Area 1651 scenarios 11–16b, 13a-i, 13c-* |

Commands run:
- `bash scripts/development-workflow/tests/test-reviewer-loop-commit-ancestry.sh` → 10 passed
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area missed` → 95 passed

## Test plan

- [x] `bash scripts/development-workflow/tests/test-reviewer-loop-commit-ancestry.sh` (10 passed)
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area missed` (95 passed)
- [ ] Smoke runbook: `docs/testing/workflow/1651-missed-findings-telemetry.smoke-test.md`

## Tracker

Closes #1651 (child of epic #1647)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, fail-closed changes to `pr-review-loop.sh` orchestration and history/summary posting; outcomes are meant to stay observational, but regressions could affect attribution, summary comments, or history append behavior.
> 
> **Overview**
> Adds **observational missed-finding telemetry** to the automated reviewer loop: when an **external** reviewer reports **blocking** findings on an attributable commit, the round’s `reviewer_loop_history.v1` entry gains `platform_results[]` and `missed_findings[]` (schema string unchanged). Each miss records reviewer, `reviewed_head` from `reviewed_heads[]`, paths, local evidence state, and `confirmed_miss` / `possible_miss` / `not_a_miss`—derived from the local reviewer’s **most recent** verdict (including a synthetic current-round entry), with git **ancestry** for same vs earlier clean commits. **Readiness, labels, and merge decisions are unchanged.**
> 
> **Commit attribution** is extended end-to-end: companion scripts (`coderabbit-cli`, `codex-github`, `haystack`) and many `pr-review-loop.sh` paths now emit **`REVIEWED_HEAD`** only when a single commit can be established (e.g. unique `commit_id` on comments/reviews, Codex terminal exits, unresolved-thread GraphQL). Blocking path extraction is improved for Codex/CodeRabbit REST edge cases.
> 
> The PR summary comment gains ≤200-character lines per miss; if history cannot be appended but a record was owed, the **prior history block is preserved** and a telemetry-failure note is shown. **Late post-clean threads** can synthesize blocking records so misses are still eligible. Protocol docs and changelog document the behavior; Area **1651** harness tests plus `test-reviewer-loop-commit-ancestry.sh` cover the new logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3c94ae5fd4928ee2a0ec4e0b572bead87ee892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

