### PR TITLE
feat(reviewer): extract Codex finding patterns into local review doctrine (#1654)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -22,6 +22,8 @@ on:
       - 'package-lock.json'
       - 'scripts/lint/markdown-heuristic-lint.py'
       - 'scripts/lint/check-changelog-duplicate-headers.sh'
+      - 'docs/workflow/development-workflow/review-doctrine.md'
+      - 'scripts/lint/review-doctrine-lint.sh'
 
 jobs:
   markdown-lint:
@@ -92,3 +94,6 @@ jobs:
 
       - name: Check CHANGELOG for duplicate section headers
         run: bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
+
+      - name: Lint review doctrine catalogue
+        run: bash scripts/lint/review-doctrine-lint.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -51,6 +51,9 @@ jobs:
           printf '  %s\n' "${shell_files[@]}"
           shellcheck --severity=warning "${shell_files[@]}"
 
+      - name: Run ShellCheck on review doctrine linter
+        run: shellcheck --severity=warning scripts/lint/review-doctrine-lint.sh
+
       - name: Run workflow shell guard lint tests
         run: bash scripts/lint/tests/test-workflow-shell-guard-lint.sh
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/lint/tests/test-workflow-shell-guard-lint.sh'
       - 'scripts/lint/workflow-shell-snippet-lint.py'
       - 'scripts/lint/tests/test-workflow-shell-snippet-lint.sh'
+      - 'scripts/lint/review-doctrine-lint.sh'
       - 'docs/workflow/**'
       - 'docs/best-practices/**'
       - '.agents/skills/**'

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -405,6 +405,9 @@ branch implies.
    named?
 6. Do the protocol document, the integration document and the `--help`
    output describe the same behavior as the code?
+7. Does every catalogue entry read generally — no person's name, no document
+   title, no wording that only makes sense to someone who saw the original
+   incident?
 
 ---
 

--- a/changelog.d/1654.added.review-doctrine.md
+++ b/changelog.d/1654.added.review-doctrine.md
@@ -1,0 +1,3 @@
+### Added
+
+- Review doctrine catalogue at `docs/workflow/development-workflow/review-doctrine.md` with five seeded finding patterns, a shell linter, and local AI reviewer supply-state reporting (`REVIEW_DOCTRINE_*` keys and bundle fields).

--- a/changelog.d/1654.added.review-doctrine.md
+++ b/changelog.d/1654.added.review-doctrine.md
@@ -1,3 +1,5 @@
-### Added
-
-- Review doctrine catalogue at `docs/workflow/development-workflow/review-doctrine.md` with five seeded finding patterns, a shell linter, and local AI reviewer supply-state reporting (`REVIEW_DOCTRINE_*` keys and bundle fields).
+- **Review doctrine for local AI reviewer** (#1654): adds
+  `docs/workflow/development-workflow/review-doctrine.md` with five generalized
+  finding patterns, `scripts/lint/review-doctrine-lint.sh`, and
+  `REVIEW_DOCTRINE_*` supply-state reporting in the local reviewer context
+  bundle and reviewer-loop summaries.

--- a/docs/testing/workflow/1654-planted-violation-proofs.md
+++ b/docs/testing/workflow/1654-planted-violation-proofs.md
@@ -1,0 +1,84 @@
+# Planted-violation proofs — #1654
+
+Recorded for PR #1690 per REVIEW.md Workflow Policy checklist item 4 and the
+implementation plan. Each proof names a concrete plant location, the command
+that must change outcome, and both runs.
+
+## P3 — duplicate bound literal in linter
+
+**Canonical file**: `scripts/lint/review-doctrine-lint.sh:43`
+
+```bash
+# Pass (canonical): no 3+ digit literal comparison
+grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' scripts/lint/review-doctrine-lint.sh && echo FAIL || echo PASS
+# → PASS
+
+# Fail (plant line 43 to `-gt 12000` instead of `-gt "$REVIEW_DOCTRINE_MAX_BYTES"`)
+grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' /tmp/p3-plant.sh && echo FAIL || echo PASS
+# → FAIL (reports FAIL — plant detected)
+
+bash scripts/development-workflow/tests/test-review-doctrine-lint.sh
+# → PASS s15_linter_no_literal_gt (canonical)
+```
+
+## P4 — incident scan on whole file
+
+**Canonical file**: `scripts/lint/review-doctrine-lint.sh:74-94` (entry-scoped loop)
+
+```bash
+# Pass (canonical): preamble fixture with docs/specs/developments/
+bash scripts/lint/review-doctrine-lint.sh \
+  scripts/development-workflow/tests/fixtures/review-doctrine/preamble-dev-path-clean-entries.md
+# → exit 0
+
+# Fail (plant: run incident grep on full file instead of entry text — rejects preamble)
+bash scripts/lint/review-doctrine-lint.sh docs/workflow/development-workflow/review-doctrine.md
+# with plant applied to full-file scan → exit 1 on preamble path
+# Canonical entry-scoped scan → exit 0 (shipped catalogue passes)
+```
+
+## P14 — CI step without path filter entries
+
+**Canonical file**: `.github/workflows/markdown-lint.yml:25-26`
+
+```bash
+# Pass (canonical)
+grep -Fq 'docs/workflow/development-workflow/review-doctrine.md' .github/workflows/markdown-lint.yml \
+  && grep -Fq 'scripts/lint/review-doctrine-lint.sh' .github/workflows/markdown-lint.yml \
+  && echo PASS || echo FAIL
+# → PASS
+
+# Fail (plant: remove both paths lines) → catalogue-only PR triggers no workflow
+# Verified by test-review-doctrine-lint.sh s17_markdown_paths_* (would FAIL if paths removed)
+```
+
+## P9 — doctrine text via shell `--arg`
+
+**Canonical file**: `scripts/development-workflow/local-ai-reviewer.sh:668-697`
+
+```bash
+# Pass (canonical --argjson doctrine_supply)
+bash scripts/development-workflow/tests/test-local-ai-reviewer.sh
+# → PASS 1654_s7a_bytes_match
+
+# Fail (plant: --arg review_doctrine "$review_doctrine_text" from jq -r .text)
+# → 1654_s7a_bytes_match FAIL (3416 vs 3417 bytes when file lacks terminal newline handling)
+```
+
+## P1 — collapsed supply states
+
+**Canonical file**: `scripts/development-workflow/local-ai-reviewer.sh:409-447`
+
+```bash
+bash scripts/development-workflow/tests/test-local-ai-reviewer.sh
+# → PASS 1654_s1_absent_state / _unreadable_state / _oversized_state / _supplied_state
+# Fail if plant merges the three error states into one `not_supplied`
+```
+
+## Regression suite (canonical head)
+
+```bash
+bash scripts/lint/review-doctrine-lint.sh
+bash scripts/development-workflow/tests/test-review-doctrine-lint.sh   # 25 passed
+bash scripts/development-workflow/tests/test-local-ai-reviewer.sh      # 283 passed
+```

--- a/docs/testing/workflow/1654-planted-violation-proofs.md
+++ b/docs/testing/workflow/1654-planted-violation-proofs.md
@@ -134,7 +134,7 @@ of `unreadable`.
 
 ## P13 — evidence file without review_doctrine object
 
-**Plant**: `local-ai-reviewer.sh:1034-1040` (`write_evidence_file`) — omit
+**Plant**: `local-ai-reviewer.sh:1044-1048` (`write_evidence_file`) — omit
 `review_doctrine` object from evidence JSON.
 
 **Fail**: `test-local-ai-reviewer.sh` → FAIL `1654_s8a_evidence_state` while kv

--- a/docs/testing/workflow/1654-planted-violation-proofs.md
+++ b/docs/testing/workflow/1654-planted-violation-proofs.md
@@ -57,7 +57,8 @@ empty string instead of failing when neither `sha256sum` nor `shasum` exists.
 **Fail**: with `PATH` stripped of digest tools, supply returns `supplied` and empty
 `version` instead of `unreadable`.
 
-**Pass (canonical)**: digest absence yields `unreadable` (plan scenario 6).
+**Pass (canonical)**: `test-local-ai-reviewer.sh` → PASS `1654_s6_no_digest_state` and
+`1654_s6_no_digest_version_empty`.
 
 ## P6 — doctrine text in key=value output
 
@@ -106,8 +107,8 @@ bytes when trailing newline mishandled).
 **Fail**: file removed after `[ -r ]` aborts reviewer under `set -e` instead of
 reporting `unreadable`.
 
-**Pass (canonical per-operation handlers)**: PASS `1654_s1_unreadable_state` with
-chmod 000 fixture.
+**Pass (canonical per-operation handlers)**: PASS `1654_s1_unreadable_state`,
+`1654_s1a_grep_error_unreadable`, and `1654_s1a_cp_fail_unreadable`.
 
 ## P11 — multi-read race (version ≠ text bytes)
 
@@ -117,8 +118,8 @@ separate reads of the live file instead of one snapshot.
 **Fail**: rewrite catalogue after snapshot; returned `version` is hash of different
 bytes than `text` (plan scenario 1b).
 
-**Pass (canonical single snapshot)**: all four values from one `cp` in
-`reviewer_doctrine_supply`.
+**Pass (canonical single snapshot)**: PASS `1654_s1b_version_matches_text`; all four
+values from one `cp` in `reviewer_doctrine_supply`.
 
 ## P12 — `grep -c … || true` on pattern count
 
@@ -128,8 +129,8 @@ exit 1 and exit >1.
 **Fail**: unreadable grep error reports `supplied` with `pattern_count=0` instead
 of `unreadable`.
 
-**Pass (canonical status branch)**: grep exit 1 → count 0 + `supplied`; exit >1 →
-`unreadable`.
+**Pass (canonical status branch)**: PASS `1654_s1a_grep_error_unreadable`; grep exit 1
+→ count 0 + `supplied`; exit >1 → `unreadable`.
 
 ## P13 — evidence file without review_doctrine object
 
@@ -157,6 +158,6 @@ output still passes.
 ```bash
 bash scripts/lint/review-doctrine-lint.sh
 bash scripts/development-workflow/tests/test-review-doctrine-lint.sh   # 25 passed
-bash scripts/development-workflow/tests/test-local-ai-reviewer.sh      # 283 passed
+bash scripts/development-workflow/tests/test-local-ai-reviewer.sh      # 288 passed
 shellcheck --severity=warning scripts/lint/review-doctrine-lint.sh
 ```

--- a/docs/testing/workflow/1654-planted-violation-proofs.md
+++ b/docs/testing/workflow/1654-planted-violation-proofs.md
@@ -1,79 +1,156 @@
 # Planted-violation proofs — #1654
 
 Recorded for PR #1690 per REVIEW.md Workflow Policy checklist item 4 and the
-implementation plan. Each proof names a concrete plant location, the command
-that must change outcome, and both runs.
-
-## P3 — duplicate bound literal in linter
-
-**Canonical file**: `scripts/lint/review-doctrine-lint.sh:43`
-
-```bash
-# Pass (canonical): no 3+ digit literal comparison
-grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' scripts/lint/review-doctrine-lint.sh && echo FAIL || echo PASS
-# → PASS
-
-# Fail (plant line 43 to `-gt 12000` instead of `-gt "$REVIEW_DOCTRINE_MAX_BYTES"`)
-grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' /tmp/p3-plant.sh && echo FAIL || echo PASS
-# → FAIL (reports FAIL — plant detected)
-
-bash scripts/development-workflow/tests/test-review-doctrine-lint.sh
-# → PASS s15_linter_no_literal_gt (canonical)
-```
-
-## P4 — incident scan on whole file
-
-**Canonical file**: `scripts/lint/review-doctrine-lint.sh:74-94` (entry-scoped loop)
-
-```bash
-# Pass (canonical): preamble fixture with docs/specs/developments/
-bash scripts/lint/review-doctrine-lint.sh \
-  scripts/development-workflow/tests/fixtures/review-doctrine/preamble-dev-path-clean-entries.md
-# → exit 0
-
-# Fail (plant: run incident grep on full file instead of entry text — rejects preamble)
-bash scripts/lint/review-doctrine-lint.sh docs/workflow/development-workflow/review-doctrine.md
-# with plant applied to full-file scan → exit 1 on preamble path
-# Canonical entry-scoped scan → exit 0 (shipped catalogue passes)
-```
-
-## P14 — CI step without path filter entries
-
-**Canonical file**: `.github/workflows/markdown-lint.yml:25-26`
-
-```bash
-# Pass (canonical)
-grep -Fq 'docs/workflow/development-workflow/review-doctrine.md' .github/workflows/markdown-lint.yml \
-  && grep -Fq 'scripts/lint/review-doctrine-lint.sh' .github/workflows/markdown-lint.yml \
-  && echo PASS || echo FAIL
-# → PASS
-
-# Fail (plant: remove both paths lines) → catalogue-only PR triggers no workflow
-# Verified by test-review-doctrine-lint.sh s17_markdown_paths_* (would FAIL if paths removed)
-```
-
-## P9 — doctrine text via shell `--arg`
-
-**Canonical file**: `scripts/development-workflow/local-ai-reviewer.sh:668-697`
-
-```bash
-# Pass (canonical --argjson doctrine_supply)
-bash scripts/development-workflow/tests/test-local-ai-reviewer.sh
-# → PASS 1654_s7a_bytes_match
-
-# Fail (plant: --arg review_doctrine "$review_doctrine_text" from jq -r .text)
-# → 1654_s7a_bytes_match FAIL (3416 vs 3417 bytes when file lacks terminal newline handling)
-```
+implementation plan. Each proof: plant location (file:line), fail command/outcome,
+restore, pass command/outcome.
 
 ## P1 — collapsed supply states
 
-**Canonical file**: `scripts/development-workflow/local-ai-reviewer.sh:409-447`
+**Plant**: `scripts/development-workflow/local-ai-reviewer.sh:409-447` — merge
+`absent`, `unreadable`, and `oversized` into one `not_supplied` state.
+
+**Fail**: `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh` →
+FAIL `1654_s1_absent_state`, `1654_s1_unreadable_state`, or `1654_s2_oversized_state`.
+
+**Pass (canonical)**: same command → PASS all four `1654_s1_*` / `1654_s2_*` state tests.
+
+## P2 — truncated oversized doctrine text
+
+**Plant**: `local-ai-reviewer.sh:426-430` — supply first `REVIEW_DOCTRINE_MAX_BYTES`
+of snapshot instead of empty `text` in oversized row.
+
+**Fail**: `test-local-ai-reviewer.sh` → FAIL `1654_s2_oversized_text_empty`.
+
+**Pass**: PASS `1654_s2_oversized_text_empty` and `1654_s2_oversized_version_present`.
+
+## P3 — duplicate bound in linter
+
+**Plant**: `scripts/lint/review-doctrine-lint.sh:43` — compare with literal
+`-gt 12000` instead of `-gt "$REVIEW_DOCTRINE_MAX_BYTES"`.
+
+**Fail**:
 
 ```bash
-bash scripts/development-workflow/tests/test-local-ai-reviewer.sh
-# → PASS 1654_s1_absent_state / _unreadable_state / _oversized_state / _supplied_state
-# Fail if plant merges the three error states into one `not_supplied`
+grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' scripts/lint/review-doctrine-lint.sh && echo PLANT_DETECTED
+bash scripts/development-workflow/tests/test-review-doctrine-lint.sh  # FAIL s15_linter_no_literal_gt
 ```
+
+**Pass (canonical line 43)**: `test-review-doctrine-lint.sh` → PASS `s15_*`.
+
+## P4 — whole-file incident scan
+
+**Plant**: `scripts/lint/review-doctrine-lint.sh:74-94` — apply AC-4 grep to the
+full file instead of `$entry_text`.
+
+**Fail**: lint rejects
+`scripts/development-workflow/tests/fixtures/review-doctrine/preamble-dev-path-clean-entries.md`
+(exit 1 on preamble `docs/specs/developments/`).
+
+**Pass (canonical entry scope)**: `test-review-doctrine-lint.sh` → PASS
+`s13_preamble_path_pass`.
+
+## P5 — supplied with empty version when digest missing
+
+**Plant**: `local-ai-reviewer.sh:391-405` (`reviewer_doctrine_version`) — return
+empty string instead of failing when neither `sha256sum` nor `shasum` exists.
+
+**Fail**: with `PATH` stripped of digest tools, supply returns `supplied` and empty
+`version` instead of `unreadable`.
+
+**Pass (canonical)**: digest absence yields `unreadable` (plan scenario 6).
+
+## P6 — doctrine text in key=value output
+
+**Plant**: `local-ai-reviewer.sh:704-707` — add `print_kv` for full doctrine text.
+
+**Fail**: `test-local-ai-reviewer.sh` → FAIL `1654_s8_no_text_kv` and fabricated
+`PLATFORM_1_*` keys in `1654_s8_no_fabricated`.
+
+**Pass**: PASS `1654_s8_no_text_kv` (count 0) and `1654_s8_platform_*`.
+
+## P7 — stage-conditional doctrine supply
+
+**Plant**: `local-ai-reviewer.sh:626-697` — wrap doctrine fields in
+`if [ "$review_stage" != default ]`.
+
+**Fail**: `test-local-ai-reviewer.sh` → FAIL `1654_s9_main_state` or
+`1654_s9_develop_state` (not `supplied`).
+
+**Pass**: PASS all `1654_s9_*` branches including `main` and `develop`.
+
+## P8 — overridable bound constant
+
+**Plant**: `scripts/development-workflow/workflow-lib.sh:7` — use
+`"${REVIEW_DOCTRINE_MAX_BYTES:-12000}"` instead of `readonly …=12000`.
+
+**Fail**: with env `REVIEW_DOCTRINE_MAX_BYTES=20000`, 12,001-byte catalogue passes
+lint and is `supplied`.
+
+**Pass (canonical readonly)**: `test-review-doctrine-lint.sh` → PASS `s14_at_12001_fail`.
+
+## P9 — command-substitution text path
+
+**Plant**: `local-ai-reviewer.sh:668-697` — pass doctrine via `--arg` from
+`$(jq -r '.text' …)` instead of `--argjson doctrine_supply`.
+
+**Fail**: `test-local-ai-reviewer.sh` → FAIL `1654_s7a_bytes_match` (3416 vs 3417
+bytes when trailing newline mishandled).
+
+**Pass (canonical `--argjson`)**: PASS `1654_s7a_bytes_match`.
+
+## P10 — permission-bit probe only
+
+**Plant**: `local-ai-reviewer.sh:409-447` — replace read handlers with single
+`[ -r "$path" ]` before any operation.
+
+**Fail**: file removed after `[ -r ]` aborts reviewer under `set -e` instead of
+reporting `unreadable`.
+
+**Pass (canonical per-operation handlers)**: PASS `1654_s1_unreadable_state` with
+chmod 000 fixture.
+
+## P11 — multi-read race (version ≠ text bytes)
+
+**Plant**: `local-ai-reviewer.sh:409-447` — derive hash, count, and text from
+separate reads of the live file instead of one snapshot.
+
+**Fail**: rewrite catalogue after snapshot; returned `version` is hash of different
+bytes than `text` (plan scenario 1b).
+
+**Pass (canonical single snapshot)**: all four values from one `cp` in
+`reviewer_doctrine_supply`.
+
+## P12 — `grep -c … || true` on pattern count
+
+**Plant**: `local-ai-reviewer.sh:437-444` — use `grep -c … || true` flattening
+exit 1 and exit >1.
+
+**Fail**: unreadable grep error reports `supplied` with `pattern_count=0` instead
+of `unreadable`.
+
+**Pass (canonical status branch)**: grep exit 1 → count 0 + `supplied`; exit >1 →
+`unreadable`.
+
+## P13 — evidence file without review_doctrine object
+
+**Plant**: `local-ai-reviewer.sh:1034-1040` (`write_evidence_file`) — omit
+`review_doctrine` object from evidence JSON.
+
+**Fail**: `test-local-ai-reviewer.sh` → FAIL `1654_s8a_evidence_state` while kv
+output still passes.
+
+**Pass**: PASS `1654_s8a_evidence_*` with `review_doctrine` object present.
+
+## P14 — CI step without path filter entries
+
+**Plant**: `.github/workflows/markdown-lint.yml:25-26` — remove
+`review-doctrine.md` and `review-doctrine-lint.sh` from `paths`.
+
+**Fail**: `test-review-doctrine-lint.sh` → FAIL `s17_markdown_paths_catalogue` /
+`s17_markdown_paths_linter`; catalogue-only PR triggers no workflow.
+
+**Pass (canonical lines 25-26 + step at line 98)**: PASS `s17_*`; explicit
+`bash scripts/lint/review-doctrine-lint.sh` step runs on catalogue edits.
 
 ## Regression suite (canonical head)
 
@@ -81,4 +158,5 @@ bash scripts/development-workflow/tests/test-local-ai-reviewer.sh
 bash scripts/lint/review-doctrine-lint.sh
 bash scripts/development-workflow/tests/test-review-doctrine-lint.sh   # 25 passed
 bash scripts/development-workflow/tests/test-local-ai-reviewer.sh      # 283 passed
+shellcheck --severity=warning scripts/lint/review-doctrine-lint.sh
 ```

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -81,6 +81,7 @@ The command runs under `sh -c` with these environment variables:
 - `HEAD_BRANCH`
 - `REVIEWED_HEAD`
 - `REVIEW_STAGE`, `REVIEW_STAGE_SOURCE`, `REVIEW_CHECKLISTS`
+- `REVIEW_DOCTRINE_STATE`, `REVIEW_DOCTRINE_PATTERN_COUNT`, `REVIEW_DOCTRINE_VERSION`
 - `LOCAL_AI_REVIEWER_MODE` — `ordinary` (default) or `strict`
 
 The context bundle JSON uses `schema_version:
@@ -98,6 +99,12 @@ local_ai_reviewer_context.v1` and includes:
 - `review_stage_source` — `branch`, `branch+files`, or `none`
 - `review_checklists` — ordered list of exact `REVIEW.md` level-2 heading
   strings (may be empty for `default`)
+- `review_doctrine` — full catalogue bytes when supplied, otherwise empty
+- `review_doctrine_state` — `supplied`, `absent`, `unreadable`, or `oversized`
+- `review_doctrine_pattern_count` — patterns **supplied** (zero when not
+  `supplied`)
+- `review_doctrine_version` — first twelve hex characters of the catalogue
+  SHA-256 (empty when no bytes were read)
 
 Selection is **additive and monotone**: `REVIEW.md` as a whole and its Core
 Rules always apply. The branch tier names one stage checklist; changed files
@@ -136,7 +143,8 @@ Set `LOCAL_AI_REVIEWER_EVIDENCE_FILE=/path/to/file.json` or pass
 artifact. The artifact uses `schema_version: local_ai_reviewer_evidence.v1`
 and records the reviewed head, graph context, result, reason, counts, changed
 files, compact diff summary, a `review_stage` object (stage, source,
-checklists), and a `strict_spec` object that mirrors the
+checklists), a `review_doctrine` object (state, pattern_count, version), and a
+`strict_spec` object that mirrors the
 `STRICT_SPEC_*` keys. Keep this artifact alongside ready-phase
 reviewer-loop evidence when measuring whether Bugbot or another ready-phase
 reviewer found net-new blockers. Relative evidence paths are resolved from the

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -230,7 +230,11 @@ Conditions are evaluated in order and stop at the first unmet one:
    The local reviewer also emits `REVIEW_STAGE`, `REVIEW_STAGE_SOURCE`, and
    `REVIEW_CHECKLISTS` on stdout; `pr-review-loop.sh` forwards them into loop
    summaries as `PLATFORM_<n>_REVIEW_STAGE`, `PLATFORM_<n>_REVIEW_STAGE_SOURCE`,
-   and `PLATFORM_<n>_REVIEW_CHECKLISTS`.
+   and `PLATFORM_<n>_REVIEW_CHECKLISTS`. It also emits `REVIEW_DOCTRINE_STATE`,
+   `REVIEW_DOCTRINE_PATTERN_COUNT`, and `REVIEW_DOCTRINE_VERSION`; the loop
+   forwards them as `PLATFORM_<n>_REVIEW_DOCTRINE_STATE`,
+   `PLATFORM_<n>_REVIEW_DOCTRINE_PATTERN_COUNT`, and
+   `PLATFORM_<n>_REVIEW_DOCTRINE_VERSION`.
 2. **Preceding peer evidence** — every platform that precedes this reviewer
    under the reordered list (same-bucket non-expensive peers plus every earlier
    bucket) has already run with acceptable evidence: `clean`, or `skipped`

--- a/docs/workflow/development-workflow/review-doctrine.md
+++ b/docs/workflow/development-workflow/review-doctrine.md
@@ -1,0 +1,84 @@
+# Review Doctrine
+
+This catalogue lists recurring finding **shapes** worth looking for during
+review. It is **not** the set of things worth reporting — withhold no real
+finding because it fits no catalogued pattern. When you match a pattern below,
+**name it** in your finding so later readers can tell doctrine-driven findings
+from the rest.
+
+## Adding patterns
+
+Each entry has four parts in this order: a level-3 heading (pattern name), then
+exactly one `**Shape**:`, one `**Example**:` and one `**Detect**:` paragraph.
+Remove every trace of the specific incident — no pull request number, no issue
+number, no person, no title, no path from the incident. Paths in this guidance
+are fine; paths inside entries are not.
+
+Before opening a pull request, confirm the entry reads generally — no person's
+name, no document title, no wording that only makes sense to someone who saw
+the original incident. See also the Workflow Policy Review Checklist in
+`REVIEW.md`.
+
+The catalogue is bounded at 12,000 bytes (`REVIEW_DOCTRINE_MAX_BYTES` in
+`scripts/development-workflow/workflow-lib.sh`). When the bound is reached,
+**merge or remove a pattern — never raise the bound in the same change that
+breaches it.** Raising the bound is a deliberate, separately reviewed change to
+the doctrine contract.
+
+Example development-folder paths like `docs/specs/developments/` appear only in
+this guidance, never inside pattern entries.
+
+### Criteria/matrix mismatch
+
+**Shape**: A table that enumerates decisions disagrees with the criteria stated
+above it, or omits a combination those criteria admit.
+
+**Example**: Acceptance criteria require both "logged in" and "not logged in"
+outcomes, but the decision matrix has rows only for the logged-in case.
+
+**Detect**: For each matrix row, can you point to the criterion it implements?
+For each criterion combination the prose admits, is there a row?
+
+### Opt-out ambiguity
+
+**Shape**: A way to disable or bypass behavior has its source of truth stated in
+more than one place, or in none.
+
+**Example**: One section says "set `FEATURE=0` to disable" while another says
+"unset `FEATURE` to disable."
+
+**Detect**: Where is the authoritative opt-out named, and do all other mentions
+agree with it?
+
+### Parser-surface conflict
+
+**Shape**: A rule about how input is recognised conflicts with the syntax the
+document elsewhere requires, or assumes a capability the stated tooling lacks.
+
+**Example**: A protocol requires comma-separated values but the parser section
+documents only space-delimited tokens.
+
+**Detect**: Does the syntax examples use match what the parser rule accepts?
+Does the stated tooling support every construct the rule requires?
+
+### Trigger ambiguity
+
+**Shape**: A condition that starts behavior does not say what happens when its
+inputs are absent, empty, or malformed.
+
+**Example**: "When the flag is set, run the check" with no row for an unset or
+invalid flag value.
+
+**Detect**: For each input the trigger names, is the outcome defined when that
+input is missing, empty, or invalid?
+
+### Example contradicting rule
+
+**Shape**: A worked example demonstrates something the rule beside it forbids,
+or omits a step the rule requires.
+
+**Example**: The rule says "always emit a reason" but the example output omits
+the reason field entirely.
+
+**Detect**: Does the example satisfy every requirement stated in the adjacent
+rule, with no extra steps the rule forbids?

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -28,7 +28,9 @@ Environment:
                                     PR_NUMBER, OWNER, REPO, BASE_BRANCH,
                                     HEAD_BRANCH, REVIEWED_HEAD,
                                     REVIEW_STAGE, REVIEW_STAGE_SOURCE,
-                                    REVIEW_CHECKLISTS, and
+                                    REVIEW_CHECKLISTS, REVIEW_DOCTRINE_STATE,
+                                    REVIEW_DOCTRINE_PATTERN_COUNT,
+                                    REVIEW_DOCTRINE_VERSION, and
                                     LOCAL_AI_REVIEWER_MODE (ordinary|strict) in env.
   LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1
                                     Do not apply the bundled Codex preset default.
@@ -382,6 +384,65 @@ reviewer_resolve_review_stage() {
   printf '%s\n%s\n%s\n' "$stage" "$source" "$checklists"
 }
 
+# ---------------------------------------------------------------------------
+# Review doctrine supply (#1654)
+# ---------------------------------------------------------------------------
+
+reviewer_doctrine_version() {
+  local snapshot="$1"
+  local digest_cmd=""
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest_cmd="sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    digest_cmd="shasum -a 256"
+  else
+    return 1
+  fi
+
+  local full_hash
+  full_hash="$($digest_cmd "$snapshot" 2>/dev/null | awk '{print $1}')" || return 1
+  [ -n "$full_hash" ] || return 1
+  printf '%s\n' "${full_hash:0:12}"
+}
+
+reviewer_doctrine_supply() {
+  local path="docs/workflow/development-workflow/review-doctrine.md"
+  local snapshot bytes version count status
+  local unreadable='{"state":"unreadable","text":"","pattern_count":0,"version":""}'
+
+  [ -f "$path" ] || { printf '{"state":"absent","text":"","pattern_count":0,"version":""}\n'; return 0; }
+
+  snapshot="$(mktemp)" || { printf '%s\n' "$unreadable"; return 0; }
+  cp "$path" "$snapshot" 2>/dev/null || { rm -f "$snapshot"; printf '%s\n' "$unreadable"; return 0; }
+
+  bytes="$(wc -c <"$snapshot" 2>/dev/null)" || { rm -f "$snapshot"; printf '%s\n' "$unreadable"; return 0; }
+  bytes="${bytes//[[:space:]]/}"
+  [ -n "$bytes" ] || { rm -f "$snapshot"; printf '%s\n' "$unreadable"; return 0; }
+
+  version="$(reviewer_doctrine_version "$snapshot")" || {
+    rm -f "$snapshot"; printf '%s\n' "$unreadable"; return 0; }
+
+  if [ "$bytes" -gt "$REVIEW_DOCTRINE_MAX_BYTES" ]; then
+    rm -f "$snapshot"
+    jq -n --arg v "$version" '{state:"oversized", text:"", pattern_count:0, version:$v}'
+    return 0
+  fi
+
+  status=0
+  count="$(grep -c '^### ' "$snapshot" 2>/dev/null)" || status=$?
+  if [ "$status" -eq 1 ]; then
+    count=0
+  elif [ "$status" -ne 0 ]; then
+    rm -f "$snapshot"; printf '%s\n' "$unreadable"; return 0
+  fi
+
+  jq -n --rawfile t "$snapshot" --arg v "$version" --argjson c "${count:-0}" \
+    '{state:"supplied", text:$t, pattern_count:$c, version:$v}' 2>/dev/null || {
+    rm -f "$snapshot"; printf '%s\n' "$unreadable"; return 0; }
+  rm -f "$snapshot"
+}
+
 # Effective harness mode: only when HARNESS_MODE=1 AND the script is sourced.
 _HARNESS_MODE_EFFECTIVE=0
 if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
@@ -562,6 +623,12 @@ else
   review_checklists_json="[]"
 fi
 
+doctrine_supply_json="$(reviewer_doctrine_supply)"
+review_doctrine_state="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.state // "unreadable"')"
+review_doctrine_text="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.text // ""')"
+review_doctrine_pattern_count="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.pattern_count // 0')"
+review_doctrine_version="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.version // ""')"
+
 graph_strategy="${LOCAL_AI_REVIEWER_GRAPH_STRATEGY:-none}"
 graph_context="none"
 case "$graph_strategy" in
@@ -606,6 +673,10 @@ jq -n \
   --arg diff_stat "$diff_stat" \
   --arg review_stage "$review_stage" \
   --arg review_stage_source "$review_stage_source" \
+  --arg review_doctrine "$review_doctrine_text" \
+  --arg review_doctrine_state "$review_doctrine_state" \
+  --argjson review_doctrine_pattern_count "$review_doctrine_pattern_count" \
+  --arg review_doctrine_version "$review_doctrine_version" \
   --argjson changed_files "$changed_files_json" \
   --argjson review_checklists "$review_checklists_json" \
   '{
@@ -624,7 +695,11 @@ jq -n \
     graph_context: $graph_context,
     review_stage: $review_stage,
     review_stage_source: $review_stage_source,
-    review_checklists: $review_checklists
+    review_checklists: $review_checklists,
+    review_doctrine: $review_doctrine,
+    review_doctrine_state: $review_doctrine_state,
+    review_doctrine_pattern_count: $review_doctrine_pattern_count,
+    review_doctrine_version: $review_doctrine_version
   }' >"$context_file"
 
 print_kv BASE_BRANCH "$BASE_BRANCH"
@@ -634,6 +709,9 @@ print_kv GRAPH_CONTEXT "$graph_context"
 print_kv REVIEW_STAGE "$review_stage"
 print_kv REVIEW_STAGE_SOURCE "$review_stage_source"
 [ -n "$review_checklists_csv" ] && print_kv REVIEW_CHECKLISTS "$review_checklists_csv"
+print_kv REVIEW_DOCTRINE_STATE "$review_doctrine_state"
+print_kv REVIEW_DOCTRINE_PATTERN_COUNT "$review_doctrine_pattern_count"
+print_kv REVIEW_DOCTRINE_VERSION "$review_doctrine_version"
 
 # Strict-spec state (always emitted after a completed ordinary parse).
 strict_spec_state=""
@@ -666,6 +744,9 @@ REVIEWED_HEAD="$HEAD_SHA" \
 REVIEW_STAGE="$review_stage" \
 REVIEW_STAGE_SOURCE="$review_stage_source" \
 REVIEW_CHECKLISTS="$review_checklists_csv" \
+REVIEW_DOCTRINE_STATE="$review_doctrine_state" \
+REVIEW_DOCTRINE_PATTERN_COUNT="$review_doctrine_pattern_count" \
+REVIEW_DOCTRINE_VERSION="$review_doctrine_version" \
   run_with_timeout "$TIMEOUT" "$stdout_file" "$stderr_file" sh -c "$LOCAL_AI_REVIEWER_COMMAND"
 command_exit=$?
 set -e
@@ -843,6 +924,9 @@ case "$strict_stage" in
           REVIEW_STAGE="$review_stage" \
           REVIEW_STAGE_SOURCE="$review_stage_source" \
           REVIEW_CHECKLISTS="$review_checklists_csv" \
+          REVIEW_DOCTRINE_STATE="$review_doctrine_state" \
+          REVIEW_DOCTRINE_PATTERN_COUNT="$review_doctrine_pattern_count" \
+          REVIEW_DOCTRINE_VERSION="$review_doctrine_version" \
             run_with_timeout "$remaining" "$strict_stdout_file" "$strict_stderr_file" \
               sh -c "$LOCAL_AI_REVIEWER_COMMAND"
           strict_exit=$?
@@ -926,6 +1010,9 @@ write_evidence_file() {
     --arg review_stage "$review_stage" \
     --arg review_stage_source "$review_stage_source" \
     --arg review_checklists "$review_checklists_csv" \
+    --arg review_doctrine_state "$review_doctrine_state" \
+    --argjson review_doctrine_pattern_count "$review_doctrine_pattern_count" \
+    --arg review_doctrine_version "$review_doctrine_version" \
     --argjson changed_files "$changed_files_json" \
     --argjson comment_count "$final_comment_count" \
     --argjson blocking_count "$final_blocking_count" \
@@ -957,6 +1044,11 @@ write_evidence_file() {
         stage: $review_stage,
         source: $review_stage_source,
         checklists: ($review_checklists | if . == "" then [] else (split(",") | map(select(length > 0))) end)
+      },
+      review_doctrine: {
+        state: $review_doctrine_state,
+        pattern_count: $review_doctrine_pattern_count,
+        version: $review_doctrine_version
       },
       strict_spec: $strict_spec
     }' >"$LOCAL_AI_REVIEWER_EVIDENCE_FILE"; then

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -625,7 +625,6 @@ fi
 
 doctrine_supply_json="$(reviewer_doctrine_supply)"
 review_doctrine_state="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.state // "unreadable"')"
-review_doctrine_text="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.text // ""')"
 review_doctrine_pattern_count="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.pattern_count // 0')"
 review_doctrine_version="$(printf '%s\n' "$doctrine_supply_json" | jq -r '.version // ""')"
 
@@ -673,10 +672,7 @@ jq -n \
   --arg diff_stat "$diff_stat" \
   --arg review_stage "$review_stage" \
   --arg review_stage_source "$review_stage_source" \
-  --arg review_doctrine "$review_doctrine_text" \
-  --arg review_doctrine_state "$review_doctrine_state" \
-  --argjson review_doctrine_pattern_count "$review_doctrine_pattern_count" \
-  --arg review_doctrine_version "$review_doctrine_version" \
+  --argjson doctrine_supply "$doctrine_supply_json" \
   --argjson changed_files "$changed_files_json" \
   --argjson review_checklists "$review_checklists_json" \
   '{
@@ -696,10 +692,10 @@ jq -n \
     review_stage: $review_stage,
     review_stage_source: $review_stage_source,
     review_checklists: $review_checklists,
-    review_doctrine: $review_doctrine,
-    review_doctrine_state: $review_doctrine_state,
-    review_doctrine_pattern_count: $review_doctrine_pattern_count,
-    review_doctrine_version: $review_doctrine_version
+    review_doctrine: $doctrine_supply.text,
+    review_doctrine_state: $doctrine_supply.state,
+    review_doctrine_pattern_count: $doctrine_supply.pattern_count,
+    review_doctrine_version: $doctrine_supply.version
   }' >"$context_file"
 
 print_kv BASE_BRANCH "$BASE_BRANCH"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3676,12 +3676,15 @@ emit_local_ai_review_stage_keys() {
 emit_local_ai_review_doctrine_keys() {
   local script_output="$1"
   local state pattern_count version
+  if ! grep -q '^REVIEW_DOCTRINE_STATE=' <<< "$script_output"; then
+    return 0
+  fi
   state="$(kv_value_default REVIEW_DOCTRINE_STATE "$script_output" "")"
-  pattern_count="$(kv_value_default REVIEW_DOCTRINE_PATTERN_COUNT "$script_output" "")"
+  pattern_count="$(kv_value_default REVIEW_DOCTRINE_PATTERN_COUNT "$script_output" "0")"
   version="$(kv_value_default REVIEW_DOCTRINE_VERSION "$script_output" "")"
-  [ -n "$state" ] && print_kv REVIEW_DOCTRINE_STATE "$state"
-  [ -n "$pattern_count" ] && print_kv REVIEW_DOCTRINE_PATTERN_COUNT "$pattern_count"
-  [ -n "$version" ] && print_kv REVIEW_DOCTRINE_VERSION "$version"
+  print_kv REVIEW_DOCTRINE_STATE "$state"
+  print_kv REVIEW_DOCTRINE_PATTERN_COUNT "$pattern_count"
+  print_kv REVIEW_DOCTRINE_VERSION "$version"
 }
 
 # Capture STRICT_SPEC_* into globals for reviewer_loop_history_build_entry.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3673,6 +3673,17 @@ emit_local_ai_review_stage_keys() {
   [ -n "$checklists" ] && print_kv REVIEW_CHECKLISTS "$checklists"
 }
 
+emit_local_ai_review_doctrine_keys() {
+  local script_output="$1"
+  local state pattern_count version
+  state="$(kv_value_default REVIEW_DOCTRINE_STATE "$script_output" "")"
+  pattern_count="$(kv_value_default REVIEW_DOCTRINE_PATTERN_COUNT "$script_output" "")"
+  version="$(kv_value_default REVIEW_DOCTRINE_VERSION "$script_output" "")"
+  [ -n "$state" ] && print_kv REVIEW_DOCTRINE_STATE "$state"
+  [ -n "$pattern_count" ] && print_kv REVIEW_DOCTRINE_PATTERN_COUNT "$pattern_count"
+  [ -n "$version" ] && print_kv REVIEW_DOCTRINE_VERSION "$version"
+}
+
 # Capture STRICT_SPEC_* into globals for reviewer_loop_history_build_entry.
 # Present object vs absent object is gated by strict_spec_recorded.
 capture_strict_spec_globals_from_output() {
@@ -3773,6 +3784,7 @@ run_local_ai_reviewer_review() {
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
       emit_local_ai_strict_spec_keys "$script_output"
       emit_local_ai_review_stage_keys "$script_output"
+      emit_local_ai_review_doctrine_keys "$script_output"
       return 0
       ;;
     1)
@@ -3803,6 +3815,7 @@ run_local_ai_reviewer_review() {
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
       emit_local_ai_strict_spec_keys "$script_output"
       emit_local_ai_review_stage_keys "$script_output"
+      emit_local_ai_review_doctrine_keys "$script_output"
       return 1
       ;;
     2)
@@ -3824,6 +3837,7 @@ run_local_ai_reviewer_review() {
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
       emit_local_ai_strict_spec_keys "$script_output"
       emit_local_ai_review_stage_keys "$script_output"
+      emit_local_ai_review_doctrine_keys "$script_output"
       return 2
       ;;
     *)
@@ -3845,6 +3859,7 @@ run_local_ai_reviewer_review() {
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
       emit_local_ai_strict_spec_keys "$script_output"
       emit_local_ai_review_stage_keys "$script_output"
+      emit_local_ai_review_doctrine_keys "$script_output"
       return 0
       ;;
   esac

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/empty.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/empty.md
@@ -1,0 +1,4 @@
+# Empty catalogue
+
+This catalogue lists shapes worth looking for. It is not the set of things
+worth reporting. Name matched patterns in findings when possible.

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/incident-dev-path.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/incident-dev-path.md
@@ -1,0 +1,9 @@
+# Incident development path
+
+### Bad entry
+
+**Shape**: References a development-folder path inside an entry.
+
+**Example**: See docs/specs/developments/x/1_x_specs.md.
+
+**Detect**: Is there a development path?

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/incident-forge-url.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/incident-forge-url.md
@@ -1,0 +1,9 @@
+# Incident forge URL
+
+### Bad entry
+
+**Shape**: References a forge URL.
+
+**Example**: See https://github.com/o/r/pull/1 for context.
+
+**Detect**: Is there a URL?

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/incident-hash-number.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/incident-hash-number.md
@@ -1,0 +1,11 @@
+# Incident hash-number
+
+Guidance may cite docs/specs/developments/ in the preamble only.
+
+### Bad entry
+
+**Shape**: References an incident by number.
+
+**Example**: See issue #1646 for context.
+
+**Detect**: Is there a hash-number?

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/incident-spelled-out.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/incident-spelled-out.md
@@ -1,0 +1,9 @@
+# Incident spelled-out
+
+### Bad entry
+
+**Shape**: References a spelled-out pull request.
+
+**Example**: As noted in PR 1646.
+
+**Detect**: Is there a spelled-out reference?

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/malformed-duplicate-shape.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/malformed-duplicate-shape.md
@@ -1,0 +1,11 @@
+# Malformed — duplicate Shape
+
+### Duplicate shape pattern
+
+**Shape**: First shape paragraph.
+
+**Shape**: Second shape paragraph under the same heading.
+
+**Example**: An example.
+
+**Detect**: A detect question?

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/malformed-missing-detect.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/malformed-missing-detect.md
@@ -1,0 +1,7 @@
+# Malformed — missing Detect
+
+### Incomplete pattern
+
+**Shape**: A shape without its detect paragraph.
+
+**Example**: An example only.

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/malformed-wrong-order.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/malformed-wrong-order.md
@@ -1,0 +1,9 @@
+# Wrong order
+
+### Reordered pattern
+
+**Detect**: Question before shape?
+
+**Shape**: Shape after detect.
+
+**Example**: Example last.

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/preamble-dev-path-clean-entries.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/preamble-dev-path-clean-entries.md
@@ -1,0 +1,11 @@
+# Preamble path only
+
+Example development-folder paths like docs/specs/developments/ belong in guidance.
+
+### Clean entry
+
+**Shape**: A general shape with no incident references.
+
+**Example**: A neutral example.
+
+**Detect**: Does it read generally?

--- a/scripts/development-workflow/tests/fixtures/review-doctrine/well-formed.md
+++ b/scripts/development-workflow/tests/fixtures/review-doctrine/well-formed.md
@@ -1,0 +1,29 @@
+# Fixture catalogue
+
+This catalogue lists recurring finding **shapes** worth looking for during
+review. It is **not** the set of things worth reporting. When you match a
+pattern, **name it** in your finding.
+
+### Alpha pattern
+
+**Shape**: First shape description for testing.
+
+**Example**: A minimal example for alpha.
+
+**Detect**: Ask whether alpha holds?
+
+### Beta pattern
+
+**Shape**: Second shape description for testing.
+
+**Example**: A minimal example for beta.
+
+**Detect**: Ask whether beta holds?
+
+### Gamma pattern
+
+**Shape**: Third shape description for testing.
+
+**Example**: A minimal example for gamma.
+
+**Detect**: Ask whether gamma holds?

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1210,6 +1210,10 @@ run_test "1654_s8_platform_state" "1" "$(printf '%s\n' "$_1654_emit_out" | grep 
 run_test "1654_s8_platform_count" "1" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_REVIEW_DOCTRINE_PATTERN_COUNT=' || true)"
 run_test "1654_s8_platform_version" "1" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_REVIEW_DOCTRINE_VERSION=' || true)"
 run_test "1654_s8_no_fabricated" "0" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_[^=]*Shape' || true)"
+_1654_absent_kv="$(printf '%s\n' 'RESULT=clean' 'REVIEW_DOCTRINE_STATE=absent' 'REVIEW_DOCTRINE_PATTERN_COUNT=0' 'REVIEW_DOCTRINE_VERSION=')"
+_1654_absent_emit="$(bash -c 'HARNESS_MODE=1 source "$1"; emit_local_ai_review_doctrine_keys "$2"' bash "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" "$_1654_absent_kv")"
+run_test "1654_s8_absent_forwards_version" "REVIEW_DOCTRINE_VERSION=" "$(printf '%s\n' "$_1654_absent_emit" | grep '^REVIEW_DOCTRINE_VERSION=' || true)"
+run_test "1654_s8_absent_forwards_count" "REVIEW_DOCTRINE_PATTERN_COUNT=0" "$(printf '%s\n' "$_1654_absent_emit" | grep '^REVIEW_DOCTRINE_PATTERN_COUNT=' || true)"
 rm -f "$BUNDLE_DUMP"
 
 # Scenario 8a: evidence object

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1064,6 +1064,149 @@ run_test "1653_s14_evidence_stage" "implementation" "$(jq -r '.review_stage.stag
 run_test "1653_s14_evidence_source" "branch+files" "$(jq -r '.review_stage.source' "$EVIDENCE_FILE")"
 run_test "1653_s14_evidence_schema" "local_ai_reviewer_evidence.v1" "$(jq -r '.schema_version' "$EVIDENCE_FILE")"
 
+# ---------------------------------------------------------------------------
+# #1654 — review doctrine supply
+# ---------------------------------------------------------------------------
+
+_1654_doctrine_root="$(mktemp -d)"
+_1654_install_doctrine() {
+  local root="$1"
+  local src="$2"
+  mkdir -p "$root/docs/workflow/development-workflow"
+  cp "$src" "$root/docs/workflow/development-workflow/review-doctrine.md"
+}
+
+_1654_run_supply() {
+  local root="$1"
+  (cd "$root" && reviewer_doctrine_supply)
+}
+
+_1654_independent_version() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print substr($1,1,12)}'
+  else
+    shasum -a 256 "$file" | awk '{print substr($1,1,12)}'
+  fi
+}
+
+# Scenario 1: four states, all four values
+_1654_install_doctrine "$_1654_doctrine_root" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+_1654_supplied="$(_1654_run_supply "$_1654_doctrine_root")"
+run_test "1654_s1_supplied_state" "supplied" "$(printf '%s\n' "$_1654_supplied" | jq -r '.state')"
+run_test "1654_s1_supplied_count" "5" "$(printf '%s\n' "$_1654_supplied" | jq -r '.pattern_count')"
+run_test "1654_s1_supplied_version_len" "12" "$(printf '%s\n' "$_1654_supplied" | jq -r '.version | length')"
+run_test "1654_s1_supplied_text_nonempty" "true" "$(printf '%s\n' "$_1654_supplied" | jq -r '.text | length > 0')"
+
+_1654_absent_root="$(mktemp -d)"
+_1654_absent="$(_1654_run_supply "$_1654_absent_root")"
+run_test "1654_s1_absent_state" "absent" "$(printf '%s\n' "$_1654_absent" | jq -r '.state')"
+run_test "1654_s1_absent_count" "0" "$(printf '%s\n' "$_1654_absent" | jq -r '.pattern_count')"
+run_test "1654_s1_absent_version" "" "$(printf '%s\n' "$_1654_absent" | jq -r '.version')"
+
+_1654_unreadable_root="$(mktemp -d)"
+mkdir -p "$_1654_unreadable_root/docs/workflow/development-workflow"
+printf 'secret\n' > "$_1654_unreadable_root/docs/workflow/development-workflow/review-doctrine.md"
+chmod 000 "$_1654_unreadable_root/docs/workflow/development-workflow/review-doctrine.md"
+_1654_unreadable="$(_1654_run_supply "$_1654_unreadable_root")"
+chmod 644 "$_1654_unreadable_root/docs/workflow/development-workflow/review-doctrine.md"
+run_test "1654_s1_unreadable_state" "unreadable" "$(printf '%s\n' "$_1654_unreadable" | jq -r '.state')"
+
+_1654_oversized_root="$(mktemp -d)"
+_1654_oversized_file="$_1654_oversized_root/docs/workflow/development-workflow/review-doctrine.md"
+mkdir -p "$(dirname "$_1654_oversized_file")"
+python3 - <<'PY' "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md" "$_1654_oversized_file"
+import pathlib, sys
+body = pathlib.Path(sys.argv[1]).read_bytes()
+while len(body) <= 12000:
+    body += b"x"
+pathlib.Path(sys.argv[2]).write_bytes(body[:12001])
+PY
+_1654_oversized="$(_1654_run_supply "$_1654_oversized_root")"
+run_test "1654_s2_oversized_state" "oversized" "$(printf '%s\n' "$_1654_oversized" | jq -r '.state')"
+run_test "1654_s2_oversized_text_empty" "" "$(printf '%s\n' "$_1654_oversized" | jq -r '.text')"
+run_test "1654_s2_oversized_version_present" "true" "$(printf '%s\n' "$_1654_oversized" | jq -r '.version | length > 0')"
+
+# Scenario 4: empty catalogue
+_1654_empty_root="$(mktemp -d)"
+_1654_install_doctrine "$_1654_empty_root" "$REPO_ROOT/scripts/development-workflow/tests/fixtures/review-doctrine/empty.md"
+_1654_empty="$(_1654_run_supply "$_1654_empty_root")"
+run_test "1654_s4_empty_supplied" "supplied" "$(printf '%s\n' "$_1654_empty" | jq -r '.state')"
+run_test "1654_s4_empty_count" "0" "$(printf '%s\n' "$_1654_empty" | jq -r '.pattern_count')"
+
+# Scenario 5: version hash
+_1654_expected_version="$(_1654_independent_version "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md")"
+run_test "1654_s5_version_matches_file" "$_1654_expected_version" "$(printf '%s\n' "$_1654_supplied" | jq -r '.version')"
+
+# Scenario 7/7a: bundle fields and byte-identical text
+reset_mocks
+BUNDLE_DUMP="$(mktemp)"
+cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+if [ -n "${MOCK_BUNDLE_DUMP:-}" ]; then
+  cp "$CONTEXT_BUNDLE_PATH" "$MOCK_BUNDLE_DUMP"
+fi
+printf '%s\n' '{"result":"clean","findings":[]}'
+MOCK_REVIEWER
+chmod +x "$MOCK_BIN/local-reviewer-mock"
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_BUNDLE_DUMP="$BUNDLE_DUMP"
+MOCK_PR_HEAD_BRANCH="feature/1654-codex-patterns-to-local-doctrine"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export LOCAL_AI_REVIEWER_COMMAND MOCK_BUNDLE_DUMP MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+_1654_install_doctrine "$VALID_REPO_ROOT" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+for _1654_field in schema_version pr_number owner repo base_branch head_branch reviewed_head changed_files pr_body diff_name_status diff_stat review_contract graph_context review_stage review_stage_source review_checklists review_doctrine review_doctrine_state review_doctrine_pattern_count review_doctrine_version; do
+  run_test "1654_s7_field_${_1654_field}" "yes" "$(jq -e "has(\"${_1654_field}\")" "$BUNDLE_DUMP" >/dev/null && echo yes || echo no)"
+done
+run_test "1654_s7a_bytes_match" "0" "$(cmp -s "$VALID_REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md" <(jq -r '.review_doctrine' "$BUNDLE_DUMP") && echo 0 || echo 1)"
+run_test "1654_s8_state_kv" "REVIEW_DOCTRINE_STATE=supplied" "$(line_for REVIEW_DOCTRINE_STATE)"
+run_test "1654_s8_count_kv" "REVIEW_DOCTRINE_PATTERN_COUNT=5" "$(line_for REVIEW_DOCTRINE_PATTERN_COUNT)"
+run_test "1654_s8_no_text_kv" "0" "$(grep -c '^REVIEW_DOCTRINE=' "$OUTPUT_FILE" 2>/dev/null || true)"
+_1654_emit_out="$(bash -c 'HARNESS_MODE=1 source "$1"; emit_prefixed_platform_output 1 "$(cat "$2")"' bash "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" "$OUTPUT_FILE")"
+run_test "1654_s8_platform_state" "1" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_REVIEW_DOCTRINE_STATE=' || true)"
+run_test "1654_s8_platform_count" "1" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_REVIEW_DOCTRINE_PATTERN_COUNT=' || true)"
+run_test "1654_s8_platform_version" "1" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_REVIEW_DOCTRINE_VERSION=' || true)"
+run_test "1654_s8_no_fabricated" "0" "$(printf '%s\n' "$_1654_emit_out" | grep -c '^PLATFORM_1_[^=]*Shape' || true)"
+rm -f "$BUNDLE_DUMP"
+
+# Scenario 8a: evidence object
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$EVIDENCE_FILE"
+MOCK_PR_HEAD_BRANCH="feature/1654-codex-patterns-to-local-doctrine"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+set_mock_stdout '{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA MOCK_LOCAL_REVIEWER_STDOUT
+_1654_install_doctrine "$VALID_REPO_ROOT" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "1654_s8a_evidence_state" "supplied" "$(jq -r '.review_doctrine.state' "$EVIDENCE_FILE")"
+run_test "1654_s8a_evidence_count_type" "number" "$(jq -r '.review_doctrine.pattern_count | type' "$EVIDENCE_FILE")"
+run_test "1654_s8a_evidence_version_type" "string" "$(jq -r '.review_doctrine.version | type' "$EVIDENCE_FILE")"
+
+# Scenario 9: every stage gets doctrine
+for _1654_branch in spec/foo implementation-plan/foo feature/foo refactor/foo fix/foo hotfix/foo main develop; do
+  reset_mocks
+  BUNDLE_DUMP="$(mktemp)"
+  cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+cp "$CONTEXT_BUNDLE_PATH" "$MOCK_BUNDLE_DUMP"
+printf '%s\n' '{"result":"clean","findings":[]}'
+MOCK_REVIEWER
+  chmod +x "$MOCK_BIN/local-reviewer-mock"
+  LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+  MOCK_BUNDLE_DUMP="$BUNDLE_DUMP"
+  MOCK_PR_HEAD_BRANCH="$_1654_branch"
+  MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+  export LOCAL_AI_REVIEWER_COMMAND MOCK_BUNDLE_DUMP MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+  _1654_install_doctrine "$VALID_REPO_ROOT" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+  run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+  run_test "1654_s9_${_1654_branch//\//_}_state" "supplied" "$(jq -r '.review_doctrine_state' "$BUNDLE_DUMP")"
+  rm -f "$BUNDLE_DUMP"
+done
+
+rm -rf "$_1654_doctrine_root" "$_1654_absent_root" "$_1654_unreadable_root" "$_1654_oversized_root" "$_1654_empty_root"
+
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"
   exit 1

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1112,6 +1112,48 @@ _1654_unreadable="$(_1654_run_supply "$_1654_unreadable_root")"
 chmod 644 "$_1654_unreadable_root/docs/workflow/development-workflow/review-doctrine.md"
 run_test "1654_s1_unreadable_state" "unreadable" "$(printf '%s\n' "$_1654_unreadable" | jq -r '.state')"
 
+# Scenario 1a: grep exit >1 is unreadable (distinct from exit 1 → count 0 supplied)
+_1654_grep_err_bin="$(mktemp -d)"
+cat > "$_1654_grep_err_bin/grep" <<'GREP_STUB'
+#!/usr/bin/env bash
+if [[ "$*" == *'-c '^###\ '* ]]; then exit 2; fi
+exec /usr/bin/grep "$@"
+GREP_STUB
+chmod +x "$_1654_grep_err_bin/grep"
+_1654_grep_err_root="$(mktemp -d)"
+_1654_install_doctrine "$_1654_grep_err_root" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+_1654_grep_err_out="$(cd "$_1654_grep_err_root" && PATH="$_1654_grep_err_bin:$PATH" reviewer_doctrine_supply)"
+run_test "1654_s1a_grep_error_unreadable" "unreadable" "$(printf '%s\n' "$_1654_grep_err_out" | jq -r '.state')"
+
+# Scenario 1a: cp failure while catalogue present → unreadable
+_1654_cp_fail_bin="$(mktemp -d)"
+cat > "$_1654_cp_fail_bin/cp" <<'CP_STUB'
+#!/usr/bin/env bash
+if [[ "$1" == *review-doctrine.md ]]; then exit 1; fi
+exec /bin/cp "$@"
+CP_STUB
+chmod +x "$_1654_cp_fail_bin/cp"
+_1654_cp_fail_root="$(mktemp -d)"
+_1654_install_doctrine "$_1654_cp_fail_root" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+_1654_cp_fail_out="$(cd "$_1654_cp_fail_root" && PATH="$_1654_cp_fail_bin:/usr/bin:/bin" reviewer_doctrine_supply)"
+run_test "1654_s1a_cp_fail_unreadable" "unreadable" "$(printf '%s\n' "$_1654_cp_fail_out" | jq -r '.state')"
+
+# Scenario 1b: returned version is hash of returned text (same snapshot)
+_1654_text_hash="$(printf '%s\n' "$_1654_supplied" | jq -j -r '.text' | if command -v sha256sum >/dev/null 2>&1; then sha256sum; else shasum -a 256; fi | awk '{print substr($1,1,12)}')"
+run_test "1654_s1b_version_matches_text" "$_1654_text_hash" "$(printf '%s\n' "$_1654_supplied" | jq -r '.version')"
+
+# Scenario 6: no digest command → unreadable, not supplied with empty version
+_1654_no_digest_root="$(mktemp -d)"
+_1654_install_doctrine "$_1654_no_digest_root" "$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+_1654_no_digest_path="$(mktemp -d)"
+for _1654_tool in awk bash cat cp date dirname grep jq mktemp perl rm sed sh sleep tr wc; do
+  _1654_p="$(command -v "$_1654_tool" 2>/dev/null || true)"
+  [ -n "$_1654_p" ] && ln -sf "$_1654_p" "$_1654_no_digest_path/$_1654_tool"
+done
+_1654_no_digest_out="$(cd "$_1654_no_digest_root" && PATH="$_1654_no_digest_path" reviewer_doctrine_supply)"
+run_test "1654_s6_no_digest_state" "unreadable" "$(printf '%s\n' "$_1654_no_digest_out" | jq -r '.state')"
+run_test "1654_s6_no_digest_version_empty" "" "$(printf '%s\n' "$_1654_no_digest_out" | jq -r '.version')"
+
 _1654_oversized_root="$(mktemp -d)"
 _1654_oversized_file="$_1654_oversized_root/docs/workflow/development-workflow/review-doctrine.md"
 mkdir -p "$(dirname "$_1654_oversized_file")"
@@ -1205,7 +1247,7 @@ MOCK_REVIEWER
   rm -f "$BUNDLE_DUMP"
 done
 
-rm -rf "$_1654_doctrine_root" "$_1654_absent_root" "$_1654_unreadable_root" "$_1654_oversized_root" "$_1654_empty_root"
+rm -rf "$_1654_doctrine_root" "$_1654_absent_root" "$_1654_unreadable_root" "$_1654_oversized_root" "$_1654_empty_root" "$_1654_grep_err_bin" "$_1654_grep_err_root" "$_1654_cp_fail_bin" "$_1654_cp_fail_root" "$_1654_no_digest_root" "$_1654_no_digest_path"
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1159,7 +1159,7 @@ run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
 for _1654_field in schema_version pr_number owner repo base_branch head_branch reviewed_head changed_files pr_body diff_name_status diff_stat review_contract graph_context review_stage review_stage_source review_checklists review_doctrine review_doctrine_state review_doctrine_pattern_count review_doctrine_version; do
   run_test "1654_s7_field_${_1654_field}" "yes" "$(jq -e "has(\"${_1654_field}\")" "$BUNDLE_DUMP" >/dev/null && echo yes || echo no)"
 done
-run_test "1654_s7a_bytes_match" "0" "$(cmp -s "$VALID_REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md" <(jq -r '.review_doctrine' "$BUNDLE_DUMP") && echo 0 || echo 1)"
+run_test "1654_s7a_bytes_match" "0" "$(jq -j -r '.review_doctrine' "$BUNDLE_DUMP" > /tmp/1654-doctrine-bytes.tmp && cmp -s "$VALID_REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md" /tmp/1654-doctrine-bytes.tmp && echo 0 || echo 1)"
 run_test "1654_s8_state_kv" "REVIEW_DOCTRINE_STATE=supplied" "$(line_for REVIEW_DOCTRINE_STATE)"
 run_test "1654_s8_count_kv" "REVIEW_DOCTRINE_PATTERN_COUNT=5" "$(line_for REVIEW_DOCTRINE_PATTERN_COUNT)"
 run_test "1654_s8_no_text_kv" "0" "$(grep -c '^REVIEW_DOCTRINE=' "$OUTPUT_FILE" 2>/dev/null || true)"

--- a/scripts/development-workflow/tests/test-review-doctrine-lint.sh
+++ b/scripts/development-workflow/tests/test-review-doctrine-lint.sh
@@ -98,7 +98,9 @@ _assign_count="$(rg -l 'REVIEW_DOCTRINE_MAX_BYTES=' scripts --glob '*.sh' 2>/dev
 run_test "s15_single_assignment" "1" "$_assign_count"
 run_test "s15_linter_uses_constant" "yes" "$(grep -Fq '$REVIEW_DOCTRINE_MAX_BYTES' "$LINTER" && echo yes || echo no)"
 run_test "s15_linter_no_literal_gt" "no" "$(grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' "$LINTER" && echo yes || echo no)"
-run_test "s15_reviewer_uses_constant" "yes" "$(grep -Fq '$REVIEW_DOCTRINE_MAX_BYTES' "$REPO_ROOT/scripts/development-workflow/local-ai-reviewer.sh" && echo yes || echo no)"
+_reviewer_supply_fn="$(sed -n '/^reviewer_doctrine_supply(/,/^}/p' "$REPO_ROOT/scripts/development-workflow/local-ai-reviewer.sh")"
+run_test "s15_reviewer_uses_constant" "yes" "$(printf '%s\n' "$_reviewer_supply_fn" | grep -Fq '$REVIEW_DOCTRINE_MAX_BYTES' && echo yes || echo no)"
+run_test "s15_reviewer_no_literal_gt" "no" "$(printf '%s\n' "$_reviewer_supply_fn" | grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' && echo yes || echo no)"
 
 # Scenario 16: shipped catalogue
 run_test "s16_shipped_passes_linter" "0" "$(lint_exit "$CATALOGUE")"

--- a/scripts/development-workflow/tests/test-review-doctrine-lint.sh
+++ b/scripts/development-workflow/tests/test-review-doctrine-lint.sh
@@ -95,7 +95,13 @@ run_test "s15b_linter_rejects_oversized" "1" "$(lint_exit "$_boundary_fail")"
 rm -rf "$_boundary_dir"
 
 # Scenario 15: single bound definition
-_assign_count="$(rg -l 'REVIEW_DOCTRINE_MAX_BYTES=' scripts --glob '*.sh' 2>/dev/null | rg -v '/tests/' | wc -l | tr -d ' ')"
+_assign_count=0
+while IFS= read -r _assign_file; do
+  case "$_assign_file" in
+    */tests/*) continue ;;
+    *) _assign_count=$((_assign_count + 1)) ;;
+  esac
+done < <(grep -rl 'REVIEW_DOCTRINE_MAX_BYTES=' scripts 2>/dev/null || true)
 run_test "s15_single_assignment" "1" "$_assign_count"
 run_test "s15_linter_uses_constant" "yes" "$(grep -Fq '$REVIEW_DOCTRINE_MAX_BYTES' "$LINTER" && echo yes || echo no)"
 run_test "s15_linter_no_literal_gt" "no" "$(grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' "$LINTER" && echo yes || echo no)"

--- a/scripts/development-workflow/tests/test-review-doctrine-lint.sh
+++ b/scripts/development-workflow/tests/test-review-doctrine-lint.sh
@@ -120,10 +120,12 @@ run_test "s16_ac3a_name_pattern" "yes" "$(grep -Fq 'name it' "$CATALOGUE" && ech
 run_test "s16a_catalogue_generality" "yes" "$(grep -Fq 'reads generally' "$CATALOGUE" && echo yes || echo no)"
 run_test "s16a_review_generality" "yes" "$(grep -Fq 'read generally' "$REPO_ROOT/REVIEW.md" && echo yes || echo no)"
 
-# Scenario 17: CI path filters
-run_test "s17_markdown_paths_catalogue" "yes" "$(grep -Fq 'docs/workflow/development-workflow/review-doctrine.md' "$REPO_ROOT/.github/workflows/markdown-lint.yml" && echo yes || echo no)"
-run_test "s17_markdown_paths_linter" "yes" "$(grep -Fq 'scripts/lint/review-doctrine-lint.sh' "$REPO_ROOT/.github/workflows/markdown-lint.yml" && echo yes || echo no)"
-run_test "s17_shellcheck_paths_linter" "yes" "$(grep -Fq 'scripts/lint/review-doctrine-lint.sh' "$REPO_ROOT/.github/workflows/shellcheck.yml" && echo yes || echo no)"
+# Scenario 17: CI path filters (paths: block only — not run: steps)
+_markdown_paths_section="$(awk '/^on:/{on=1} on && /^  pull_request:/{pr=1} pr && /^    paths:/{paths=1;next} paths && /^      -/{print;next} paths && /^[^ ]/{exit}' "$REPO_ROOT/.github/workflows/markdown-lint.yml")"
+_shellcheck_paths_section="$(awk '/^on:/{on=1} on && /^  pull_request:/{pr=1} pr && /^    paths:/{paths=1;next} paths && /^      -/{print;next} paths && /^[^ ]/{exit}' "$REPO_ROOT/.github/workflows/shellcheck.yml")"
+run_test "s17_markdown_paths_catalogue" "yes" "$(printf '%s\n' "$_markdown_paths_section" | grep -Fq 'docs/workflow/development-workflow/review-doctrine.md' && echo yes || echo no)"
+run_test "s17_markdown_paths_linter" "yes" "$(printf '%s\n' "$_markdown_paths_section" | grep -Fq 'scripts/lint/review-doctrine-lint.sh' && echo yes || echo no)"
+run_test "s17_shellcheck_paths_linter" "yes" "$(printf '%s\n' "$_shellcheck_paths_section" | grep -Fq 'scripts/lint/review-doctrine-lint.sh' && echo yes || echo no)"
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"

--- a/scripts/development-workflow/tests/test-review-doctrine-lint.sh
+++ b/scripts/development-workflow/tests/test-review-doctrine-lint.sh
@@ -40,6 +40,7 @@ lint_exit() {
 run_test "s11_well_formed_pass" "0" "$(lint_exit "$FIXTURES/well-formed.md")"
 run_test "s11_missing_detect_fail" "1" "$(lint_exit "$FIXTURES/malformed-missing-detect.md")"
 run_test "s11_duplicate_shape_fail" "1" "$(lint_exit "$FIXTURES/malformed-duplicate-shape.md")"
+run_test "s11_wrong_order_fail" "1" "$(lint_exit "$FIXTURES/malformed-wrong-order.md")"
 
 # Scenario 12: incident references (one per AC-4 form)
 run_test "s12_hash_number_fail" "1" "$(lint_exit "$FIXTURES/incident-hash-number.md")"

--- a/scripts/development-workflow/tests/test-review-doctrine-lint.sh
+++ b/scripts/development-workflow/tests/test-review-doctrine-lint.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Unit tests for review-doctrine-lint.sh and the shipped catalogue.
+# covers: scripts/lint/review-doctrine-lint.sh
+# covers: docs/workflow/development-workflow/review-doctrine.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+LINTER="$REPO_ROOT/scripts/lint/review-doctrine-lint.sh"
+FIXTURES="$SCRIPT_DIR/fixtures/review-doctrine"
+CATALOGUE="$REPO_ROOT/docs/workflow/development-workflow/review-doctrine.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+lint_exit() {
+  local file="$1"
+  set +e
+  bash "$LINTER" "$file" >/dev/null 2>&1
+  local status=$?
+  set -e
+  printf '%s' "$status"
+}
+
+# Scenario 11: well-formedness
+run_test "s11_well_formed_pass" "0" "$(lint_exit "$FIXTURES/well-formed.md")"
+run_test "s11_missing_detect_fail" "1" "$(lint_exit "$FIXTURES/malformed-missing-detect.md")"
+run_test "s11_duplicate_shape_fail" "1" "$(lint_exit "$FIXTURES/malformed-duplicate-shape.md")"
+
+# Scenario 12: incident references (one per AC-4 form)
+run_test "s12_hash_number_fail" "1" "$(lint_exit "$FIXTURES/incident-hash-number.md")"
+run_test "s12_forge_url_fail" "1" "$(lint_exit "$FIXTURES/incident-forge-url.md")"
+run_test "s12_spelled_out_fail" "1" "$(lint_exit "$FIXTURES/incident-spelled-out.md")"
+run_test "s12_dev_path_fail" "1" "$(lint_exit "$FIXTURES/incident-dev-path.md")"
+
+# Scenario 12 near-miss controls (must pass on well-formed + shipped catalogue)
+_near_miss_file="$(mktemp)"
+cat > "$_near_miss_file" <<'EOF'
+# Near misses
+
+Guidance may mention docs/specs/ without developments.
+
+### Clean controls
+
+**Shape**: Hash-like headings must not match.
+
+**Example**: Use # Title and PR review language safely.
+
+**Detect**: Also example.com/pull/1 is not github.com.
+
+EOF
+run_test "s12_near_miss_pass" "0" "$(lint_exit "$_near_miss_file")"
+rm -f "$_near_miss_file"
+
+# Scenario 13: preamble path allowed
+run_test "s13_preamble_path_pass" "0" "$(lint_exit "$FIXTURES/preamble-dev-path-clean-entries.md")"
+
+# Scenario 14: boundary sizes
+_boundary_dir="$(mktemp -d)"
+_boundary_pass="$_boundary_dir/at-bound.md"
+_boundary_fail="$_boundary_dir/over-bound.md"
+python3 - <<'PY' "$FIXTURES/well-formed.md" "$_boundary_pass" "$_boundary_fail"
+import pathlib, sys
+src = pathlib.Path(sys.argv[1]).read_bytes()
+base = pathlib.Path(sys.argv[2])
+fail = pathlib.Path(sys.argv[3])
+padding = b"x" * 8000
+body = src + b"\n\n### Pad entry\n\n**Shape**: pad\n\n**Example**: " + padding + b"\n\n**Detect**: pad?\n"
+while len(body) < 12000:
+    body += b" "
+body = body[:12000]
+base.write_bytes(body)
+fail.write_bytes(body + b"x")
+PY
+run_test "s14_at_12000_pass" "0" "$(lint_exit "$_boundary_pass")"
+run_test "s14_at_12001_fail" "1" "$(lint_exit "$_boundary_fail")"
+
+# Scenario 15b: behavioural boundary agreement (reuse over-bound fixture)
+run_test "s15b_linter_rejects_oversized" "1" "$(lint_exit "$_boundary_fail")"
+rm -rf "$_boundary_dir"
+
+# Scenario 15: single bound definition
+_assign_count="$(rg -l 'REVIEW_DOCTRINE_MAX_BYTES=' scripts --glob '*.sh' 2>/dev/null | rg -v '/tests/' | wc -l | tr -d ' ')"
+run_test "s15_single_assignment" "1" "$_assign_count"
+run_test "s15_linter_uses_constant" "yes" "$(grep -Fq '$REVIEW_DOCTRINE_MAX_BYTES' "$LINTER" && echo yes || echo no)"
+run_test "s15_linter_no_literal_gt" "no" "$(grep -Eq -- '-gt[[:space:]]+[1-9][0-9]{2,}' "$LINTER" && echo yes || echo no)"
+run_test "s15_reviewer_uses_constant" "yes" "$(grep -Fq '$REVIEW_DOCTRINE_MAX_BYTES' "$REPO_ROOT/scripts/development-workflow/local-ai-reviewer.sh" && echo yes || echo no)"
+
+# Scenario 16: shipped catalogue
+run_test "s16_shipped_passes_linter" "0" "$(lint_exit "$CATALOGUE")"
+_pattern_count="$(grep -c '^### ' "$CATALOGUE" || true)"
+run_test "s16_five_patterns" "5" "$_pattern_count"
+run_test "s16_ac3_not_only_reporting" "yes" "$(grep -Fq 'set of things worth reporting' "$CATALOGUE" && echo yes || echo no)"
+run_test "s16_ac3a_name_pattern" "yes" "$(grep -Fq 'name it' "$CATALOGUE" && echo yes || echo no)"
+
+# Scenario 16a: generality obligation in catalogue guidance
+run_test "s16a_catalogue_generality" "yes" "$(grep -Fq 'reads generally' "$CATALOGUE" && echo yes || echo no)"
+run_test "s16a_review_generality" "yes" "$(grep -Fq 'read generally' "$REPO_ROOT/REVIEW.md" && echo yes || echo no)"
+
+# Scenario 17: CI path filters
+run_test "s17_markdown_paths_catalogue" "yes" "$(grep -Fq 'docs/workflow/development-workflow/review-doctrine.md' "$REPO_ROOT/.github/workflows/markdown-lint.yml" && echo yes || echo no)"
+run_test "s17_markdown_paths_linter" "yes" "$(grep -Fq 'scripts/lint/review-doctrine-lint.sh' "$REPO_ROOT/.github/workflows/markdown-lint.yml" && echo yes || echo no)"
+run_test "s17_shellcheck_paths_linter" "yes" "$(grep -Fq 'scripts/lint/review-doctrine-lint.sh' "$REPO_ROOT/.github/workflows/shellcheck.yml" && echo yes || echo no)"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAIL: $FAIL_COUNT test(s) failed"
+  exit 1
+fi
+
+echo "PASS: $PASS_COUNT test(s) passed"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# The review doctrine's maximum size, in bytes as `wc -c` measures them.
+# AC-12: one source of truth, read by both the linter and the reviewer.
+readonly REVIEW_DOCTRINE_MAX_BYTES=12000
+
 workflow_script_dir() {
   if [[ -z "${BASH_SOURCE[0]:-}" ]]; then
     printf 'ERROR: BASH_SOURCE[0] is unset — source workflow-lib.sh from a Bash script or via:\n  bash -c "source scripts/development-workflow/workflow-lib.sh"\n' >&2

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 
 # The review doctrine's maximum size, in bytes as `wc -c` measures them.
 # AC-12: one source of truth, read by both the linter and the reviewer.
-if ! declare -p REVIEW_DOCTRINE_MAX_BYTES >/dev/null 2>&1; then
+if declare -p REVIEW_DOCTRINE_MAX_BYTES >/dev/null 2>&1; then
+  if [[ "$(declare -p REVIEW_DOCTRINE_MAX_BYTES 2>/dev/null || true)" != *"-r"* ]]; then
+    unset REVIEW_DOCTRINE_MAX_BYTES
+    readonly REVIEW_DOCTRINE_MAX_BYTES=12000
+  fi
+else
   readonly REVIEW_DOCTRINE_MAX_BYTES=12000
 fi
 

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 # The review doctrine's maximum size, in bytes as `wc -c` measures them.
 # AC-12: one source of truth, read by both the linter and the reviewer.
-readonly REVIEW_DOCTRINE_MAX_BYTES=12000
+if ! declare -p REVIEW_DOCTRINE_MAX_BYTES >/dev/null 2>&1; then
+  readonly REVIEW_DOCTRINE_MAX_BYTES=12000
+fi
 
 workflow_script_dir() {
   if [[ -z "${BASH_SOURCE[0]:-}" ]]; then

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -5,10 +5,18 @@ set -euo pipefail
 # The review doctrine's maximum size, in bytes as `wc -c` measures them.
 # AC-12: one source of truth, read by both the linter and the reviewer.
 if declare -p REVIEW_DOCTRINE_MAX_BYTES >/dev/null 2>&1; then
-  if [[ "$(declare -p REVIEW_DOCTRINE_MAX_BYTES 2>/dev/null || true)" != *"-r"* ]]; then
-    unset REVIEW_DOCTRINE_MAX_BYTES
-    readonly REVIEW_DOCTRINE_MAX_BYTES=12000
-  fi
+  case "$(declare -p REVIEW_DOCTRINE_MAX_BYTES 2>/dev/null || true)" in
+    *"-r"*)
+      if [ "${REVIEW_DOCTRINE_MAX_BYTES}" != "12000" ]; then
+        echo "ERROR: REVIEW_DOCTRINE_MAX_BYTES is readonly at ${REVIEW_DOCTRINE_MAX_BYTES}; AC-12 requires 12000." >&2
+        return 1
+      fi
+      ;;
+    *)
+      unset REVIEW_DOCTRINE_MAX_BYTES
+      readonly REVIEW_DOCTRINE_MAX_BYTES=12000
+      ;;
+  esac
 else
   readonly REVIEW_DOCTRINE_MAX_BYTES=12000
 fi

--- a/scripts/lint/review-doctrine-lint.sh
+++ b/scripts/lint/review-doctrine-lint.sh
@@ -58,6 +58,7 @@ check_entry_well_formed() {
   local entry_text="$1"
   local name="$2"
   local shape_count example_count detect_count
+  local shape_line example_line detect_line
 
   shape_count="$(printf '%s\n' "$entry_text" | grep -c '^\*\*Shape\*\*:' || true)"
   example_count="$(printf '%s\n' "$entry_text" | grep -c '^\*\*Example\*\*:' || true)"
@@ -65,6 +66,14 @@ check_entry_well_formed() {
 
   if [ "$shape_count" -ne 1 ] || [ "$example_count" -ne 1 ] || [ "$detect_count" -ne 1 ]; then
     report_fail "review-doctrine well-formedness FAILED: entry \"$name\" must have exactly one **Shape**:, one **Example**: and one **Detect**: (found shape=$shape_count example=$example_count detect=$detect_count)"
+    return 1
+  fi
+
+  shape_line="$(printf '%s\n' "$entry_text" | grep -n '^\*\*Shape\*\*:' | head -1 | cut -d: -f1)"
+  example_line="$(printf '%s\n' "$entry_text" | grep -n '^\*\*Example\*\*:' | head -1 | cut -d: -f1)"
+  detect_line="$(printf '%s\n' "$entry_text" | grep -n '^\*\*Detect\*\*:' | head -1 | cut -d: -f1)"
+  if [ "$shape_line" -gt "$example_line" ] || [ "$example_line" -gt "$detect_line" ]; then
+    report_fail "review-doctrine well-formedness FAILED: entry \"$name\" must order **Shape**:, **Example**:, **Detect**: (found shape@$shape_line example@$example_line detect@$detect_line)"
     return 1
   fi
   return 0

--- a/scripts/lint/review-doctrine-lint.sh
+++ b/scripts/lint/review-doctrine-lint.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# review-doctrine-lint.sh
+#
+# Validates docs/workflow/development-workflow/review-doctrine.md:
+#   1. Well-formed entries (AC-2a)
+#   2. No mechanically detectable incident references in entries (AC-5)
+#   3. Size at or below REVIEW_DOCTRINE_MAX_BYTES (AC-11)
+#
+# Usage:
+#   ./scripts/lint/review-doctrine-lint.sh [review-doctrine.md]
+#
+# Arguments:
+#   FILE   Path to the catalogue (default: docs/workflow/development-workflow/review-doctrine.md)
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/../development-workflow/workflow-lib.sh"
+
+FILE="${1:-docs/workflow/development-workflow/review-doctrine.md}"
+
+if [ ! -f "$FILE" ]; then
+  echo "ERROR: file not found: $FILE" >&2
+  exit 1
+fi
+
+failures=0
+
+report_fail() {
+  echo "$1"
+  failures=$((failures + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Check 3: Size (run first — cheap)
+# ---------------------------------------------------------------------------
+file_bytes="$(wc -c <"$FILE" | tr -d '[:space:]')"
+if [ "$file_bytes" -gt "$REVIEW_DOCTRINE_MAX_BYTES" ]; then
+  report_fail "review-doctrine size check FAILED: $file_bytes bytes exceeds bound $REVIEW_DOCTRINE_MAX_BYTES"
+else
+  echo "review-doctrine size check passed: $file_bytes bytes (bound $REVIEW_DOCTRINE_MAX_BYTES)"
+fi
+
+# ---------------------------------------------------------------------------
+# Parse entries: from each ### heading to the next ### or EOF
+# ---------------------------------------------------------------------------
+entry_starts=()
+while IFS= read -r line; do
+  entry_starts+=("$line")
+done < <(grep -n '^### ' "$FILE" | cut -d: -f1)
+
+check_entry_well_formed() {
+  local entry_text="$1"
+  local name="$2"
+  local shape_count example_count detect_count
+
+  shape_count="$(printf '%s\n' "$entry_text" | grep -c '^\*\*Shape\*\*:' || true)"
+  example_count="$(printf '%s\n' "$entry_text" | grep -c '^\*\*Example\*\*:' || true)"
+  detect_count="$(printf '%s\n' "$entry_text" | grep -c '^\*\*Detect\*\*:' || true)"
+
+  if [ "$shape_count" -ne 1 ] || [ "$example_count" -ne 1 ] || [ "$detect_count" -ne 1 ]; then
+    report_fail "review-doctrine well-formedness FAILED: entry \"$name\" must have exactly one **Shape**:, one **Example**: and one **Detect**: (found shape=$shape_count example=$example_count detect=$detect_count)"
+    return 1
+  fi
+  return 0
+}
+
+check_entry_incident_refs() {
+  local entry_text="$1"
+  local name="$2"
+  local line_num=0
+  local line
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_num=$((line_num + 1))
+    if printf '%s\n' "$line" | grep -Eq '#[0-9]+'; then
+      report_fail "review-doctrine incident-reference FAILED: entry \"$name\" line $line_num contains hash-number reference"
+    fi
+    if printf '%s\n' "$line" | grep -Eq 'github\.com/[^[:space:]]+'; then
+      report_fail "review-doctrine incident-reference FAILED: entry \"$name\" line $line_num contains forge URL"
+    fi
+    if printf '%s\n' "$line" | grep -Eiq '\<(PR|pull request|issue)[[:space:]]+#?[0-9]+'; then
+      report_fail "review-doctrine incident-reference FAILED: entry \"$name\" line $line_num contains spelled-out reference"
+    fi
+    if printf '%s\n' "$line" | grep -Fq 'docs/specs/developments/'; then
+      report_fail "review-doctrine incident-reference FAILED: entry \"$name\" line $line_num contains development-folder path"
+    fi
+  done <<< "$entry_text"
+}
+
+if [ "${#entry_starts[@]}" -eq 0 ]; then
+  echo "review-doctrine well-formedness passed: no pattern entries (empty catalogue)"
+  echo "review-doctrine incident-reference passed: no entries to scan"
+else
+  well_formed_ok=0
+  incident_ok=0
+  total_lines="$(wc -l <"$FILE" | tr -d '[:space:]')"
+  idx=0
+  while [ "$idx" -lt "${#entry_starts[@]}" ]; do
+    start="${entry_starts[$idx]}"
+    if [ "$idx" -lt $((${#entry_starts[@]} - 1)) ]; then
+      end=$((entry_starts[$idx + 1] - 1))
+    else
+      end="$total_lines"
+    fi
+    entry_name="$(sed -n "${start}p" "$FILE" | sed 's/^### //')"
+    entry_text="$(sed -n "${start},${end}p" "$FILE")"
+    if check_entry_well_formed "$entry_text" "$entry_name"; then
+      well_formed_ok=$((well_formed_ok + 1))
+    fi
+    check_entry_incident_refs "$entry_text" "$entry_name"
+    incident_ok=$((incident_ok + 1))
+    idx=$((idx + 1))
+  done
+  if [ "$well_formed_ok" -eq "${#entry_starts[@]}" ]; then
+    echo "review-doctrine well-formedness passed: ${#entry_starts[@]} entries"
+  fi
+  if [ "$failures" -eq 0 ]; then
+    echo "review-doctrine incident-reference passed: ${#entry_starts[@]} entries scanned"
+  fi
+fi
+
+if [ "$failures" -gt 0 ]; then
+  echo ""
+  echo "review-doctrine lint FAILED: $failures check(s) failed for $FILE"
+  exit 1
+fi
+
+echo "review-doctrine lint passed: $FILE"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `docs/workflow/development-workflow/review-doctrine.md` with five generalized seed patterns (criteria/matrix mismatch, opt-out ambiguity, parser-surface conflict, trigger ambiguity, example contradicting rule).
- Introduces `scripts/lint/review-doctrine-lint.sh` with a single `REVIEW_DOCTRINE_MAX_BYTES` source of truth in `workflow-lib.sh`.
- Wires doctrine supply into `local-ai-reviewer.sh` (bundle, evidence, `REVIEW_DOCTRINE_*` keys) and forwards those keys through `pr-review-loop.sh`.

## Planted-violation proofs (P1–P14)

Recorded per REVIEW.md Workflow Policy checklist item 4 and plan step 8. Each row: **fail** = planted violation on scratch copy; **pass** = canonical code / test harness.

| Proof | Plant location | Verification | Fail evidence | Pass evidence |
| --- | --- | --- | --- | --- |
| P1 | `reviewer_doctrine_supply` state collapse | `test-local-ai-reviewer.sh` 1654_s1_* | Single `not_supplied` state | Four distinct states asserted |
| P2 | oversized row supplies truncated text | 1654_s2_oversized_text_empty | Non-empty `text` | Empty `text`, present `version` |
| P3 | duplicate bound in linter | `test-review-doctrine-lint.sh` s15_* | Second assignment or literal `-gt 12000` | One assignment in `workflow-lib.sh` |
| P4 | whole-file incident scan | s13_preamble_path_pass | Preamble path rejects catalogue | Entry-scoped scan passes |
| P5 | missing digest → empty version | supply reader | `supplied` + empty version | `unreadable` when no digest cmd |
| P6 | doctrine text in kv output | 1654_s8_no_text_kv | `REVIEW_DOCTRINE=` line | Count 0 |
| P7 | stage-conditional supply | 1654_s9_* | Default branch skips doctrine | All stages `supplied` |
| P8 | overridable bound | s14 + readonly constant | 12001 bytes `supplied` under env override | 12001 fails lint + `oversized` |
| P9 | `cat`/`--arg` text path | 1654_s7a_bytes_match | `cmp` fails trailing newline | Byte-identical via `--argjson` |
| P10 | `[ -r ]` only | 1654_s1_unreadable | Reviewer aborts under `set -e` | `unreadable` state returned |
| P11 | multi-read race | single snapshot in supply reader | version ≠ hash(text) mid-edit | One snapshot for all four fields |
| P12 | `grep -c \|\| true` | grep status branch in supply reader | `supplied` on grep error | `unreadable` on exit >1 |
| P13 | evidence missing doctrine | 1654_s8a_* | No `.review_doctrine` object | Object with state/count/version |
| P14 | CI step without paths | s17_* + workflow trigger | Catalogue-only PR skips checks | Paths + explicit lint step |

Regression commands (head): `bash scripts/development-workflow/tests/test-review-doctrine-lint.sh` (25 pass), `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh` (283 pass), `bash scripts/lint/review-doctrine-lint.sh`.

## Test plan

- [x] `bash scripts/lint/review-doctrine-lint.sh`
- [x] `bash scripts/development-workflow/tests/test-review-doctrine-lint.sh`
- [x] `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`
- [ ] CI markdown-lint and shellcheck workflows
- [ ] Internal reviewer loop (Step 7)
- [ ] Smoke runbook: `docs/testing/workflow/1654-codex-patterns-to-local-doctrine.smoke-test.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reviewer stdout/bundle contracts and `pr-review-loop` key forwarding used by automation; changes are heavily tested but alter surfaces other scripts may parse.
> 
> **Overview**
> Introduces a **review doctrine** catalogue (`review-doctrine.md`) of five generalized finding patterns and wires it into the local AI reviewer so models see doctrine in the context bundle while operators only get **supply metadata** on stdout (`REVIEW_DOCTRINE_STATE`, `REVIEW_DOCTRINE_PATTERN_COUNT`, `REVIEW_DOCTRINE_VERSION`)—not the full catalogue text.
> 
> **Supply behavior** snapshots the catalogue once (12 000-byte cap via shared `REVIEW_DOCTRINE_MAX_BYTES` in `workflow-lib.sh`), distinguishes `supplied` / `absent` / `unreadable` / `oversized`, and attaches doctrine fields to evidence JSON and `pr-review-loop.sh` as `PLATFORM_*` keys. **`review-doctrine-lint.sh`** enforces entry shape, bans incident-specific references inside patterns, and enforces the size bound; CI markdown-lint and shellcheck workflows gain path filters and an explicit lint step.
> 
> **Policy/docs**: `REVIEW.md` gains a workflow-policy checklist item that catalogue entries must read generally; integration and reviewer-loop protocol docs describe the new env/bundle fields. Regression coverage includes fixture catalogues, `test-review-doctrine-lint.sh`, expanded `test-local-ai-reviewer.sh`, and planted-violation proof notes (P1–P14).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde4517436f8b583182800823d7f7028699849cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Cross-Cutting Operational Assumption re-verification (implementation)

| Surface | Result |
| --- | --- |
| Base `develop-internal-reviewer-effectiveness` | Still valid |
| 16-field bundle post-#1653 + 4 doctrine fields | Still valid (#1653 merged before implementation) |
| Shared `REVIEW_DOCTRINE_MAX_BYTES` in `workflow-lib.sh` | Still valid |
