### PR TITLE
refactor: tighten small-finding terminal policy (#1652)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -25,6 +25,10 @@ Use it for every pre-PR review gate and as the normalization layer for PR review
 
 When a review references mirrored agent docs, compare the live repository surface map before treating the finding as blocking. A `Rules violation` that only points at tool-specific front matter differences or an absent `.cursor/skills` tree is advisory only; a real mismatch between mirrored workflow bodies is actionable.
 
+### Small-finding terminal policy
+
+A **blocking** finding on a normative document (spec, plan, protocol, `REVIEW.md`, best-practices, project docs, or the agent guidance files) is never classified as small, whatever its wording. On other non-shipped documentation paths, a finding that touches a contract surface (acceptance criteria, decision gates/matrices, fail-closed semantics, and related allow-listed phrases) is escalated to non-small; a cosmetic blocking finding may still terminate the small-findings tail. The terminal rule requires both its prior counted rounds and the round being decided to be on the current PR head. When the rule does not fire for a content or currency cause, `SMALL_FINDINGS_BLOCKED_BY` reports one of `shipped_path`, `contract_surface`, `stale_head`, or `head_unknown` (within-group precedence: `shipped_path` over `contract_surface`, `stale_head` over `head_unknown`). Full detail lives in Protocol 93's small-finding terminal policy section.
+
 ### Fix vs. Report
 
 Fix directly when:

--- a/changelog.d/1652.changed.small-finding-terminal-policy.md
+++ b/changelog.d/1652.changed.small-finding-terminal-policy.md
@@ -1,0 +1,1 @@
+- **Tighten the small-finding terminal policy** (#1652): a blocking finding on a spec, plan, protocol or the review contract is no longer classified as small whatever its wording, a finding touching a contract surface is escalated on other documentation paths, and the terminal rule now requires both its prior counted rounds and the round being decided to be on the current head.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -799,23 +799,53 @@ Use the **PR feedback ledger** (keyed by `(platform, path, body_snippet)`) to de
    low-confidence cases; repeated low-confidence security labels indicate reviewer
    calibration drift, not necessarily a code defect.
 
-5. **Small non-shipped-artifact tail**: `pr-review-loop.sh` may stop a repeated
+5. **Small-finding terminal policy**: `pr-review-loop.sh` may stop a repeated
    small-findings tail when all of the following are true:
    - The current review result would otherwise be `needs_fixes`.
-   - Every blocking finding with a machine-readable path targets a non-shipped
-     artifact such as docs, tests, fixtures, snapshots, or markdown.
+   - Every **blocking** finding is classified as small under the two-tier rule
+     below. Advisory and suggestion-level findings never reach this rule.
    - The strict GraphQL review-thread audit reports
      `UNRESOLVED_THREAD_COUNT=0`.
+   - Both the prior counted rounds **and** the round being decided were
+     produced on the current PR head (`loop_head_sha`): each prior ledger
+     entry's `classification_head` must equal the current head, its
+     `contributing_platforms[]` must be non-empty, and every named contributor
+     must have a valid `reviewed_heads[]` head equal to that
+     `classification_head`; every contributor to the deciding round must
+     likewise report `loop_head_sha`. An absent, empty, or synthetic
+     `unknown-…` head ends the consecutive run (`head_unknown`) rather than
+     counting as current.
    - The latest reviewer-loop history already contains enough consecutive
-     `small_findings_only=true` rounds for the current round to reach
-     `PR_REVIEW_LOOP_SMALL_FINDINGS_STOP_ROUNDS` (default `2`).
+     qualifying `small_findings_only=true` rounds for the current round to
+     reach `PR_REVIEW_LOOP_SMALL_FINDINGS_STOP_ROUNDS` (default `2`).
+
+   **Two-tier small classification** (blocking findings only):
+
+   | Finding path | Blocking finding is small? |
+   | --- | --- |
+   | A **normative document** — `REVIEW.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `LLM_RULES.md`, `.ai-dev-workflow.yaml`, `docs/workflow/**`, `docs/best-practices/**`, `docs/specs/developments/**`, `docs/testing/workflow/**`, `docs/project/**` | **Never**, whatever its wording |
+   | Any other non-shipped path — `CHANGELOG.md`, fixtures, snapshots, and other non-shipped `*.md` outside the normative set | Small **unless** its body touches a contract surface (acceptance criteria, decision gates/matrices, parser/input behavior, scope/coverage, fail-closed semantics, state/status models, telemetry/contracts, proof obligations). Matching is case-insensitive on POSIX word boundaries; bare common words such as `gate`, `scope`, or `state` alone do not match. |
+   | A shipped path | Never |
 
    When this rule fires, the script emits `RESULT=clean`,
    `REASON=small_findings_terminal`, `SMALL_FINDINGS_STOP=1`, and records
-   `small_findings_paths` in the summary history. This is only a review-loop
-   terminal condition: the caller must still run exact-head tests, exact-head CI,
-   readiness self-checks, and merge gates. The summary's `Unreviewed tail` line
-   is the audit record for the non-shipped findings that ended the review loop.
+   `small_findings_paths` plus `contributing_platforms[]` in the summary
+   history. This is only a review-loop terminal condition: the caller must
+   still run exact-head tests, exact-head CI, readiness self-checks, and merge
+   gates. The summary's `Unreviewed tail` line is the audit record for the
+   small findings that ended the review loop.
+
+   When the terminal rule does **not** fire for a content or currency cause,
+   the script emits `SMALL_FINDINGS_BLOCKED_BY` as one of `shipped_path`,
+   `contract_surface`, `stale_head`, or `head_unknown`. Content causes
+   (`shipped_path`, `contract_surface`) and currency causes (`stale_head`,
+   `head_unknown`) are mutually exclusive by construction. Within each group,
+   precedence is `shipped_path` over `contract_surface`, and `stale_head` over
+   `head_unknown`. The summary line names **every** cause present (shipped
+   paths, matched contract-surface identities, and platforms with stale or
+   unknown heads); only the single-valued key is reduced by precedence. The
+   key is empty when the rule fired and empty when the run was simply short
+   (`exhausted` or `not_small`).
 
 #### Escalation trigger
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7724,8 +7724,27 @@ reviewer_loop_history_platforms_json() {
     jq -R -s -c 'split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0 and . != "none"))'
 }
 
+# Tier 1 fail-closed guard (#1652): a blocking finding on a normative document
+# is never small, whatever its wording. Consulted from
+# reviewer_loop_path_is_non_shipped_artifact before the existing patterns so
+# normative paths are excluded from the non-shipped (small-findings) set.
+reviewer_loop_path_is_normative_document() {
+  case "${1:-}" in
+    REVIEW.md|AGENTS.md|CLAUDE.md|GEMINI.md|LLM_RULES.md|.ai-dev-workflow.yaml)
+      return 0 ;;
+    docs/workflow/*|docs/best-practices/*|docs/specs/developments/*|docs/testing/workflow/*|docs/project/*)
+      return 0 ;;
+  esac
+  return 1
+}
+
 reviewer_loop_path_is_non_shipped_artifact() {
   local path="${1:-}"
+
+  # Normative documents are never treated as small-finding (non-shipped) paths.
+  if reviewer_loop_path_is_normative_document "$path"; then
+    return 1
+  fi
 
   case "$path" in
     ""|docs/*|test/*|tests/*|fixtures/*|fixture/*|__fixtures__/*|__tests__/*|*.md|*.mdx|test-*|*.snap)
@@ -7738,6 +7757,44 @@ reviewer_loop_path_is_non_shipped_artifact() {
       return 0
       ;;
   esac
+
+  return 1
+}
+
+# Tier 2 escalation (#1652): allow-list of contract-bearing surfaces as ordered
+# (identity, pattern) pairs. Prints the matched surface identity and returns
+# success; prints nothing and returns failure on no match. First match in table
+# order wins. Every pattern is a phrase or qualified form — bare common words
+# (gate, scope, state, status, proof, parse, contract) are deliberately absent.
+# Separators are literal, never the regex wildcard ".".
+REVIEWER_LOOP_CONTRACT_SURFACES=(
+  'acceptance_criteria|acceptance criterion|acceptance criteria|AC-[0-9]+'
+  'decision_gates_and_matrices|decision gate|decision matrix|matrix row|readiness gate|gate condition|gating'
+  'parser_and_input_behavior|parser|regex|input surface|word boundary'
+  'scope_and_coverage|out of scope|in scope|scope creep|coverage matrix|brief objective'
+  'fail_closed_semantics|fail-closed|fail closed|allow-list|deny-list|vacuous'
+  'state_and_status_models|state machine|state table|evidence state|valid transition|status label|status transition'
+  'telemetry_and_contracts|telemetry|stdout key|key=value contract|output contract'
+  'proof_obligations|planted-violation|planted violation|proof obligation'
+)
+
+# Case-insensitive word-boundary match via POSIX ERE character classes — never
+# \b (GNU/PCRE only; BSD grep on stock macOS does not recognise it).
+reviewer_loop_finding_touches_contract_surface() {
+  local body="${1:-}"
+  local entry identity pattern
+
+  [ -n "${body//[[:space:]]/}" ] || return 1
+
+  for entry in "${REVIEWER_LOOP_CONTRACT_SURFACES[@]}"; do
+    identity="${entry%%|*}"
+    pattern="${entry#*|}"
+    if printf '%s' "$body" \
+      | grep -Eqi "(^|[^[:alnum:]_])(${pattern})([^[:alnum:]_]|\$)"; then
+      printf '%s\n' "$identity"
+      return 0
+    fi
+  done
 
   return 1
 }
@@ -7766,6 +7823,42 @@ reviewer_loop_blocking_paths_from_output() {
     path="$(kv_value_default "BLOCKING_${index}_PATH" "$output" "")"
     [ -n "$path" ] && printf '%s\n' "$path"
   done
+}
+
+# Emit one compact JSON finding object per blocking finding (#1652).
+# Platform is a third argument from the caller's platform_name — reviewer
+# output carries no per-finding platform key. Does not skip empty paths:
+# all_findings_are_small fail-closes on them. Bodies are stored as received;
+# newline-sequence normalisation happens only at match time.
+reviewer_loop_blocking_findings_from_output() {
+  local output="${1:-}"
+  local blocking_count="${2:-0}"
+  local platform="${3:-}"
+  local index path body
+
+  [[ "$blocking_count" =~ ^[0-9]+$ ]] || blocking_count=0
+  [ "$blocking_count" -gt 0 ] || return 0
+
+  for index in $(seq 1 "$blocking_count"); do
+    path="$(kv_value_default "BLOCKING_${index}_PATH" "$output" "")"
+    body="$(kv_value_default "BLOCKING_${index}_BODY" "$output" "")"
+    jq -c -n \
+      --arg path "$path" \
+      --arg platform "$platform" \
+      --arg body "$body" \
+      '{path: $path, platform: $platform, body: $body}'
+  done
+}
+
+# Normalise a finding body for contract-surface matching only (#1652).
+# local-ai-reviewer emits real newlines as the two-character sequence \n
+# without escaping pre-existing backslashes — lossy and not reversible.
+# Replacing \n with a space restores word boundaries for matching without
+# claiming to decode. Never used for storage.
+reviewer_loop_normalize_finding_body_for_match() {
+  local body="${1:-}"
+  # Replace every literal two-character sequence \n with a space.
+  printf '%s' "${body//\\n/ }"
 }
 
 # --- Missed-finding telemetry helpers (#1651) -------------------------------
@@ -8412,45 +8505,328 @@ ${line}"
 
 
 
-reviewer_loop_all_paths_non_shipped() {
-  local path
-  local saw_path=0
+# Classify whether every finding record is "small" (#1652).
+# Reads newline-delimited JSON objects {path,platform,body} from stdin.
+# Fail-closed: empty array → failure; any empty/absent path → failure.
+# A finding is non-small when it is on a normative document, has a shipped
+# path, or touches a contract surface (after body normalisation for matching).
+reviewer_loop_all_findings_are_small() {
+  local line path body normalized
+  local -a lines=()
 
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    saw_path=1
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    lines+=("$line")
+  done
+
+  [ "${#lines[@]}" -gt 0 ] || return 1
+
+  for line in "${lines[@]}"; do
+    path="$(printf '%s' "$line" | jq -r '.path // empty' 2>/dev/null)" || path=""
+    body="$(printf '%s' "$line" | jq -r '.body // empty' 2>/dev/null)" || body=""
+    [ -n "$path" ] || return 1
+    if reviewer_loop_path_is_normative_document "$path"; then
+      return 1
+    fi
     if ! reviewer_loop_path_is_non_shipped_artifact "$path"; then
+      return 1
+    fi
+    normalized="$(reviewer_loop_normalize_finding_body_for_match "$body")"
+    if reviewer_loop_finding_touches_contract_surface "$normalized" >/dev/null; then
       return 1
     fi
   done
 
-  [ "$saw_path" -eq 1 ]
+  return 0
 }
 
+# Thin path-only wrapper kept for existing harness callers (#1652). Converts
+# newline-delimited paths into cosmetic finding records and delegates to
+# reviewer_loop_all_findings_are_small. Outside this change set, no production
+# caller remains — the main loop uses the findings array directly.
+reviewer_loop_all_paths_non_shipped() {
+  local path
+  local -a findings=()
+  local record
+
+  while IFS= read -r path || [ -n "$path" ]; do
+    [ -n "$path" ] || continue
+    record="$(jq -c -n --arg path "$path" --arg platform "" --arg body "" \
+      '{path: $path, platform: $platform, body: $body}')" || return 1
+    findings+=("$record")
+  done
+
+  [ "${#findings[@]}" -gt 0 ] || return 1
+  printf '%s\n' "${findings[@]}" | reviewer_loop_all_findings_are_small
+}
+
+# Analyse finding records for content causes and summary detail (#1652).
+# Reads newline-delimited JSON findings from stdin.
+# Prints one compact JSON object:
+#   {"blocked_by":"shipped_path|contract_surface|",
+#    "shipped_paths":[...],"contract_surfaces":[...],"all_small":true|false}
+# Within the content group, shipped_path outranks contract_surface.
+reviewer_loop_small_findings_content_analysis() {
+  local line path body normalized surface
+  local -a lines=() shipped_paths=() surfaces=()
+  local has_shipped=0 has_contract=0 has_empty_path=0 all_small=1
+  local blocked_by="" shipped_json surfaces_json
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    lines+=("$line")
+  done
+
+  if [ "${#lines[@]}" -eq 0 ]; then
+    jq -c -n '{blocked_by:"", shipped_paths:[], contract_surfaces:[], all_small:false}'
+    return 0
+  fi
+
+  for line in "${lines[@]}"; do
+    path="$(printf '%s' "$line" | jq -r '.path // empty' 2>/dev/null)" || path=""
+    body="$(printf '%s' "$line" | jq -r '.body // empty' 2>/dev/null)" || body=""
+    if [ -z "$path" ]; then
+      has_empty_path=1
+      all_small=0
+      continue
+    fi
+    if reviewer_loop_path_is_normative_document "$path" \
+        || ! reviewer_loop_path_is_non_shipped_artifact "$path"; then
+      has_shipped=1
+      all_small=0
+      shipped_paths+=("$path")
+      continue
+    fi
+    normalized="$(reviewer_loop_normalize_finding_body_for_match "$body")"
+    surface=""
+    if surface="$(reviewer_loop_finding_touches_contract_surface "$normalized")"; then
+      has_contract=1
+      all_small=0
+      surfaces+=("$surface")
+    fi
+  done
+
+  if [ "$has_empty_path" -eq 1 ]; then
+    # Unlocatable blockers cannot be classified small; no single blocked_by
+    # value applies (not in the four-value set). Leave blocked_by empty.
+    blocked_by=""
+  elif [ "$has_shipped" -eq 1 ]; then
+    blocked_by="shipped_path"
+  elif [ "$has_contract" -eq 1 ]; then
+    blocked_by="contract_surface"
+  fi
+
+  if [ "${#shipped_paths[@]}" -gt 0 ]; then
+    shipped_json="$(printf '%s\n' "${shipped_paths[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
+  else
+    shipped_json='[]'
+  fi
+  if [ "${#surfaces[@]}" -gt 0 ]; then
+    surfaces_json="$(printf '%s\n' "${surfaces[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0)) | unique')"
+  else
+    surfaces_json='[]'
+  fi
+
+  jq -c -n \
+    --arg blocked_by "$blocked_by" \
+    --argjson shipped_paths "$shipped_json" \
+    --argjson contract_surfaces "$surfaces_json" \
+    --argjson all_small "$all_small" \
+    '{
+      blocked_by: $blocked_by,
+      shipped_paths: $shipped_paths,
+      contract_surfaces: $contract_surfaces,
+      all_small: ($all_small == 1)
+    }'
+}
+
+# True when a head is absent, empty, synthetic unknown-*, or not a full SHA.
+reviewer_loop_head_is_unknown_or_invalid() {
+  local head="${1:-}"
+  [ -n "$head" ] || return 0
+  case "$head" in
+    unknown-*) return 0 ;;
+  esac
+  if reviewer_loop_head_evidence_full_sha "$head"; then
+    return 1
+  fi
+  return 0
+}
+
+# Count consecutive prior small-findings rounds on the current head (#1652).
+# Args: <summary_body> <current_loop_head_sha>
+# Emits one compact JSON object: {"count":N,"stop_reason":"..."}.
+# stop_reason is one of: exhausted | not_small | stale_head | head_unknown.
+# Malformed caller parse should treat missing/invalid output as count 0 /
+# head_unknown (see reviewer_loop_parse_small_findings_count).
 reviewer_loop_small_findings_prior_consecutive_count() {
   local body="${1:-}"
+  local current_head="${2:-}"
   local json
+  local count=0
+  local stop_reason="exhausted"
+  local entries_json entry classification_head contributing_json
+  local platform reviewed_head idx total contrib_stop
 
   json="$(printf '%s\n' "$body" | reviewer_loop_history_extract_latest_json)"
-  [ -n "$json" ] || { printf '0\n'; return 0; }
+  if [ -z "$json" ]; then
+    jq -c -n --argjson count 0 --arg stop_reason "head_unknown" \
+      '{count: $count, stop_reason: $stop_reason}'
+    return 0
+  fi
 
-  printf '%s\n' "$json" | jq -r '
-    if .schema != "reviewer_loop_history.v1"
-      or ((.history_status // "available") != "available")
-      or ((.entries | type) != "array")
-    then
-      0
-    else
-      reduce ((.entries // []) | reverse[]) as $entry (
-        {count: 0, active: true};
-        if .active and (($entry.small_findings_only // false) == true) then
-          .count += 1
-        else
-          .active = false
-        end
-      ) | .count
-    end
-  ' 2>/dev/null || printf '0\n'
+  if ! printf '%s\n' "$json" | jq -e '
+      .schema == "reviewer_loop_history.v1"
+      and ((.history_status // "available") == "available")
+      and ((.entries | type) == "array")
+    ' >/dev/null 2>&1; then
+    jq -c -n --argjson count 0 --arg stop_reason "head_unknown" \
+      '{count: $count, stop_reason: $stop_reason}'
+    return 0
+  fi
+
+  entries_json="$(printf '%s\n' "$json" | jq -c '[(.entries // []) | reverse[]]' 2>/dev/null)" || entries_json='[]'
+  total="$(printf '%s' "$entries_json" | jq -r 'length' 2>/dev/null)" || total=0
+  [[ "$total" =~ ^[0-9]+$ ]] || total=0
+
+  idx=0
+  while [ "$idx" -lt "$total" ]; do
+    entry="$(printf '%s' "$entries_json" | jq -c --argjson i "$idx" '.[$i]' 2>/dev/null)" || entry=""
+    [ -n "$entry" ] || break
+
+    if [ "$(printf '%s' "$entry" | jq -r '.small_findings_only // false')" != "true" ]; then
+      stop_reason="not_small"
+      break
+    fi
+
+    classification_head="$(printf '%s' "$entry" | jq -r '.classification_head // empty' 2>/dev/null)" || classification_head=""
+    if reviewer_loop_head_is_unknown_or_invalid "$classification_head"; then
+      stop_reason="head_unknown"
+      break
+    fi
+    # Compare case-insensitively like head_evidence_classify.
+    if [ "$(printf '%s' "$classification_head" | tr 'A-F' 'a-f')" != "$(printf '%s' "$current_head" | tr 'A-F' 'a-f')" ]; then
+      stop_reason="stale_head"
+      break
+    fi
+
+    contributing_json="$(printf '%s' "$entry" | jq -c '.contributing_platforms // empty' 2>/dev/null)" || contributing_json=""
+    if [ -z "$contributing_json" ] || [ "$contributing_json" = "null" ] \
+        || [ "$(printf '%s' "$contributing_json" | jq -r 'if type == "array" then length else 0 end')" = "0" ]; then
+      stop_reason="head_unknown"
+      break
+    fi
+
+    # Check every contributing platform's reviewed_heads entry.
+    contrib_stop=""
+    while IFS= read -r platform; do
+      [ -n "$platform" ] || continue
+      reviewed_head="$(printf '%s' "$entry" | jq -r --arg p "$platform" '
+        ([.reviewed_heads // [] | .[]? | select(.platform == $p) | .reviewed_head // ""] | first) // ""
+      ' 2>/dev/null)" || reviewed_head=""
+      if reviewer_loop_head_is_unknown_or_invalid "$reviewed_head"; then
+        contrib_stop="head_unknown"
+        break
+      fi
+      if [ "$(printf '%s' "$reviewed_head" | tr 'A-F' 'a-f')" != "$(printf '%s' "$classification_head" | tr 'A-F' 'a-f')" ]; then
+        contrib_stop="stale_head"
+        break
+      fi
+    done < <(printf '%s' "$contributing_json" | jq -r '.[]?' 2>/dev/null)
+
+    if [ -n "$contrib_stop" ]; then
+      stop_reason="$contrib_stop"
+      break
+    fi
+
+    count=$((count + 1))
+    idx=$((idx + 1))
+  done
+
+  jq -c -n --argjson count "$count" --arg stop_reason "$stop_reason" \
+    '{count: $count, stop_reason: $stop_reason}'
+}
+
+# Parse counter JSON fail-closed (#1652). Prints "count stop_reason".
+# Malformed / missing / out-of-domain → "0 head_unknown".
+reviewer_loop_parse_small_findings_count() {
+  local raw="${1:-}"
+  local count stop_reason
+
+  count="$(printf '%s' "$raw" | jq -r '.count // empty' 2>/dev/null)" || count=""
+  stop_reason="$(printf '%s' "$raw" | jq -r '.stop_reason // empty' 2>/dev/null)" || stop_reason=""
+
+  if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    printf '0 head_unknown\n'
+    return 0
+  fi
+  case "$stop_reason" in
+    exhausted|not_small|stale_head|head_unknown) ;;
+    *)
+      printf '0 head_unknown\n'
+      return 0
+      ;;
+  esac
+  printf '%s %s\n' "$count" "$stop_reason"
+}
+
+# Check current-round contributing platforms against loop_head_sha (#1652).
+# Args: current_head, then optional "platform:sha" entries (platform_reviewed_heads).
+# Reads contributing platform names from stdin (one per line).
+# Prints one compact JSON object:
+#   {"status":"ok|stale_head|head_unknown","blocked_by":"...",
+#    "details":["stale_head:plat",...]}
+# Within the currency group, stale_head outranks head_unknown for blocked_by;
+# details lists every currency cause present for the summary line.
+reviewer_loop_current_round_heads_ok() {
+  local current_head="${1:-}"
+  shift
+  local -a reviewed_entries=("$@")
+  local platform reviewed_head entry found
+  local -a details=()
+  local has_stale=0 has_unknown=0
+  local blocked_by="" status="ok" details_json
+
+  while IFS= read -r platform || [ -n "$platform" ]; do
+    [ -n "$platform" ] || continue
+    found=0
+    reviewed_head=""
+    for entry in "${reviewed_entries[@]:-}"; do
+      if [ "${entry%%:*}" = "$platform" ]; then
+        reviewed_head="${entry#*:}"
+        found=1
+      fi
+    done
+    if [ "$found" -eq 0 ] || reviewer_loop_head_is_unknown_or_invalid "$reviewed_head"; then
+      has_unknown=1
+      details+=("head_unknown:${platform}")
+      continue
+    fi
+    if [ "$(printf '%s' "$reviewed_head" | tr 'A-F' 'a-f')" != "$(printf '%s' "$current_head" | tr 'A-F' 'a-f')" ]; then
+      has_stale=1
+      details+=("stale_head:${platform}")
+    fi
+  done
+
+  if [ "$has_stale" -eq 1 ]; then
+    blocked_by="stale_head"
+    status="stale_head"
+  elif [ "$has_unknown" -eq 1 ]; then
+    blocked_by="head_unknown"
+    status="head_unknown"
+  fi
+
+  if [ "${#details[@]}" -gt 0 ]; then
+    details_json="$(printf '%s\n' "${details[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+  else
+    details_json='[]'
+  fi
+
+  jq -c -n \
+    --arg status "$status" \
+    --arg blocked_by "$blocked_by" \
+    --argjson details "$details_json" \
+    '{status: $status, blocked_by: $blocked_by, details: $details}'
 }
 
 reviewer_loop_head_evidence_full_sha() {
@@ -8675,6 +9051,19 @@ reviewer_loop_history_build_entry() {
     missed_findings_for_entry='[]'
   fi
 
+  # contributing_platforms (#1652): platforms that produced a counted blocking
+  # finding this round. Derived from aggregate_blocking_findings; empty when
+  # none. Prior ledger entries without this field fail closed in the
+  # small-findings counter.
+  local contributing_platforms_json='[]'
+  if declare -p aggregate_blocking_findings >/dev/null 2>&1 \
+      && [ "${#aggregate_blocking_findings[@]}" -gt 0 ]; then
+    contributing_platforms_json="$(
+      printf '%s\n' "${aggregate_blocking_findings[@]}" \
+        | jq -s -c '[.[].platform // empty | select(length > 0)] | unique'
+    )" || contributing_platforms_json='[]'
+  fi
+
   # run_id (#1502 dual-cap follow-up): read from the current_run_id global,
   # following the same convention already used in this function for
   # unresolved_thread_count/late_thread_count (set by the caller before
@@ -8707,6 +9096,7 @@ reviewer_loop_history_build_entry() {
     --arg smallFindingsPaths "${small_findings_paths:-}" \
     --arg classificationHead "${loop_head_sha:-}" \
     --argjson reviewedHeads "$reviewed_heads_json" \
+    --argjson contributingPlatforms "$contributing_platforms_json" \
     --argjson platformResults "$platform_results_for_entry" \
     --argjson missedFindings "$missed_findings_for_entry" \
     --arg egPlatform "${expensive_gate_last_platform:-}" \
@@ -8725,6 +9115,7 @@ reviewer_loop_history_build_entry() {
       head_sha: $headSha,
       classification_head: $classificationHead,
       reviewed_heads: $reviewedHeads,
+      contributing_platforms: $contributingPlatforms,
       platform_results: $platformResults,
       missed_findings: $missedFindings,
       run_id: $runId,
@@ -10419,8 +10810,15 @@ small_findings_stop=0
 small_findings_rounds=0
 small_findings_paths=""
 small_findings_paths_inline=""
+small_findings_blocked_by=""
+small_findings_shipped_detail=""
+small_findings_surfaces_detail=""
+small_findings_currency_detail=""
 declare -a compare_verdicts=()
 declare -a aggregate_blocking_paths=()
+# Parallel to aggregate_blocking_paths: one JSON finding record per blocking
+# finding, never deduplicated (#1652).
+declare -a aggregate_blocking_findings=()
 # The head this run reviews, captured BEFORE any reviewer is dispatched
 # (issue #1574). Every verdict below describes this commit; the settle emits it
 # as POST_CLEAN_HEAD_SHA, and the head-move guard after the settle turns a
@@ -10679,6 +11077,10 @@ for index in "${!platforms[@]}"; do
     [ -n "$_blocking_path" ] && aggregate_blocking_paths+=("$_blocking_path")
   done < <(reviewer_loop_blocking_paths_from_output "$platform_output" "$platform_blocking_count")
   unset _blocking_path
+  while IFS= read -r _blocking_finding; do
+    [ -n "$_blocking_finding" ] && aggregate_blocking_findings+=("$_blocking_finding")
+  done < <(reviewer_loop_blocking_findings_from_output "$platform_output" "$platform_blocking_count" "$platform_name")
+  unset _blocking_finding
   if [ -n "$platform_advisory_labels" ]; then
     if [ -n "$aggregate_advisory_labels" ]; then
       aggregate_advisory_labels="${aggregate_advisory_labels}|||${platform_advisory_labels}"
@@ -10877,7 +11279,7 @@ _post_review_summary() {
   case "$result" in
     clean)
       if [ "${small_findings_stop:-0}" -eq 1 ]; then
-        result_line="clean (small-findings stop) — non-shipped tail recorded for human merge audit"
+        result_line="clean (small-findings stop) — small non-shipped tail on current head recorded for human merge audit"
       elif [ "$blocking" -eq 0 ] && [ "$suggestions" -eq 0 ]; then
         result_line="clean — no blocking findings"
       else
@@ -11098,8 +11500,25 @@ $(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_h
   local small_findings_section=""
   if [ "${small_findings_stop:-0}" -eq 1 ]; then
     small_findings_section="
-**Small-findings stop:** ${small_findings_rounds:-0}/${small_findings_required_rounds:-0} consecutive review rounds contained only non-shipped-artifact findings, and the strict review-thread audit reported zero unresolved threads. Exact-head tests and CI still gate readiness after this review result.
+**Small-findings stop:** ${small_findings_rounds:-0}/${small_findings_required_rounds:-0} consecutive review rounds contained only small non-shipped-artifact findings on the current head, and the strict review-thread audit reported zero unresolved threads. Exact-head tests and CI still gate readiness after this review result.
 **Unreviewed tail:** ${small_findings_paths_inline:-none}"
+  elif [ -n "${small_findings_blocked_by:-}" ] || [ "${small_findings_only:-0}" -eq 1 ]; then
+    # Name every collected cause so precedence on SMALL_FINDINGS_BLOCKED_BY
+    # does not hide co-occurring causes within the reached group (#1652).
+    local _sf_cause_bits=""
+    [ -n "${small_findings_shipped_detail:-}" ] && _sf_cause_bits="${_sf_cause_bits} shipped_paths=${small_findings_shipped_detail};"
+    [ -n "${small_findings_surfaces_detail:-}" ] && _sf_cause_bits="${_sf_cause_bits} contract_surfaces=${small_findings_surfaces_detail};"
+    [ -n "${small_findings_currency_detail:-}" ] && _sf_cause_bits="${_sf_cause_bits} currency=${small_findings_currency_detail};"
+    if [ -n "${small_findings_blocked_by:-}" ]; then
+      small_findings_section="
+**Small-findings:** terminal rule blocked by \`${small_findings_blocked_by}\`.${_sf_cause_bits:+ Causes:}${_sf_cause_bits}
+**Candidate tail:** ${small_findings_paths_inline:-none}"
+    elif [ "${small_findings_only:-0}" -eq 1 ]; then
+      small_findings_section="
+**Small-findings:** ${small_findings_rounds:-0}/${small_findings_required_rounds:-0} consecutive small rounds so far (threshold not reached; not a blocking cause).
+**Candidate tail:** ${small_findings_paths_inline:-none}"
+    fi
+    unset _sf_cause_bits
   fi
 
   # Errors in the comment-posting block must not change the script's exit code or
@@ -11419,12 +11838,20 @@ done
 
 if [ "$aggregate_result" = "needs_fixes" ] \
     && [ "$total_blocking_count" -gt 0 ] \
-    && [ "${#aggregate_blocking_paths[@]}" -gt 0 ]; then
+    && [ "${#aggregate_blocking_findings[@]}" -gt 0 ]; then
   small_findings_paths="$(printf '%s\n' "${aggregate_blocking_paths[@]}" | sort -u)"
-  if printf '%s\n' "$small_findings_paths" | reviewer_loop_all_paths_non_shipped; then
+  _sf_content_json="$(printf '%s\n' "${aggregate_blocking_findings[@]}" | reviewer_loop_small_findings_content_analysis)"
+  if [ "$(printf '%s' "$_sf_content_json" | jq -r '.all_small // false')" = "true" ]; then
     small_findings_only=1
     small_findings_paths_inline="$(printf '%s\n' "$small_findings_paths" | awk 'BEGIN { sep = "" } { printf "%s%s", sep, $0; sep = ", " } END { printf "\n" }')"
+  else
+    # Content causes: set SMALL_FINDINGS_BLOCKED_BY by within-group precedence.
+    # Currency causes are unreachable when findings are not all small.
+    small_findings_blocked_by="$(printf '%s' "$_sf_content_json" | jq -r '.blocked_by // empty')"
+    small_findings_shipped_detail="$(printf '%s' "$_sf_content_json" | jq -r '.shipped_paths // [] | join(", ")')"
+    small_findings_surfaces_detail="$(printf '%s' "$_sf_content_json" | jq -r '.contract_surfaces // [] | join(", ")')"
   fi
+  unset _sf_content_json
 fi
 
 if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ] \
@@ -11495,17 +11922,59 @@ if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ] \
       && [ "$unresolved_thread_count" -eq 0 ] \
       && [ "$small_findings_only" -eq 1 ]; then
     reviewer_loop_latest_summary_body="$(reviewer_loop_fetch_latest_summary_body "$pr_number")"
-    small_findings_prior_count="$(reviewer_loop_small_findings_prior_consecutive_count "$reviewer_loop_latest_summary_body")"
+    _sf_count_json="$(reviewer_loop_small_findings_prior_consecutive_count "$reviewer_loop_latest_summary_body" "${loop_head_sha:-}")"
+    read -r small_findings_prior_count _sf_prior_stop < <(reviewer_loop_parse_small_findings_count "$_sf_count_json")
     [[ "${small_findings_prior_count:-}" =~ ^[0-9]+$ ]] || small_findings_prior_count=0
+    _sf_prior_stop="${_sf_prior_stop:-head_unknown}"
+
+    # Current-round head check for every contributing platform (#1652).
+    _sf_contributors="$(
+      printf '%s\n' "${aggregate_blocking_findings[@]}" \
+        | jq -r '.platform // empty' 2>/dev/null \
+        | awk 'NF && !seen[$0]++'
+    )"
+    if [ -n "$_sf_contributors" ]; then
+      _sf_current_json="$(
+        printf '%s\n' "$_sf_contributors" \
+          | reviewer_loop_current_round_heads_ok "${loop_head_sha:-}" "${platform_reviewed_heads[@]:-}"
+      )"
+    else
+      _sf_current_json='{"status":"head_unknown","blocked_by":"head_unknown","details":["head_unknown:"]}'
+    fi
+    _sf_current_currency="$(printf '%s' "$_sf_current_json" | jq -r '.blocked_by // empty')"
+    _sf_currency_detail_list="$(printf '%s' "$_sf_current_json" | jq -r '.details // [] | join(", ")')"
+
     small_findings_rounds=$((small_findings_prior_count + 1))
-    if [ "$small_findings_rounds" -ge "$small_findings_required_rounds" ]; then
+
+    if [ -n "$_sf_current_currency" ]; then
+      # Current round is not on loop_head_sha for every contributor.
+      # Within-group precedence already applied inside current_round_heads_ok.
+      small_findings_blocked_by="$_sf_current_currency"
+      if [ "$_sf_current_currency" = "head_unknown" ] && [ "$_sf_prior_stop" = "stale_head" ]; then
+        small_findings_blocked_by="stale_head"
+      fi
+      small_findings_currency_detail="$_sf_currency_detail_list"
+      if [ "$_sf_prior_stop" = "stale_head" ] || [ "$_sf_prior_stop" = "head_unknown" ]; then
+        if [[ "$small_findings_currency_detail" != *"$_sf_prior_stop"* ]]; then
+          small_findings_currency_detail="${small_findings_currency_detail}; prior:${_sf_prior_stop}"
+        fi
+      fi
+    elif [ "$small_findings_rounds" -ge "$small_findings_required_rounds" ]; then
       aggregate_result="clean"
       aggregate_reason="small_findings_terminal"
       aggregate_status=0
       small_findings_stop=1
-      echo "INFO: small-findings stop — ${small_findings_rounds}/${small_findings_required_rounds} consecutive rounds only touched non-shipped artifacts; strict thread audit found zero unresolved threads" >&2
+      small_findings_blocked_by=""
+      echo "INFO: small-findings stop — ${small_findings_rounds}/${small_findings_required_rounds} consecutive rounds only touched small non-shipped findings on the current head; strict thread audit found zero unresolved threads" >&2
+    elif [ "$_sf_prior_stop" = "stale_head" ] || [ "$_sf_prior_stop" = "head_unknown" ]; then
+      # Short of the threshold because a prior round failed the head check.
+      small_findings_blocked_by="$_sf_prior_stop"
+      small_findings_currency_detail="prior:${_sf_prior_stop}"
     fi
+    # exhausted / not_small with insufficient rounds: leave blocked_by empty.
     unset reviewer_loop_latest_summary_body small_findings_prior_count
+    unset _sf_count_json _sf_prior_stop _sf_contributors _sf_current_json
+    unset _sf_current_currency _sf_currency_detail_list
   fi
 else
   print_kv UNRESOLVED_THREAD_COUNT 0
@@ -11754,6 +12223,7 @@ print_kv SMALL_FINDINGS_STOP "$small_findings_stop"
 print_kv SMALL_FINDINGS_ROUNDS "$small_findings_rounds"
 print_kv SMALL_FINDINGS_REQUIRED_ROUNDS "$small_findings_required_rounds"
 [ -n "$small_findings_paths_inline" ] && print_kv SMALL_FINDINGS_PATHS "$small_findings_paths_inline"
+[ -n "${small_findings_blocked_by:-}" ] && print_kv SMALL_FINDINGS_BLOCKED_BY "$small_findings_blocked_by"
 print_kv PHASE_AFTER_CLEAN_STARTED "$phase_after_clean_started"
 print_kv READY_PHASE_STARTED "$phase_after_clean_started"
 if [ "$phase_after_clean_enabled" -eq 1 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -666,6 +666,22 @@ Environment variables:
                                      Bypass the expensive-reviewer gate for manual escalation. The gate still
                                      evaluates and emits EXPENSIVE_GATE_* with RESULT=forced and the reason it
                                      would have deferred; justify use in the PR.
+  PR_REVIEW_LOOP_SMALL_FINDINGS_STOP_ROUNDS=<n>
+                                     Consecutive small-findings rounds required before RESULT=clean with
+                                     REASON=small_findings_terminal (default: 2; valid range 1–999). A round
+                                     qualifies only when every blocking finding is small under the two-tier
+                                     rule (normative documents are never small; other non-shipped paths are
+                                     small unless the body touches a contract surface), the strict thread
+                                     audit is zero, and both prior counted rounds and the deciding round are
+                                     on the current PR head for every contributing platform. See Protocol 93.
+  SMALL_FINDINGS_BLOCKED_BY=<cause>  Emitted when the small-findings terminal rule does not fire for a content
+                                     or currency cause: shipped_path | contract_surface | stale_head |
+                                     head_unknown. Within-group precedence: shipped_path over contract_surface;
+                                     stale_head over head_unknown. Empty when the rule fired or the run was
+                                     simply short. Contract-surface identities include acceptance_criteria,
+                                     decision_gates_and_matrices, parser_and_input_behavior, scope_and_coverage,
+                                     fail_closed_semantics, state_and_status_models, telemetry_and_contracts,
+                                     proof_obligations.
 EOF
 }
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8803,26 +8803,35 @@ reviewer_loop_current_round_heads_ok() {
   local has_stale=0 has_unknown=0
   local blocked_by="" status="ok" details_json
 
-  while IFS= read -r platform || [ -n "$platform" ]; do
-    [ -n "$platform" ] || continue
-    found=0
-    reviewed_head=""
-    for entry in "${reviewed_entries[@]:-}"; do
-      if [ "${entry%%:*}" = "$platform" ]; then
-        reviewed_head="${entry#*:}"
-        found=1
-      fi
-    done
-    if [ "$found" -eq 0 ] || reviewer_loop_head_is_unknown_or_invalid "$reviewed_head"; then
+  # Fail closed: without a verifiable current head, currency cannot be established.
+  if reviewer_loop_head_is_unknown_or_invalid "$current_head"; then
+    while IFS= read -r platform || [ -n "$platform" ]; do
+      [ -n "$platform" ] || continue
       has_unknown=1
       details+=("head_unknown:${platform}")
-      continue
-    fi
-    if [ "$(printf '%s' "$reviewed_head" | tr 'A-F' 'a-f')" != "$(printf '%s' "$current_head" | tr 'A-F' 'a-f')" ]; then
-      has_stale=1
-      details+=("stale_head:${platform}")
-    fi
-  done
+    done
+  else
+    while IFS= read -r platform || [ -n "$platform" ]; do
+      [ -n "$platform" ] || continue
+      found=0
+      reviewed_head=""
+      for entry in "${reviewed_entries[@]:-}"; do
+        if [ "${entry%%:*}" = "$platform" ]; then
+          reviewed_head="${entry#*:}"
+          found=1
+        fi
+      done
+      if [ "$found" -eq 0 ] || reviewer_loop_head_is_unknown_or_invalid "$reviewed_head"; then
+        has_unknown=1
+        details+=("head_unknown:${platform}")
+        continue
+      fi
+      if [ "$(printf '%s' "$reviewed_head" | tr 'A-F' 'a-f')" != "$(printf '%s' "$current_head" | tr 'A-F' 'a-f')" ]; then
+        has_stale=1
+        details+=("stale_head:${platform}")
+      fi
+    done
+  fi
 
   if [ "$has_stale" -eq 1 ]; then
     blocked_by="stale_head"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8854,6 +8854,133 @@ reviewer_loop_current_round_heads_ok() {
     '{status: $status, blocked_by: $blocked_by, details: $details}'
 }
 
+# Evaluate the production small-findings terminal decision (#1652).
+# Args: <summary_body> <loop_head_sha> <required_rounds> <unresolved_thread_count>
+#       then optional platform:reviewed_head entries; finding JSON records on stdin.
+# Prints one compact JSON object:
+#   {result, reason, small_findings_only, small_findings_stop, small_findings_rounds,
+#    small_findings_blocked_by, currency_detail}
+reviewer_loop_evaluate_small_findings_terminal() {
+  local summary_body="${1:-}"
+  local loop_head_sha="${2:-}"
+  local required_rounds="${3:-2}"
+  local unresolved_thread_count="${4:-0}"
+  shift 4 2>/dev/null || true
+  local -a platform_reviewed_heads=("$@")
+  local -a aggregate_blocking_findings=()
+  local line aggregate_result="needs_fixes" aggregate_reason=""
+  local small_findings_only=0 small_findings_stop=0 small_findings_rounds=0
+  local small_findings_blocked_by=""
+  local small_findings_prior_count=0
+  local currency_detail=""
+  local _sf_content_json _sf_count_json _sf_prior_stop _sf_contributors
+  local _sf_current_json _sf_current_currency _sf_currency_detail_list=""
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    aggregate_blocking_findings+=("$line")
+  done
+
+  if [ "${#aggregate_blocking_findings[@]}" -eq 0 ]; then
+    jq -c -n \
+      --arg result "needs_fixes" --arg reason "" \
+      --argjson small_findings_only 0 --argjson small_findings_stop 0 \
+      --argjson small_findings_rounds 0 --arg small_findings_blocked_by "" \
+      '{result: $result, reason: $reason, small_findings_only: ($small_findings_only == 1),
+        small_findings_stop: ($small_findings_stop == 1), small_findings_rounds: $small_findings_rounds,
+        small_findings_blocked_by: $small_findings_blocked_by}'
+    return 0
+  fi
+
+  _sf_content_json="$(printf '%s\n' "${aggregate_blocking_findings[@]}" | reviewer_loop_small_findings_content_analysis)"
+  if [ "$(printf '%s' "$_sf_content_json" | jq -r '.all_small // false')" = "true" ]; then
+    small_findings_only=1
+  else
+    small_findings_blocked_by="$(printf '%s' "$_sf_content_json" | jq -r '.blocked_by // empty')"
+    jq -c -n \
+      --arg result "$aggregate_result" --arg reason "$aggregate_reason" \
+      --argjson small_findings_only "$small_findings_only" \
+      --argjson small_findings_stop "$small_findings_stop" \
+      --argjson small_findings_rounds "$small_findings_rounds" \
+      --arg small_findings_blocked_by "$small_findings_blocked_by" \
+      '{result: $result, reason: $reason, small_findings_only: ($small_findings_only == 1),
+        small_findings_stop: ($small_findings_stop == 1), small_findings_rounds: $small_findings_rounds,
+        small_findings_blocked_by: $small_findings_blocked_by}'
+    return 0
+  fi
+
+  if [ "$unresolved_thread_count" -gt 0 ]; then
+    aggregate_result="needs_fixes"
+    aggregate_reason="unresolved_review_threads"
+    jq -c -n \
+      --arg result "$aggregate_result" --arg reason "$aggregate_reason" \
+      --argjson small_findings_only "$small_findings_only" \
+      --argjson small_findings_stop 0 \
+      --argjson small_findings_rounds 0 \
+      --arg small_findings_blocked_by "" \
+      '{result: $result, reason: $reason, small_findings_only: ($small_findings_only == 1),
+        small_findings_stop: ($small_findings_stop == 1), small_findings_rounds: $small_findings_rounds,
+        small_findings_blocked_by: $small_findings_blocked_by}'
+    return 0
+  fi
+
+  _sf_count_json="$(reviewer_loop_small_findings_prior_consecutive_count "$summary_body" "$loop_head_sha")"
+  read -r small_findings_prior_count _sf_prior_stop < <(reviewer_loop_parse_small_findings_count "$_sf_count_json")
+  [[ "${small_findings_prior_count:-}" =~ ^[0-9]+$ ]] || small_findings_prior_count=0
+  _sf_prior_stop="${_sf_prior_stop:-head_unknown}"
+
+  _sf_contributors="$(
+    printf '%s\n' "${aggregate_blocking_findings[@]}" \
+      | jq -r '.platform // empty' 2>/dev/null \
+      | awk 'NF && !seen[$0]++'
+  )"
+  if [ -n "$_sf_contributors" ]; then
+    _sf_current_json="$(
+      printf '%s\n' "$_sf_contributors" \
+        | reviewer_loop_current_round_heads_ok "$loop_head_sha" "${platform_reviewed_heads[@]:-}"
+    )"
+  else
+    _sf_current_json='{"status":"head_unknown","blocked_by":"head_unknown","details":["head_unknown:"]}'
+  fi
+  _sf_current_currency="$(printf '%s' "$_sf_current_json" | jq -r '.blocked_by // empty')"
+  _sf_currency_detail_list="$(printf '%s' "$_sf_current_json" | jq -r '.details // [] | join(", ")')"
+
+  small_findings_rounds=$((small_findings_prior_count + 1))
+
+  if [ -n "$_sf_current_currency" ]; then
+    small_findings_blocked_by="$_sf_current_currency"
+    if [ "$_sf_current_currency" = "head_unknown" ] && [ "$_sf_prior_stop" = "stale_head" ]; then
+      small_findings_blocked_by="stale_head"
+    fi
+    currency_detail="$_sf_currency_detail_list"
+    if [ "$_sf_prior_stop" = "stale_head" ] || [ "$_sf_prior_stop" = "head_unknown" ]; then
+      if [[ "$currency_detail" != *"$_sf_prior_stop"* ]]; then
+        currency_detail="${currency_detail}; prior:${_sf_prior_stop}"
+      fi
+    fi
+  elif [ "$small_findings_rounds" -ge "$required_rounds" ]; then
+    aggregate_result="clean"
+    aggregate_reason="small_findings_terminal"
+    small_findings_stop=1
+    small_findings_blocked_by=""
+  elif [ "$_sf_prior_stop" = "stale_head" ] || [ "$_sf_prior_stop" = "head_unknown" ]; then
+    small_findings_blocked_by="$_sf_prior_stop"
+    currency_detail="prior:${_sf_prior_stop}"
+  fi
+
+  jq -c -n \
+    --arg result "$aggregate_result" \
+    --arg reason "$aggregate_reason" \
+    --argjson small_findings_only "$small_findings_only" \
+    --argjson small_findings_stop "$small_findings_stop" \
+    --argjson small_findings_rounds "$small_findings_rounds" \
+    --arg small_findings_blocked_by "$small_findings_blocked_by" \
+    --arg currency_detail "$currency_detail" \
+    '{result: $result, reason: $reason, small_findings_only: ($small_findings_only == 1),
+      small_findings_stop: ($small_findings_stop == 1), small_findings_rounds: $small_findings_rounds,
+      small_findings_blocked_by: $small_findings_blocked_by, currency_detail: $currency_detail}'
+}
+
 reviewer_loop_head_evidence_full_sha() {
   local value="$1"
 
@@ -11947,59 +12074,26 @@ if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ] \
       && [ "$unresolved_thread_count" -eq 0 ] \
       && [ "$small_findings_only" -eq 1 ]; then
     reviewer_loop_latest_summary_body="$(reviewer_loop_fetch_latest_summary_body "$pr_number")"
-    _sf_count_json="$(reviewer_loop_small_findings_prior_consecutive_count "$reviewer_loop_latest_summary_body" "${loop_head_sha:-}")"
-    read -r small_findings_prior_count _sf_prior_stop < <(reviewer_loop_parse_small_findings_count "$_sf_count_json")
-    [[ "${small_findings_prior_count:-}" =~ ^[0-9]+$ ]] || small_findings_prior_count=0
-    _sf_prior_stop="${_sf_prior_stop:-head_unknown}"
-
-    # Current-round head check for every contributing platform (#1652).
-    _sf_contributors="$(
+    _sf_terminal_json="$(
       printf '%s\n' "${aggregate_blocking_findings[@]}" \
-        | jq -r '.platform // empty' 2>/dev/null \
-        | awk 'NF && !seen[$0]++'
+        | reviewer_loop_evaluate_small_findings_terminal \
+            "$reviewer_loop_latest_summary_body" \
+            "${loop_head_sha:-}" \
+            "$small_findings_required_rounds" \
+            "$unresolved_thread_count" \
+            "${platform_reviewed_heads[@]:-}"
     )"
-    if [ -n "$_sf_contributors" ]; then
-      _sf_current_json="$(
-        printf '%s\n' "$_sf_contributors" \
-          | reviewer_loop_current_round_heads_ok "${loop_head_sha:-}" "${platform_reviewed_heads[@]:-}"
-      )"
-    else
-      _sf_current_json='{"status":"head_unknown","blocked_by":"head_unknown","details":["head_unknown:"]}'
-    fi
-    _sf_current_currency="$(printf '%s' "$_sf_current_json" | jq -r '.blocked_by // empty')"
-    _sf_currency_detail_list="$(printf '%s' "$_sf_current_json" | jq -r '.details // [] | join(", ")')"
-
-    small_findings_rounds=$((small_findings_prior_count + 1))
-
-    if [ -n "$_sf_current_currency" ]; then
-      # Current round is not on loop_head_sha for every contributor.
-      # Within-group precedence already applied inside current_round_heads_ok.
-      small_findings_blocked_by="$_sf_current_currency"
-      if [ "$_sf_current_currency" = "head_unknown" ] && [ "$_sf_prior_stop" = "stale_head" ]; then
-        small_findings_blocked_by="stale_head"
-      fi
-      small_findings_currency_detail="$_sf_currency_detail_list"
-      if [ "$_sf_prior_stop" = "stale_head" ] || [ "$_sf_prior_stop" = "head_unknown" ]; then
-        if [[ "$small_findings_currency_detail" != *"$_sf_prior_stop"* ]]; then
-          small_findings_currency_detail="${small_findings_currency_detail}; prior:${_sf_prior_stop}"
-        fi
-      fi
-    elif [ "$small_findings_rounds" -ge "$small_findings_required_rounds" ]; then
-      aggregate_result="clean"
-      aggregate_reason="small_findings_terminal"
+    aggregate_result="$(printf '%s' "$_sf_terminal_json" | jq -r '.result // "needs_fixes"')"
+    aggregate_reason="$(printf '%s' "$_sf_terminal_json" | jq -r '.reason // empty')"
+    small_findings_rounds="$(printf '%s' "$_sf_terminal_json" | jq -r '.small_findings_rounds // 0')"
+    small_findings_blocked_by="$(printf '%s' "$_sf_terminal_json" | jq -r '.small_findings_blocked_by // empty')"
+    small_findings_currency_detail="$(printf '%s' "$_sf_terminal_json" | jq -r '.currency_detail // empty')"
+    if [ "$(printf '%s' "$_sf_terminal_json" | jq -r '.small_findings_stop // false')" = "true" ]; then
       aggregate_status=0
       small_findings_stop=1
-      small_findings_blocked_by=""
       echo "INFO: small-findings stop — ${small_findings_rounds}/${small_findings_required_rounds} consecutive rounds only touched small non-shipped findings on the current head; strict thread audit found zero unresolved threads" >&2
-    elif [ "$_sf_prior_stop" = "stale_head" ] || [ "$_sf_prior_stop" = "head_unknown" ]; then
-      # Short of the threshold because a prior round failed the head check.
-      small_findings_blocked_by="$_sf_prior_stop"
-      small_findings_currency_detail="prior:${_sf_prior_stop}"
     fi
-    # exhausted / not_small with insufficient rounds: leave blocked_by empty.
-    unset reviewer_loop_latest_summary_body small_findings_prior_count
-    unset _sf_count_json _sf_prior_stop _sf_contributors _sf_current_json
-    unset _sf_current_currency _sf_currency_detail_list
+    unset reviewer_loop_latest_summary_body _sf_terminal_json
   fi
 else
   print_kv UNRESOLVED_THREAD_COUNT 0

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2872,7 +2872,9 @@ _sf_s14="$(jq -n '{
 run_test "1652_s14_prechange_ends_run" "0 head_unknown" \
   "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s14")" "$_sf_head")")"
 
-# Parser-risk addendum negatives
+# Parser-risk addendum (plan § Parser-risk addendum — one case per edge)
+run_test "1652_parser_delegates_not_gate" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "the handler delegates to another module" || echo NONE)"
 run_test "1652_parser_microscope" "NONE" \
   "$(reviewer_loop_finding_touches_contract_surface "look into the microscope carefully" || echo NONE)"
 run_test "1652_parser_failXclosed" "NONE" \
@@ -2881,8 +2883,22 @@ run_test "1652_parser_allow_list_unhyphenated" "NONE" \
   "$(reviewer_loop_finding_touches_contract_surface "the allow list is incomplete" || echo NONE)"
 run_test "1652_parser_empty_body" "NONE" \
   "$(reviewer_loop_finding_touches_contract_surface "" || echo NONE)"
+run_test "1652_parser_whitespace_only_body" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "   " || echo NONE)"
 run_test "1652_parser_case_insensitive" "fail_closed_semantics" \
   "$(reviewer_loop_finding_touches_contract_surface "FAIL-CLOSED required")"
+run_test "1652_parser_acceptance_criteria_title_case" "acceptance_criteria" \
+  "$(reviewer_loop_finding_touches_contract_surface "Acceptance Criteria AC-3 is missing")"
+run_test "1652_parser_code_fence_quoted_term" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface $'```\ndecision gate\n``` is wrong in the spec')"
+run_test "1652_parser_listed_phrase_in_url" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "see https://example.com/decision gate section for details")"
+run_test "1652_parser_bare_word_in_url" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "see https://example.com/scope/section for context" || echo NONE)"
+run_test "1652_parser_quoted_negation_still_matches" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "this is not a decision gate but the matrix row is wrong")"
+run_test "1652_parser_multiline_term_on_last_line" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface $'first line is cosmetic\ndecision matrix row is inconsistent')"
 
 unset _sf_head _sf_other _sf_finding _sf_ledger _sf_is_small
 unset _sf_spec _sf_a _sf_b _sf_c _sf_same_cosmetic _sf_same_contract _sf_nl_body

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2856,6 +2856,8 @@ run_test "1652_s11_stale_head" "stale_head" \
   "$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" "local-ai-reviewer:$_sf_other" | jq -r '.blocked_by')"
 run_test "1652_s11_head_unknown" "head_unknown" \
   "$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" | jq -r '.blocked_by')"
+run_test "1652_s11_head_unknown_when_current_missing" "head_unknown" \
+  "$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "" "local-ai-reviewer:$_sf_head" | jq -r '.blocked_by')"
 run_test "1652_s11_empty_when_small" "" \
   "$(printf '%s\n' "$_sf_a" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2407,6 +2407,8 @@ run_test "cycles_entries_count_no_marker" "0 0 available" \
   "$(reviewer_loop_history_entries_count "$_mc_no_marker_body" "run-x")"
 
 run_test "small_findings_docs_path_non_shipped" "yes" \
+  "$(reviewer_loop_path_is_non_shipped_artifact "docs/other/example.md" && echo yes || echo no)"
+run_test "small_findings_workflow_path_normative_not_non_shipped" "no" \
   "$(reviewer_loop_path_is_non_shipped_artifact "docs/workflow/example.md" && echo yes || echo no)"
 run_test "small_findings_tests_path_non_shipped" "yes" \
   "$(reviewer_loop_path_is_non_shipped_artifact "scripts/development-workflow/tests/test-pr-review-loop.sh" && echo yes || echo no)"
@@ -2429,12 +2431,17 @@ run_test "small_findings_paths_from_output" "docs/a.md tests/b.sh" "$(
   reviewer_loop_blocking_paths_from_output "$_sf_paths_output" 2 | tr '\n' ' ' | sed 's/[[:space:]]$//'
 )"
 
-_sf_history_payload="$(jq -n '{
+_sf_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_sf_history_payload="$(jq -n --arg h "$_sf_head" '{
   schema: "reviewer_loop_history.v1",
   history_status: "available",
   entries: [
-    {iteration: 1, result: "needs_fixes", small_findings_only: true},
-    {iteration: 2, result: "needs_fixes", small_findings_only: true}
+    {iteration: 1, result: "needs_fixes", small_findings_only: true,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]},
+    {iteration: 2, result: "needs_fixes", small_findings_only: true,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}
   ]
 }')"
 _sf_history_body="### Automated Reviewer Loop Summary
@@ -2443,16 +2450,22 @@ _sf_history_body="### Automated Reviewer Loop Summary
 \`\`\`json
 $(printf '%s\n' "$_sf_history_payload" | jq '.')
 \`\`\`"
-run_test "small_findings_prior_consecutive_counts_tail" "2" \
-  "$(reviewer_loop_small_findings_prior_consecutive_count "$_sf_history_body")"
+run_test "small_findings_prior_consecutive_counts_tail" "2 exhausted" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$_sf_history_body" "$_sf_head")")"
 
-_sf_history_interrupted_payload="$(jq -n '{
+_sf_history_interrupted_payload="$(jq -n --arg h "$_sf_head" '{
   schema: "reviewer_loop_history.v1",
   history_status: "available",
   entries: [
-    {iteration: 1, result: "needs_fixes", small_findings_only: true},
-    {iteration: 2, result: "needs_fixes", small_findings_only: false},
-    {iteration: 3, result: "needs_fixes", small_findings_only: true}
+    {iteration: 1, result: "needs_fixes", small_findings_only: true,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]},
+    {iteration: 2, result: "needs_fixes", small_findings_only: false,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]},
+    {iteration: 3, result: "needs_fixes", small_findings_only: true,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}
   ]
 }')"
 _sf_history_interrupted_body="### Automated Reviewer Loop Summary
@@ -2461,8 +2474,8 @@ _sf_history_interrupted_body="### Automated Reviewer Loop Summary
 \`\`\`json
 $(printf '%s\n' "$_sf_history_interrupted_payload" | jq '.')
 \`\`\`"
-run_test "small_findings_prior_consecutive_stops_at_non_tail" "1" \
-  "$(reviewer_loop_small_findings_prior_consecutive_count "$_sf_history_interrupted_body")"
+run_test "small_findings_prior_consecutive_stops_at_non_tail" "1 not_small" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$_sf_history_interrupted_body" "$_sf_head")")"
 run_test "small_findings_main_branch_requires_zero_thread_audit" "yes" \
   "$(
     _sf_loop_src="$(cat "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
@@ -2474,6 +2487,409 @@ run_test "small_findings_main_branch_requires_zero_thread_audit" "yes" \
   )"
 unset _sf_paths_output _sf_history_payload _sf_history_body
 unset _sf_history_interrupted_payload _sf_history_interrupted_body _sf_loop_src
+# _sf_head kept for #1652 scenario block below
+
+# ===========================================================================
+# #1652 small-finding terminal policy scenarios (1-11, 14 + sub-scenarios)
+# ===========================================================================
+_sf_other="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+_sf_finding() {
+  jq -cn --arg path "$1" --arg platform "${2:-local-ai-reviewer}" --arg body "${3:-}" \
+    '{path: $path, platform: $platform, body: $body}'
+}
+_sf_ledger() {
+  printf '%s\n' "### Automated Reviewer Loop Summary
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+$(printf '%s\n' "$1" | jq '.')
+\`\`\`"
+}
+_sf_is_small() {
+  if printf '%s\n' "$@" | reviewer_loop_all_findings_are_small; then echo yes; else echo no; fi
+}
+
+# --- Scenario 1: normative document patterns ---
+for _p in \
+  "REVIEW.md" "AGENTS.md" "CLAUDE.md" "GEMINI.md" "LLM_RULES.md" ".ai-dev-workflow.yaml" \
+  "docs/workflow/protocols/x.md" "docs/best-practices/1-general.md" \
+  "docs/specs/developments/x/1_x_specs.md" "docs/testing/workflow/x.smoke-test.md" \
+  "docs/project/1-business-domain.md"; do
+  run_test "1652_s1_normative_${_p//\//_}" "yes" \
+    "$(reviewer_loop_path_is_normative_document "$_p" && echo yes || echo no)"
+done
+for _p in "tests/fixtures/x.json" "__snapshots__/x.snap" "CHANGELOG.md" "scripts/development-workflow/pr-review-loop.sh"; do
+  run_test "1652_s1_reject_${_p//\//_}" "no" \
+    "$(reviewer_loop_path_is_normative_document "$_p" && echo yes || echo no)"
+done
+
+# --- Scenario 2: normative path never small ---
+_sf_spec="docs/specs/developments/x/1_x_specs.md"
+run_test "1652_s2_matrix_body" "no" \
+  "$(_sf_is_small "$(_sf_finding "$_sf_spec" local-ai-reviewer "the decision matrix is wrong")")"
+run_test "1652_s2_trailing_whitespace" "no" \
+  "$(_sf_is_small "$(_sf_finding "$_sf_spec" local-ai-reviewer "trailing whitespace")")"
+run_test "1652_s2_no_listed_term" "no" \
+  "$(_sf_is_small "$(_sf_finding "$_sf_spec" local-ai-reviewer "required error handling is missing")")"
+
+# --- Scenario 3: non-normative non-shipped CHANGELOG ---
+run_test "1652_s3_changelog_cosmetic_small" "yes" \
+  "$(_sf_is_small "$(_sf_finding "CHANGELOG.md" local-ai-reviewer "trailing whitespace")")"
+run_test "1652_s3_changelog_contract_not_small" "no" \
+  "$(_sf_is_small "$(_sf_finding "CHANGELOG.md" local-ai-reviewer "the decision matrix is wrong")")"
+
+# --- Scenario 4: contract-surface table ---
+run_test "1652_s4_acceptance" "acceptance_criteria" \
+  "$(reviewer_loop_finding_touches_contract_surface "missing acceptance criteria here")"
+run_test "1652_s4_decision" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "broken decision gate")"
+run_test "1652_s4_parser" "parser_and_input_behavior" \
+  "$(reviewer_loop_finding_touches_contract_surface "parser mishandles input")"
+run_test "1652_s4_scope" "scope_and_coverage" \
+  "$(reviewer_loop_finding_touches_contract_surface "this is out of scope")"
+run_test "1652_s4_fail_closed" "fail_closed_semantics" \
+  "$(reviewer_loop_finding_touches_contract_surface "not fail-closed")"
+run_test "1652_s4_state" "state_and_status_models" \
+  "$(reviewer_loop_finding_touches_contract_surface "invalid state machine transition")"
+run_test "1652_s4_telemetry" "telemetry_and_contracts" \
+  "$(reviewer_loop_finding_touches_contract_surface "stdout key missing")"
+run_test "1652_s4_proof" "proof_obligations" \
+  "$(reviewer_loop_finding_touches_contract_surface "missing proof obligation")"
+run_test "1652_s4_reject_typo" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "typo in heading" || echo NONE)"
+run_test "1652_s4_reject_trailing" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "trailing whitespace" || echo NONE)"
+run_test "1652_s4_reject_caps" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "heading capitalisation" || echo NONE)"
+
+# --- Scenario 4a: portable boundaries (POSIX, not \b) ---
+run_test "1652_s4a_decision_gate_matches" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "a decision gate failed")"
+run_test "1652_s4a_delegates_no_match" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "the agent delegates work" || echo NONE)"
+
+# --- Scenario 4b: multi-digit AC identifiers ---
+for _ac in "AC-1" "AC-9" "AC-10" "AC-147"; do
+  run_test "1652_s4b_${_ac}" "acceptance_criteria" \
+    "$(reviewer_loop_finding_touches_contract_surface "criterion ${_ac} unmet")"
+done
+run_test "1652_s4b_AC_alone" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "see AC- alone" || echo NONE)"
+
+# --- Scenario 5: contract on CHANGELOG is not small ---
+run_test "1652_s5_changelog_contract" "no" \
+  "$(_sf_is_small "$(_sf_finding "CHANGELOG.md" x "touches a decision matrix")")"
+
+# --- Scenario 6: cosmetic on CHANGELOG is small ---
+run_test "1652_s6_changelog_cosmetic" "yes" \
+  "$(_sf_is_small "$(_sf_finding "CHANGELOG.md" x "trailing whitespace")")"
+
+# --- Scenario 6a: bare common words still small ---
+for _pair in \
+  "state|the heading state is inconsistent" \
+  "scope|a typo in the scope section" \
+  "status|the status column is misaligned" \
+  "gate|the gate heading needs a capital" \
+  "proof|fix the proof reading typo" \
+  "parse|parse is misspelled here" \
+  "contract|the contract section has a trailing space"; do
+  _word="${_pair%%|*}"
+  _body="${_pair#*|}"
+  run_test "1652_s6a_bare_${_word}" "NONE" \
+    "$(reviewer_loop_finding_touches_contract_surface "$_body" || echo NONE)"
+  run_test "1652_s6a_small_${_word}" "yes" \
+    "$(_sf_is_small "$(_sf_finding "CHANGELOG.md" x "$_body")")"
+done
+
+# --- Scenario 7: all_findings_are_small mixed ---
+_sf_a="$(_sf_finding "CHANGELOG.md" a "trailing whitespace")"
+_sf_b="$(_sf_finding "tests/x.sh" b "typo")"
+_sf_c="$(_sf_finding "CHANGELOG.md" c "decision matrix wrong")"
+run_test "1652_s7_all_small" "yes" "$(_sf_is_small "$_sf_a" "$_sf_b")"
+run_test "1652_s7_one_not_small" "no" "$(_sf_is_small "$_sf_a" "$_sf_b" "$_sf_c")"
+
+# --- Scenario 7f: empty array / empty path fail-closed ---
+run_test "1652_s7f_empty_array" "no" \
+  "$(printf '' | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+run_test "1652_s7f_empty_path" "no" \
+  "$(_sf_is_small "$(_sf_finding "" x "trailing whitespace")" "$_sf_a")"
+
+# --- Scenario 7a: same path, cosmetic + contract — not deduped ---
+_sf_same_cosmetic="$(_sf_finding "CHANGELOG.md" a "trailing whitespace")"
+_sf_same_contract="$(_sf_finding "CHANGELOG.md" a "decision matrix wrong")"
+run_test "1652_s7a_pairing_survives" "no" \
+  "$(_sf_is_small "$_sf_same_cosmetic" "$_sf_same_contract")"
+
+# --- Scenario 7b / 7b-i: \n normalisation ---
+_sf_nl_body='some prose\ndecision matrix is wrong'
+run_test "1652_s7b_normalized_match" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "$(reviewer_loop_normalize_finding_body_for_match "$_sf_nl_body")")"
+run_test "1652_s7b_raw_would_miss" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "$_sf_nl_body" || echo NONE)"
+run_test "1652_s7bi_same_either_way" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "$(reviewer_loop_normalize_finding_body_for_match "$_sf_nl_body")")"
+
+# --- Scenario 7d: hostile characters in JSON fields ---
+_sf_tab_path=$'docs/notes/x.md\textra'
+_sf_tab_body=$'decision matrix\there'
+_sf_quote_body='says "decision matrix" clearly'
+_sf_bs_body='path\\decision matrix ok'
+run_test "1652_s7d_tab_path" "no" \
+  "$(_sf_is_small "$(_sf_finding "$_sf_tab_path" x "decision matrix wrong")")"
+# Prove the path survived JSON round-trip (still contains a tab) and classification
+# used the body contract term (blocked_by=contract_surface, not shipped_path).
+run_test "1652_s7d_tab_path_intact_fields" "contract_surface" \
+  "$(printf '%s\n' "$(_sf_finding "$_sf_tab_path" x "decision matrix wrong")" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+run_test "1652_s7d_tab_path_has_tab" "yes" \
+  "$(printf '%s' "$(_sf_finding "$_sf_tab_path" x "x")" | jq -r '.path' | grep -Fq $'\t' && echo yes || echo no)"
+run_test "1652_s7d_tab_body" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "$(reviewer_loop_normalize_finding_body_for_match "$_sf_tab_body")")"
+run_test "1652_s7d_quote_body" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "$_sf_quote_body")"
+run_test "1652_s7d_backslash_body" "decision_gates_and_matrices" \
+  "$(reviewer_loop_finding_touches_contract_surface "$_sf_bs_body")"
+
+# --- Scenario 7c: platform attribution in content analysis ---
+_sf_plat="$(_sf_finding "CHANGELOG.md" "coderabbit" "decision matrix wrong")"
+run_test "1652_s7c_platform_on_record" "coderabbit" \
+  "$(printf '%s' "$_sf_plat" | jq -r '.platform')"
+run_test "1652_s7c_not_small" "no" "$(_sf_is_small "$_sf_plat")"
+
+# --- Scenario 7e: stored body is raw, not normalised ---
+_sf_raw_out="$(reviewer_loop_blocking_findings_from_output \
+  $'RESULT=needs_fixes\nBLOCKING_COUNT=1\nBLOCKING_1_PATH=CHANGELOG.md\nBLOCKING_1_BODY=some prose\\ndecision matrix is wrong' \
+  1 local-ai-reviewer)"
+run_test "1652_s7e_raw_body_preserved" "some prose\\ndecision matrix is wrong" \
+  "$(printf '%s' "$_sf_raw_out" | jq -r '.body')"
+
+# --- Scenario 8: prior count stops at stale head ---
+_sf_s8_payload="$(jq -n --arg h "$_sf_head" --arg o "$_sf_other" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [
+    {iteration: 1, small_findings_only: true, classification_head: $o,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $o, state: "current", reason: ""}]},
+    {iteration: 2, small_findings_only: true, classification_head: $o,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $o, state: "current", reason: ""}]},
+    {iteration: 3, small_findings_only: true, classification_head: $h,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}
+  ]
+}')"
+run_test "1652_s8_stale_stops_count" "1 stale_head" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8_payload")" "$_sf_head")")"
+
+# --- Scenario 8a: current-round head check ---
+run_test "1652_s8a_both_current" "ok" \
+  "$(printf '%s\n' "coderabbit" "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" \
+      "coderabbit:$_sf_head" "local-ai-reviewer:$_sf_head" | jq -r '.status')"
+run_test "1652_s8a_one_stale" "stale_head" \
+  "$(printf '%s\n' "coderabbit" "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" \
+      "coderabbit:$_sf_other" "local-ai-reviewer:$_sf_head" | jq -r '.blocked_by')"
+run_test "1652_s8a_one_unknown" "head_unknown" \
+  "$(printf '%s\n' "coderabbit" "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" \
+      "local-ai-reviewer:$_sf_head" | jq -r '.blocked_by')"
+run_test "1652_s8a_both_stale" "stale_head" \
+  "$(printf '%s\n' "coderabbit" "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" \
+      "coderabbit:$_sf_other" "local-ai-reviewer:$_sf_other" | jq -r '.blocked_by')"
+
+# --- Scenario 8b: contributing platforms only ---
+_sf_s8b_ok="$(jq -n --arg h "$_sf_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, classification_head: $h,
+    contributing_platforms: ["local-ai-reviewer", "coderabbit"],
+    reviewed_heads: [
+      {platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""},
+      {platform: "coderabbit", reviewed_head: $h, state: "current", reason: ""},
+      {platform: "pr-agent", reviewed_head: "", state: "not-reported", reason: ""}
+    ]}]
+}')"
+run_test "1652_s8b_both_current" "1 exhausted" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8b_ok")" "$_sf_head")")"
+_sf_s8b_stale="$(jq -n --arg h "$_sf_head" --arg o "$_sf_other" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, classification_head: $h,
+    contributing_platforms: ["local-ai-reviewer", "coderabbit"],
+    reviewed_heads: [
+      {platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""},
+      {platform: "coderabbit", reviewed_head: $o, state: "not-current", reason: "head_mismatch"}
+    ]}]
+}')"
+run_test "1652_s8b_one_stale" "0 stale_head" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8b_stale")" "$_sf_head")")"
+_sf_s8b_noncontrib="$(jq -n --arg h "$_sf_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, classification_head: $h,
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [
+      {platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""},
+      {platform: "coderabbit", reviewed_head: "", state: "not-reported", reason: ""}
+    ]}]
+}')"
+run_test "1652_s8b_noncontributor_ignored" "1 exhausted" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8b_noncontrib")" "$_sf_head")")"
+_sf_s8b_absent="$(jq -n --arg h "$_sf_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, classification_head: $h,
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}]
+}')"
+run_test "1652_s8b_absent_contributing" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8b_absent")" "$_sf_head")")"
+
+# --- Scenario 8c: classification_head, never head_sha ---
+_sf_s8c_stale_class="$(jq -n --arg h "$_sf_head" --arg o "$_sf_other" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, head_sha: $h, classification_head: $o,
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $o, state: "current", reason: ""}]}]
+}')"
+run_test "1652_s8c_ignores_head_sha_match" "0 stale_head" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8c_stale_class")" "$_sf_head")")"
+_sf_s8c_ok_class="$(jq -n --arg h "$_sf_head" --arg o "$_sf_other" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, head_sha: $o, classification_head: $h,
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}]
+}')"
+run_test "1652_s8c_uses_classification_head" "1 exhausted" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8c_ok_class")" "$_sf_head")")"
+
+# --- Scenario 9: unknown heads ---
+_sf_s9_absent="$(jq -n '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true,
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", state: "current", reason: ""}]}]
+}')"
+run_test "1652_s9_absent_classification" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s9_absent")" "$_sf_head")")"
+_sf_s9_empty="$(jq -n --arg h "$_sf_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, classification_head: "",
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}]
+}')"
+run_test "1652_s9_empty_classification" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s9_empty")" "$_sf_head")")"
+_sf_s9_placeholder="$(jq -n --arg h "$_sf_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [{iteration: 1, small_findings_only: true, classification_head: "unknown-123-1-2",
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}]
+}')"
+run_test "1652_s9_placeholder" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s9_placeholder")" "$_sf_head")")"
+
+# --- Scenario 9a: stop reasons closed set ---
+run_test "1652_s9a_exhausted" "exhausted" \
+  "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8b_ok")" "$_sf_head" | jq -r '.stop_reason')"
+_sf_s9a_interrupted="$(jq -n --arg h "$_sf_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [
+    {iteration: 1, small_findings_only: true, classification_head: $h,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]},
+    {iteration: 2, small_findings_only: false, classification_head: $h,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]},
+    {iteration: 3, small_findings_only: true, classification_head: $h,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}
+  ]
+}')"
+run_test "1652_s9a_not_small" "not_small" \
+  "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s9a_interrupted")" "$_sf_head" | jq -r '.stop_reason')"
+run_test "1652_s9a_stale" "stale_head" \
+  "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s8_payload")" "$_sf_head" | jq -r '.stop_reason')"
+run_test "1652_s9a_unknown" "head_unknown" \
+  "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s9_placeholder")" "$_sf_head" | jq -r '.stop_reason')"
+
+# --- Scenario 9b: malformed counter output fail-closed ---
+run_test "1652_s9b_malformed" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count 'not-json')"
+run_test "1652_s9b_missing_field" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count '{"count":2}')"
+run_test "1652_s9b_bad_reason" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count '{"count":2,"stop_reason":"nope"}')"
+
+# --- Scenario 10a: within-group precedence ---
+_sf_shipped="$(_sf_finding "scripts/development-workflow/pr-review-loop.sh" a "decision matrix")"
+_sf_contract="$(_sf_finding "CHANGELOG.md" b "decision matrix")"
+run_test "1652_s10a_content_shipped_wins" "shipped_path" \
+  "$(printf '%s\n' "$_sf_shipped" "$_sf_contract" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+run_test "1652_s10a_content_names_both" "yes" \
+  "$(
+    j="$(printf '%s\n' "$_sf_shipped" "$_sf_contract" | reviewer_loop_small_findings_content_analysis)"
+    sp="$(printf '%s' "$j" | jq -r '.shipped_paths | length')"
+    cs="$(printf '%s' "$j" | jq -r '.contract_surfaces | length')"
+    if [ "$sp" -ge 1 ] && [ "$cs" -ge 1 ]; then echo yes; else echo "sp=$sp cs=$cs"; fi
+  )"
+run_test "1652_s10a_currency_stale_wins" "stale_head" \
+  "$(printf '%s\n' "coderabbit" "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" \
+      "coderabbit:$_sf_other" | jq -r '.blocked_by')"
+run_test "1652_s10a_currency_names_both" "yes" \
+  "$(
+    j="$(printf '%s\n' "coderabbit" "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" \
+      "coderabbit:$_sf_other")"
+    d="$(printf '%s' "$j" | jq -r '.details | join("|")')"
+    if [[ "$d" == *stale_head:coderabbit* ]] && [[ "$d" == *head_unknown:local-ai-reviewer* ]]; then echo yes; else echo "$d"; fi
+  )"
+# Groups mutually exclusive: contract finding means currency never evaluated for blocked_by key
+run_test "1652_s10a_groups_exclusive" "contract_surface" \
+  "$(printf '%s\n' "$_sf_contract" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+
+# --- Scenario 10b: surface identity print ---
+run_test "1652_s10b_identity" "fail_closed_semantics" \
+  "$(reviewer_loop_finding_touches_contract_surface "must be fail-closed")"
+run_test "1652_s10b_no_match_silent" "" \
+  "$(reviewer_loop_finding_touches_contract_surface "trailing whitespace" || true)"
+run_test "1652_s10b_first_wins" "acceptance_criteria" \
+  "$(reviewer_loop_finding_touches_contract_surface "acceptance criteria and decision matrix both mentioned")"
+
+# --- Scenario 11: BLOCKED_BY values via content analysis / counter ---
+run_test "1652_s11_shipped_path" "shipped_path" \
+  "$(printf '%s\n' "$_sf_shipped" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+run_test "1652_s11_contract_surface" "contract_surface" \
+  "$(printf '%s\n' "$_sf_contract" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+run_test "1652_s11_stale_head" "stale_head" \
+  "$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" "local-ai-reviewer:$_sf_other" | jq -r '.blocked_by')"
+run_test "1652_s11_head_unknown" "head_unknown" \
+  "$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_sf_head" | jq -r '.blocked_by')"
+run_test "1652_s11_empty_when_small" "" \
+  "$(printf '%s\n' "$_sf_a" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+
+# --- Scenario 14: pre-change ledger without contributing_platforms / head ---
+_sf_s14="$(jq -n '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [
+    {iteration: 1, small_findings_only: true},
+    {iteration: 2, small_findings_only: true}
+  ]
+}')"
+run_test "1652_s14_prechange_ends_run" "0 head_unknown" \
+  "$(reviewer_loop_parse_small_findings_count "$(reviewer_loop_small_findings_prior_consecutive_count "$(_sf_ledger "$_sf_s14")" "$_sf_head")")"
+
+# Parser-risk addendum negatives
+run_test "1652_parser_microscope" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "look into the microscope carefully" || echo NONE)"
+run_test "1652_parser_failXclosed" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "failXclosed is wrong" || echo NONE)"
+run_test "1652_parser_allow_list_unhyphenated" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "the allow list is incomplete" || echo NONE)"
+run_test "1652_parser_empty_body" "NONE" \
+  "$(reviewer_loop_finding_touches_contract_surface "" || echo NONE)"
+run_test "1652_parser_case_insensitive" "fail_closed_semantics" \
+  "$(reviewer_loop_finding_touches_contract_surface "FAIL-CLOSED required")"
+
+unset _sf_head _sf_other _sf_finding _sf_ledger _sf_is_small
+unset _sf_spec _sf_a _sf_b _sf_c _sf_same_cosmetic _sf_same_contract _sf_nl_body
+unset _sf_tab_path _sf_tab_body _sf_quote_body _sf_bs_body _sf_plat _sf_raw_out
+unset _sf_s8_payload _sf_s8b_ok _sf_s8b_stale _sf_s8b_noncontrib _sf_s8b_absent
+unset _sf_s8c_stale_class _sf_s8c_ok_class _sf_s9_absent _sf_s9_empty _sf_s9_placeholder
+unset _sf_shipped _sf_contract _sf_s14 _sf_s9a_interrupted _p _ac _pair _word _body
+
+
 
 _mc_marker_no_json_body=$'### Automated Reviewer Loop Summary\n<!-- reviewer-loop-history:v1 -->\nNo fenced JSON block here.'
 run_test "cycles_entries_count_marker_no_json" "-1 -1 unavailable" \

--- a/scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
+++ b/scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-small-finding-terminal-policy.sh — #1661 regression replays for #1652.
+# covers: scripts/development-workflow/pr-review-loop.sh
+# covers: docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+#
+# Scenarios 12, 12a, and 13 from the implementation plan.
+# shellcheck shell=bash disable=SC2034
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name — expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+export MOCK_REPO_ROOT="$REPO_ROOT"
+# shellcheck source=scripts/development-workflow/pr-review-loop.sh
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_other="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+_finding() {
+  jq -cn --arg path "$1" --arg platform "$2" --arg body "$3" \
+    '{path: $path, platform: $platform, body: $body}'
+}
+
+_ledger_body() {
+  local payload="$1"
+  printf '%s\n' "### Automated Reviewer Loop Summary
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+$(printf '%s\n' "$payload" | jq '.')
+\`\`\`"
+}
+
+_entry() {
+  local iter="$1" path="$2" body="$3"
+  jq -n --argjson iter "$iter" --arg h "$_head" --arg path "$path" --arg body "$body" '{
+    iteration: $iter,
+    result: "needs_fixes",
+    small_findings_only: true,
+    classification_head: $h,
+    contributing_platforms: ["local-ai-reviewer"],
+    reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}],
+    small_findings_paths: [$path],
+    blocking_count: 1
+  }'
+}
+
+echo "=== test-small-finding-terminal-policy (#1652 scenarios 12/12a/13) ==="
+
+# --- Scenario 12: #1661 regression — tier 1 (normative paths) ---
+# Consecutive rounds whose only findings are on docs/specs/developments/**
+# must NOT be small, so the terminal rule cannot fire.
+_s12_f1="$(_finding "docs/specs/developments/x/1_x_specs.md" "local-ai-reviewer" "fail-closed semantics broken on deny-list")"
+_s12_f2="$(_finding "docs/specs/developments/x/1_x_specs.md" "local-ai-reviewer" "decision matrix row is wrong")"
+_s12_f3="$(_finding "docs/specs/developments/x/1_x_specs.md" "local-ai-reviewer" "acceptance criteria AC-10 unmet")"
+run_test "1652_s12_normative_not_small_fail_closed" "no" \
+  "$(printf '%s\n' "$_s12_f1" | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+run_test "1652_s12_normative_not_small_matrix" "no" \
+  "$(printf '%s\n' "$_s12_f2" | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+run_test "1652_s12_normative_not_small_ac" "no" \
+  "$(printf '%s\n' "$_s12_f3" | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+# Even with cosmetic body on normative path — still not small (tier 1).
+_s12_cosmetic="$(_finding "docs/specs/developments/x/1_x_specs.md" "local-ai-reviewer" "trailing whitespace")"
+run_test "1652_s12_normative_cosmetic_still_not_small" "no" \
+  "$(printf '%s\n' "$_s12_cosmetic" | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+# Content analysis reports shipped_path (normative excluded from non-shipped).
+run_test "1652_s12_blocked_by_shipped_path" "shipped_path" \
+  "$(printf '%s\n' "$_s12_f1" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+
+# --- Scenario 12a: tier-2 isolation on CHANGELOG.md with #1661 bodies ---
+_s12a_f1="$(_finding "CHANGELOG.md" "local-ai-reviewer" "fail-closed semantics broken on deny-list")"
+_s12a_f2="$(_finding "CHANGELOG.md" "local-ai-reviewer" "decision matrix row is wrong")"
+_s12a_f3="$(_finding "CHANGELOG.md" "local-ai-reviewer" "acceptance criteria AC-10 unmet")"
+run_test "1652_s12a_changelog_contract_not_small" "no" \
+  "$(printf '%s\n' "$_s12a_f1" "$_s12a_f2" "$_s12a_f3" | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+run_test "1652_s12a_blocked_by_contract_surface" "contract_surface" \
+  "$(printf '%s\n' "$_s12a_f1" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+# Simulate two prior "would-be-small" ledger rounds + current contract findings:
+# content analysis keeps the round non-small, so terminal cannot fire.
+_s12a_payload="$(jq -n --arg h "$_head" '{
+  schema: "reviewer_loop_history.v1",
+  history_status: "available",
+  entries: [
+    {iteration: 1, result: "needs_fixes", small_findings_only: true,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]},
+    {iteration: 2, result: "needs_fixes", small_findings_only: true,
+     classification_head: $h, contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h, state: "current", reason: ""}]}
+  ]
+}')"
+_s12a_all_small="$(printf '%s\n' "$_s12a_f1" "$_s12a_f2" | reviewer_loop_all_findings_are_small && echo 1 || echo 0)"
+run_test "1652_s12a_terminal_cannot_fire" "0" "$_s12a_all_small"
+
+# --- Scenario 13: cosmetic counter-case on same CHANGELOG.md path ---
+_s13_f1="$(_finding "CHANGELOG.md" "local-ai-reviewer" "trailing whitespace on bullet")"
+_s13_f2="$(_finding "CHANGELOG.md" "local-ai-reviewer" "typo in heading")"
+_s13_f3="$(_finding "CHANGELOG.md" "local-ai-reviewer" "heading capitalisation")"
+run_test "1652_s13_cosmetic_changelog_is_small" "yes" \
+  "$(printf '%s\n' "$_s13_f1" "$_s13_f2" "$_s13_f3" | reviewer_loop_all_findings_are_small && echo yes || echo no)"
+# With one prior small round on current head, rounds = 2 → terminal may fire.
+_s13_count="$(reviewer_loop_parse_small_findings_count "$(
+  reviewer_loop_small_findings_prior_consecutive_count "$(_ledger_body "$_s12a_payload")" "$_head"
+)")"
+run_test "1652_s13_prior_count_ready" "2 exhausted" "$_s13_count"
+# Current-round heads OK for the cosmetic contributor.
+_s13_heads="$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_head" "local-ai-reviewer:$_head")"
+run_test "1652_s13_current_heads_ok" "ok" "$(printf '%s' "$_s13_heads" | jq -r '.status')"
+# Pairing with 12a: same path/head/shape, only bodies differ → opposite outcome.
+run_test "1652_s13_opposite_of_12a" "yes" \
+  "$(
+    a="$(printf '%s\n' "$_s12a_f1" | reviewer_loop_all_findings_are_small && echo small || echo not)"
+    b="$(printf '%s\n' "$_s13_f1" | reviewer_loop_all_findings_are_small && echo small || echo not)"
+    if [ "$a" = "not" ] && [ "$b" = "small" ]; then echo yes; else echo "a=$a b=$b"; fi
+  )"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
+++ b/scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
@@ -49,8 +49,8 @@ $(printf '%s\n' "$payload" | jq '.')
 
 _evaluate_terminal() {
   local ledger_body="$1"
-  local findings="$2"
-  printf '%s\n' "$findings" \
+  local _finding_lines="$2"
+  printf '%s\n' "$_finding_lines" \
     | reviewer_loop_evaluate_small_findings_terminal \
         "$ledger_body" "$_head" 2 0 "local-ai-reviewer:$_head"
 }

--- a/scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
+++ b/scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
@@ -47,6 +47,14 @@ $(printf '%s\n' "$payload" | jq '.')
 \`\`\`"
 }
 
+_evaluate_terminal() {
+  local ledger_body="$1"
+  local findings="$2"
+  printf '%s\n' "$findings" \
+    | reviewer_loop_evaluate_small_findings_terminal \
+        "$ledger_body" "$_head" 2 0 "local-ai-reviewer:$_head"
+}
+
 _entry() {
   local iter="$1" path="$2" body="$3"
   jq -n --argjson iter "$iter" --arg h "$_head" --arg path "$path" --arg body "$body" '{
@@ -82,6 +90,24 @@ run_test "1652_s12_normative_cosmetic_still_not_small" "no" \
 # Content analysis reports shipped_path (normative excluded from non-shipped).
 run_test "1652_s12_blocked_by_shipped_path" "shipped_path" \
   "$(printf '%s\n' "$_s12_f1" | reviewer_loop_small_findings_content_analysis | jq -r '.blocked_by')"
+# Production terminal branch: normative contract findings must not reach clean.
+_s12_ledger="$(_ledger_body "$(jq -n --arg h "$_head" '{
+  schema: "reviewer_loop_history.v1", history_status: "available",
+  entries: [
+    {iteration: 1, small_findings_only: true, classification_head: $h,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h}]},
+    {iteration: 2, small_findings_only: true, classification_head: $h,
+     contributing_platforms: ["local-ai-reviewer"],
+     reviewed_heads: [{platform: "local-ai-reviewer", reviewed_head: $h}]}
+  ]
+}')")"
+run_test "1652_s12_terminal_result_needs_fixes" "needs_fixes" \
+  "$(_evaluate_terminal "$_s12_ledger" "$_s12_f1" | jq -r '.result')"
+run_test "1652_s12_terminal_stop_not_set" "false" \
+  "$(_evaluate_terminal "$_s12_ledger" "$_s12_f1" | jq -r '.small_findings_stop')"
+run_test "1652_s12_terminal_blocked_by" "shipped_path" \
+  "$(_evaluate_terminal "$_s12_ledger" "$_s12_f1" | jq -r '.small_findings_blocked_by')"
 
 # --- Scenario 12a: tier-2 isolation on CHANGELOG.md with #1661 bodies ---
 _s12a_f1="$(_finding "CHANGELOG.md" "local-ai-reviewer" "fail-closed semantics broken on deny-list")"
@@ -107,6 +133,12 @@ _s12a_payload="$(jq -n --arg h "$_head" '{
 }')"
 _s12a_all_small="$(printf '%s\n' "$_s12a_f1" "$_s12a_f2" | reviewer_loop_all_findings_are_small && echo 1 || echo 0)"
 run_test "1652_s12a_terminal_cannot_fire" "0" "$_s12a_all_small"
+run_test "1652_s12a_terminal_result_needs_fixes" "needs_fixes" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s12a_f1" | jq -r '.result')"
+run_test "1652_s12a_terminal_reason_empty" "" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s12a_f1" | jq -r '.reason')"
+run_test "1652_s12a_terminal_blocked_by_contract" "contract_surface" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s12a_f1" | jq -r '.small_findings_blocked_by')"
 
 # --- Scenario 13: cosmetic counter-case on same CHANGELOG.md path ---
 _s13_f1="$(_finding "CHANGELOG.md" "local-ai-reviewer" "trailing whitespace on bullet")"
@@ -122,6 +154,15 @@ run_test "1652_s13_prior_count_ready" "2 exhausted" "$_s13_count"
 # Current-round heads OK for the cosmetic contributor.
 _s13_heads="$(printf '%s\n' "local-ai-reviewer" | reviewer_loop_current_round_heads_ok "$_head" "local-ai-reviewer:$_head")"
 run_test "1652_s13_current_heads_ok" "ok" "$(printf '%s' "$_s13_heads" | jq -r '.status')"
+# Production terminal branch: cosmetic CHANGELOG tail with sufficient prior rounds fires clean.
+run_test "1652_s13_terminal_result_clean" "clean" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s13_f1" | jq -r '.result')"
+run_test "1652_s13_terminal_reason" "small_findings_terminal" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s13_f1" | jq -r '.reason')"
+run_test "1652_s13_terminal_stop_set" "true" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s13_f1" | jq -r '.small_findings_stop')"
+run_test "1652_s13_terminal_blocked_by_empty" "" \
+  "$(_evaluate_terminal "$(_ledger_body "$_s12a_payload")" "$_s13_f1" | jq -r '.small_findings_blocked_by')"
 # Pairing with 12a: same path/head/shape, only bodies differ → opposite outcome.
 run_test "1652_s13_opposite_of_12a" "yes" \
   "$(


### PR DESCRIPTION
## Summary

- Implement two-tier small-finding classification in `pr-review-loop.sh`: blocking findings on normative documents are never small; on other non-shipped paths, contract-surface findings are escalated while cosmetic ones may still terminate the tail.
- Require current-head evidence (`classification_head`, `contributing_platforms[]`, `reviewed_heads[]` from #1648) for both prior counted rounds and the deciding round before `small_findings_terminal` may mark clean.
- Add `SMALL_FINDINGS_BLOCKED_BY` reporting, ledger `contributing_platforms[]`, Protocol 93 / REVIEW.md documentation, changelog fragment, and regression suites.

## Cross-cutting assumptions

- **#1648 conflict**: Resolved by sequencing — #1648 merged on `develop-internal-reviewer-effectiveness`. **Still valid** before implementation.

## Planted-violation proofs (P1–P22)

Each proof is encoded in the automated harness per the implementation plan. Scenarios fail with the planted violation and pass once restored.

| Proofs | Harness coverage |
| --- | --- |
| P1, P12, P6 | Scenarios 1–3, 1652 normative tier |
| P2, P3, P14, P20, P13 | Scenarios 4–6a, parser-risk addendum |
| P15, P16, P17, P18, P22 | Scenarios 7, 7a–7f |
| P4, P5, P10, P11, P19, P21 | Scenarios 8–9, 8b–8c, 9a–9b |
| P8, P9 | Scenarios 8a, 10a |
| P7 | Scenario 6a |
| P12 replay tier-1 | `test-small-finding-terminal-policy.sh` scenario 12 |
| P14 tier-2 | scenario 12a |
| P6 restrictive counter | scenario 13 |

Commands:

```bash
bash scripts/development-workflow/tests/test-pr-review-loop.sh
bash scripts/development-workflow/tests/test-small-finding-terminal-policy.sh
shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh
```

Latest run: **1551 passed, 0 failed** (test-pr-review-loop) + **12 passed** (replay suite); shellcheck clean.

## Test plan

- [x] `test-pr-review-loop.sh` — 1551 passed
- [x] `test-small-finding-terminal-policy.sh` — 12 passed
- [x] shellcheck on `pr-review-loop.sh`
- [x] Planted-violation proofs P1–P22 mapped to harness scenarios above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fail-closed merge-readiness automation in `pr-review-loop.sh` (when outstanding blockers can be ignored); mistakes could let contract/spec issues terminate the loop or block legitimate tails.
> 
> **Overview**
> Tightens when `pr-review-loop.sh` may exit **clean** via `small_findings_terminal`: blocking findings are no longer “small” just because they sit on docs/tests.
> 
> **Two-tier classification** applies only to blocking findings. Paths under normative trees (`REVIEW.md`, workflow/spec/plan docs, agent config, etc.) are **never** small. Other non-shipped paths (e.g. `CHANGELOG.md`, fixtures) can still be small unless the finding body matches an allow-listed **contract surface** (acceptance criteria, decision gates, fail-closed semantics, and similar) via POSIX word-boundary grep. Findings are aggregated as per-platform JSON `{path, platform, body}`; bodies are normalized only at match time.
> 
> **Head currency** is required: consecutive qualifying rounds and the deciding round must align on `loop_head_sha` using ledger `classification_head`, new `contributing_platforms[]`, and per-platform `reviewed_heads[]`. When the rule does not fire, the script emits **`SMALL_FINDINGS_BLOCKED_BY`** (`shipped_path`, `contract_surface`, `stale_head`, `head_unknown`) with richer PR summary text.
> 
> Protocol 93 and `REVIEW.md` document the policy; changelog fragment added. Coverage expands in `test-pr-review-loop.sh` plus dedicated `test-small-finding-terminal-policy.sh` (#1661 regression scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41dee9d937d28cd6ee64b204546d5a37d0afa0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->