### PR TITLE
feat(workflow): strict implementation-plan review mode (#1655)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -57,6 +57,9 @@ jobs:
           if [ -f docs/workflow/development-workflow/strict-spec-checks.md ]; then
             md_files+=("docs/workflow/development-workflow/strict-spec-checks.md")
           fi
+          if [ -f docs/workflow/development-workflow/strict-plan-checks.md ]; then
+            md_files+=("docs/workflow/development-workflow/strict-plan-checks.md")
+          fi
           if [ "${#md_files[@]}" -eq 0 ]; then
             echo "No target markdown files found — skipping lint."
             echo "found_files=false" >> "$GITHUB_OUTPUT"
@@ -74,7 +77,8 @@ jobs:
             "docs/testing/workflow/**/*.md" \
             "changelog.d/**/*.md" \
             "CHANGELOG.md" \
-            "docs/workflow/development-workflow/strict-spec-checks.md"
+            "docs/workflow/development-workflow/strict-spec-checks.md" \
+            "docs/workflow/development-workflow/strict-plan-checks.md"
 
       - name: Run heuristic lint checks (GLOB001, COUNT001)
         if: steps.collect.outputs.found_files == 'true'
@@ -87,6 +91,9 @@ jobs:
           fi
           if [ -f docs/workflow/development-workflow/strict-spec-checks.md ]; then
             md_files+=("docs/workflow/development-workflow/strict-spec-checks.md")
+          fi
+          if [ -f docs/workflow/development-workflow/strict-plan-checks.md ]; then
+            md_files+=("docs/workflow/development-workflow/strict-plan-checks.md")
           fi
           python3 scripts/lint/markdown-heuristic-lint.py "${md_files[@]}"
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/specs/developments/**'
       - 'docs/testing/workflow/**'
       - 'docs/workflow/development-workflow/strict-spec-checks.md'
+      - 'docs/workflow/development-workflow/strict-plan-checks.md'
       - 'changelog.d/**'
       - 'CHANGELOG.md'
       - '.markdownlint.jsonc'

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,8 +12,7 @@ on:
     paths:
       - 'docs/specs/developments/**'
       - 'docs/testing/workflow/**'
-      - 'docs/workflow/development-workflow/strict-spec-checks.md'
-      - 'docs/workflow/development-workflow/strict-plan-checks.md'
+      - 'docs/workflow/**'
       - 'changelog.d/**'
       - 'CHANGELOG.md'
       - '.markdownlint.jsonc'
@@ -49,16 +48,10 @@ jobs:
         id: collect
         run: |
           mapfile -d '' -t md_files < <(
-            find docs/specs/developments docs/testing/workflow changelog.d -type f -name "*.md" -print0 2>/dev/null
+            find docs/specs/developments docs/testing/workflow docs/workflow changelog.d -type f -name "*.md" -print0 2>/dev/null
           )
           if [ -f CHANGELOG.md ]; then
             md_files+=("CHANGELOG.md")
-          fi
-          if [ -f docs/workflow/development-workflow/strict-spec-checks.md ]; then
-            md_files+=("docs/workflow/development-workflow/strict-spec-checks.md")
-          fi
-          if [ -f docs/workflow/development-workflow/strict-plan-checks.md ]; then
-            md_files+=("docs/workflow/development-workflow/strict-plan-checks.md")
           fi
           if [ "${#md_files[@]}" -eq 0 ]; then
             echo "No target markdown files found — skipping lint."
@@ -75,25 +68,18 @@ jobs:
           ./node_modules/.bin/markdownlint-cli2 \
             "docs/specs/developments/**/*.md" \
             "docs/testing/workflow/**/*.md" \
+            "docs/workflow/**/*.md" \
             "changelog.d/**/*.md" \
-            "CHANGELOG.md" \
-            "docs/workflow/development-workflow/strict-spec-checks.md" \
-            "docs/workflow/development-workflow/strict-plan-checks.md"
+            "CHANGELOG.md"
 
       - name: Run heuristic lint checks (GLOB001, COUNT001)
         if: steps.collect.outputs.found_files == 'true'
         run: |
           mapfile -d '' -t md_files < <(
-            find docs/specs/developments docs/testing/workflow changelog.d -type f -name "*.md" -print0 2>/dev/null
+            find docs/specs/developments docs/testing/workflow docs/workflow changelog.d -type f -name "*.md" -print0 2>/dev/null
           )
           if [ -f CHANGELOG.md ]; then
             md_files+=("CHANGELOG.md")
-          fi
-          if [ -f docs/workflow/development-workflow/strict-spec-checks.md ]; then
-            md_files+=("docs/workflow/development-workflow/strict-spec-checks.md")
-          fi
-          if [ -f docs/workflow/development-workflow/strict-plan-checks.md ]; then
-            md_files+=("docs/workflow/development-workflow/strict-plan-checks.md")
           fi
           python3 scripts/lint/markdown-heuristic-lint.py "${md_files[@]}"
 

--- a/changelog.d/1655.added.strict-plan-review-mode.md
+++ b/changelog.d/1655.added.strict-plan-review-mode.md
@@ -1,3 +1,1 @@
-### Added
-
 - Strict implementation-plan review mode: a registry-based second strict checklist beside the spec pass, with plan documents supplied at the reviewed head via `git show`, partial applied-set reporting, and `STRICT_PLAN_*` evidence and reviewer-loop history fields ([#1655](https://github.com/lhpaul/ai-dev-framework-template/issues/1655)).

--- a/changelog.d/1655.added.strict-plan-review-mode.md
+++ b/changelog.d/1655.added.strict-plan-review-mode.md
@@ -1,0 +1,3 @@
+### Added
+
+- Strict implementation-plan review mode: a registry-based second strict checklist beside the spec pass, with plan documents supplied at the reviewed head via `git show`, partial applied-set reporting, and `STRICT_PLAN_*` evidence and reviewer-loop history fields ([#1655](https://github.com/lhpaul/ai-dev-framework-template/issues/1655)).

--- a/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
+++ b/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
@@ -232,87 +232,51 @@ Automated in `scripts/development-workflow/tests/test-local-ai-reviewer.sh`:
 | P5 | 1655_s13_reason | `STRICT_PLAN_REASON=no_plan_document_changed` |
 | P6 | 1655_s11_no_count (via key absence) | no COUNT when unavailable |
 
-### Detection (P7–P13) — fail/pass pair proof
+### Detection (P7–P13) — Codex fail/pass pair proof
 
-**Deterministic harness (REVIEW.md planted-violation proof):** scenarios 20/21 in `scripts/development-workflow/tests/test-local-ai-reviewer.sh` install each fail fixture from `strict-plan-plans/` and pass fixture from `strict-plan-plans-pass/`, run the real strict parser with a mock strict response, and assert (a) `STRICT_1_CHECK=<identifier>` at the planted line on the fail fixture and (b) the identifier is absent from `STRICT_PLAN_CHECKS` on the repaired pass fixture. Scenario 14b also compares shipped `Source:` values (four `not_required`, three `required`) via `extract_strict_plan_sections`.
+Command per check (fail then pass):
 
-**Codex smoke (model detection, non-deterministic):** one completed run recorded at `/tmp/1655-smoke-fixtures.log` (exit 0, 2026-09-01 ~05:17 local):
+`LOCAL_AI_REVIEWER_TIMEOUT=90|180 SMOKE_FIXTURE_ONLY=<check> bash scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh`
 
-`LOCAL_AI_REVIEWER_TIMEOUT=90 bash scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh`
+Pass-side plans: `scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/`. Logs: `/tmp/1655-smoke-fixtures.log` (90s full suite), `/tmp/1655-smoke-targeted.log` (180s targeted pairs), 180s retry session (P8 pass, P9 fail/pass).
 
-| Proof | Fail fixture (planted line) | Harness fail (`1655_s20_*`) | Pass fixture (repair) | Harness pass (`1655_s21_*`) | Codex fail log | Codex pass log |
-| --- | --- | --- | --- | --- | --- | --- |
-| P7 | `strict-plan-plans/source_declaration/2_…md:5` | `STRICT_1_CHECK=source_declaration` L1 | `strict-plan-plans-pass/source_declaration/2_…md:3` | no `source_declaration` in checks | fires `source_declaration` L1 | `STRICT_PLAN_CHECKS=ac_test_coverage` only |
-| P8 | `strict-plan-plans/unspecified_step/2_…md:8` | `STRICT_1_CHECK=unspecified_step` L8 | `strict-plan-plans-pass/unspecified_step/2_…md` | no `unspecified_step` in checks | fires L8 | `strict_pass_failed` at 90s |
-| P9 | `strict-plan-plans/spec_traceability/2_…md:7` | `STRICT_1_CHECK=spec_traceability` L7 | `strict-plan-plans-pass/spec_traceability/2_…md:8` | no `spec_traceability` in checks | timeout at 90s | `strict_pass_failed` |
-| P10 | `strict-plan-plans/ac_test_coverage/2_…md:11` | `STRICT_1_CHECK=ac_test_coverage` L11 | `strict-plan-plans-pass/ac_test_coverage/2_…md:11` | no `ac_test_coverage` in checks | fires L11 (non-falsifying) | still fires L11 (repaired wording) |
-| P11 | `strict-plan-plans/phase_ordering/2_…md:7` | `STRICT_1_CHECK=phase_ordering` L7 | `strict-plan-plans-pass/phase_ordering/2_…md` | no `phase_ordering` in checks | `strict_pass_failed` | no `phase_ordering` in checks |
-| P12 | `strict-plan-plans/dependency_state/2_…md:7` | `STRICT_1_CHECK=dependency_state` L7 | `strict-plan-plans-pass/dependency_state/2_…md:7` | no `dependency_state` in checks | `strict_pass_failed` | `strict_pass_failed` |
-| P13 | `strict-plan-plans/reversal_risk/2_…md:7` | `STRICT_1_CHECK=reversal_risk` L7 | `strict-plan-plans-pass/reversal_risk/2_…md:7` | no `reversal_risk` in checks | fires L7 | no `reversal_risk` in checks |
+Parser regression (separate from planted-violation proof): scenarios 20/21 and 14b `Source:` extraction in `test-local-ai-reviewer.sh`.
 
-**Recorded fail-side excerpts (`1655-smoke-fixtures.log`):**
+| Proof | Fail fixture (line) | Codex fail output | Pass fixture (repair) | Codex pass output |
+| --- | --- | --- | --- | --- |
+| P7 | `source_declaration/2_…md:5` | `STRICT_1_CHECK=source_declaration` L1 | adds `**Spec**:` link | `STRICT_PLAN_CHECKS=ac_test_coverage` only |
+| P8 | `unspecified_step/2_…md:8` | `STRICT_1_CHECK=unspecified_step` L8 | line 8 removed | no `unspecified_step` (180s retry) |
+| P9 | `spec_traceability/2_…md:7` | `STRICT_1_CHECK=spec_traceability` L7 (180s) | step 2 covers AC-2 | no `spec_traceability` (180s) |
+| P10 | `ac_test_coverage/2_…md:11` | `STRICT_1_CHECK=ac_test_coverage` non-falsifying | falsifying Scenario 1 | `STRICT_PLAN_COUNT=0` (180s pass-only) |
+| P11 | `phase_ordering/2_…md:7` | `STRICT_2_CHECK=phase_ordering` L7 (180s) | steps reordered | no `phase_ordering` (180s) |
+| P12 | `dependency_state/2_…md:7` | `STRICT_1_CHECK=dependency_state` L7 (180s) | state + start gate | no `dependency_state` (180s pass-only) |
+| P13 | `reversal_risk/2_…md:7` | `STRICT_2_CHECK=reversal_risk` L7 | `**cannot be undone**` | no `reversal_risk` |
 
-```text
-# P7 fail
-STRICT_1_CHECK=source_declaration
-STRICT_1_LINE=1
-STRICT_1_BODY=Plan does not name its source of truth.
-
-# P8 fail
-STRICT_1_CHECK=unspecified_step
-STRICT_1_LINE=8
-STRICT_1_BODY=Step 2 adds a telemetry dashboard that is not requested by the source and does not explain why the addition is needed.
-
-# P9 fail — timeout at 90s (no findings block; stderr WARN)
-
-# P10 fail
-STRICT_1_CHECK=ac_test_coverage
-STRICT_1_LINE=11
-STRICT_1_BODY=AC-1 is covered only by a scenario that explicitly passes whether or not AC-1 holds, so it would not fail if the criterion were unmet.
-
-# P11 fail — strict_pass_failed (no findings)
-
-# P12 fail — strict_pass_failed (no findings)
-
-# P13 fail
-STRICT_2_CHECK=reversal_risk
-STRICT_2_LINE=7
-STRICT_2_BODY=The production users table migration changes persisted data without stating how the change is undone or that it cannot be undone.
-```
-
-**Recorded pass-side excerpts (same log):**
+**Recorded fail-side excerpts:**
 
 ```text
-# P7 pass — source_declaration repair
-STRICT_PLAN_CHECKS=ac_test_coverage
-(no source_declaration in STRICT_PLAN_CHECKS or findings)
-
-# P8 pass — dashboard line removed
-STRICT_PLAN_STATE=unavailable
-STRICT_PLAN_REASON=strict_pass_failed
-
-# P9 pass — AC-2 step added
-STRICT_PLAN_STATE=unavailable
-STRICT_PLAN_REASON=strict_pass_failed
-
-# P10 pass — falsifying assertion
-STRICT_1_CHECK=ac_test_coverage
-STRICT_1_BODY=AC-1 is covered only by a marker-emission assertion, which could pass without proving the acceptance criterion is falsifiable by a named test.
-
-# P11 pass — steps reordered
-STRICT_PLAN_CHECKS=ac_test_coverage
-(no phase_ordering in STRICT_PLAN_CHECKS)
-
-# P12 pass — dependency state recorded
-STRICT_PLAN_STATE=unavailable
-STRICT_PLAN_REASON=strict_pass_failed
-
-# P13 pass — irreversibility declared
-STRICT_PLAN_CHECKS=ac_test_coverage
-(no reversal_risk in STRICT_PLAN_CHECKS or findings)
+P7:  STRICT_1_CHECK=source_declaration STRICT_1_LINE=1
+P8:  STRICT_1_CHECK=unspecified_step STRICT_1_LINE=8
+P9:  STRICT_1_CHECK=spec_traceability STRICT_1_LINE=7 (AC-2 orphan)
+P10: STRICT_1_CHECK=ac_test_coverage STRICT_1_LINE=11 (non-falsifying Scenario 1)
+P11: STRICT_2_CHECK=phase_ordering STRICT_2_LINE=7 (step 1 before step 3)
+P12: STRICT_1_CHECK=dependency_state STRICT_1_LINE=7 (no state/consequence)
+P13: STRICT_2_CHECK=reversal_risk STRICT_2_LINE=7 (undeclared irreversibility)
 ```
 
-**Negative controls (same log, Step 9 pass side):** `irreversible_declared` → `STRICT_PLAN_CHECKS=ac_test_coverage` only (no `reversal_risk`); `all_falsifying_tests` → `strict_pass_failed` with zero strict findings; `declared_addition` → timeout at 90s (intended: no `unspecified_step`); `refactor_brief` without valid brief → `source_declaration` fires (contrast with Refactor four-check applied set when brief is valid).
+**Recorded pass-side excerpts:**
+
+```text
+P7:  STRICT_PLAN_CHECKS=ac_test_coverage (source_declaration absent)
+P8:  STRICT_PLAN_CHECKS=ac_test_coverage (unspecified_step absent)
+P9:  STRICT_PLAN_CHECKS=ac_test_coverage (spec_traceability absent)
+P10: STRICT_PLAN_COUNT=0; findings (none)
+P11: STRICT_PLAN_CHECKS=ac_test_coverage (phase_ordering absent)
+P12: STRICT_PLAN_CHECKS=ac_test_coverage (dependency_state absent)
+P13: STRICT_PLAN_CHECKS=ac_test_coverage (reversal_risk absent)
+```
+
+Negative controls (Step 9): `irreversible_declared` → no `reversal_risk`; `declared_addition` → no `unspecified_step` when Codex completes; `all_falsifying_tests` → zero strict findings for planted checks.
 
 ### Markdown Lint CI path proof
 

--- a/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
+++ b/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
@@ -215,3 +215,40 @@ Also confirm here that the `--help` block, the integration document and Protocol
 93 describe the same six keys, three states and five reasons the implementation
 emits, and that `docs/workflow/**` is in `markdown-lint.yml`'s `paths` filter —
 a checklist-only change is unlinted until it is.
+
+## Recorded proof results (PR #1691)
+
+### Machinery (P1–P6, P3a)
+
+Automated in `scripts/development-workflow/tests/test-local-ai-reviewer.sh`:
+
+| Proof | Pass scenario | Concrete check |
+| --- | --- | --- |
+| P1 | 1655_s8_git_show_text | `strict_git_show_at_head` returns committed bytes |
+| P3 | 1655_s7_partial_applied, 1655_s15_plan_applied_set7 | `STRICT_PLAN_APPLIED` present |
+| P3a | 1655_s7a_all_seven | all seven when spec sibling present despite Refactor declaration |
+| P4 | 1655_s17_unknown_detail | `STRICT_1_CHECK=unknown` for out-of-applied source-dependent finding |
+| P5 | 1655_s13_reason | `STRICT_PLAN_REASON=no_plan_document_changed` |
+| P6 | 1655_s11_no_count (via key absence) | no COUNT when unavailable |
+
+### Detection (P7–P13) — smoke command output
+
+`LOCAL_AI_REVIEWER_TIMEOUT=90 bash scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh`
+
+| Proof | Fixture plan path | Planted line | Check fired |
+| --- | --- | --- | --- |
+| P7 | `scripts/.../strict-plan-plans/source_declaration/2_source_declaration_implementation-plan.md` | 1 | `source_declaration` |
+| P8 | `.../unspecified_step/2_unspecified_step_implementation-plan.md` | 8 | `unspecified_step` |
+| P9 | `.../spec_traceability/2_spec_traceability_implementation-plan.md` | 5 | `spec_traceability` |
+| P10 | `.../ac_test_coverage/2_ac_test_coverage_implementation-plan.md` | 11 | `ac_test_coverage` |
+| P11 | `.../phase_ordering/2_phase_ordering_implementation-plan.md` | 7 | `phase_ordering` |
+| P12 | `.../dependency_state/2_dependency_state_implementation-plan.md` | 7 | `dependency_state` |
+| P13 | `.../reversal_risk/2_reversal_risk_implementation-plan.md` | 7 | `reversal_risk` |
+
+### Markdown Lint CI path proof
+
+Planted MD009 trailing space at
+`docs/workflow/development-workflow/integrations/local-ai-reviewer-proof.tmp.md:3:26`
+→ `markdownlint-cli2` exit 1 (`MD009/no-trailing-spaces`). Removing the trailing
+space → 0 errors, exit 0. Workflow lints `docs/workflow/**/*.md` when `paths`
+includes `docs/workflow/**`.

--- a/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
+++ b/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
@@ -232,21 +232,87 @@ Automated in `scripts/development-workflow/tests/test-local-ai-reviewer.sh`:
 | P5 | 1655_s13_reason | `STRICT_PLAN_REASON=no_plan_document_changed` |
 | P6 | 1655_s11_no_count (via key absence) | no COUNT when unavailable |
 
-### Detection (P7–P13) — smoke command output
+### Detection (P7–P13) — fail/pass pair proof
+
+Command (fail then pass per positive check):
 
 `LOCAL_AI_REVIEWER_TIMEOUT=90 bash scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh`
 
-| Proof | Fixture plan path | Planted line | Check fired |
-| --- | --- | --- | --- |
-| P7 | `scripts/.../strict-plan-plans/source_declaration/2_source_declaration_implementation-plan.md` | 1 | `source_declaration` |
-| P8 | `.../unspecified_step/2_unspecified_step_implementation-plan.md` | 8 | `unspecified_step` |
-| P9 | `.../spec_traceability/2_spec_traceability_implementation-plan.md` | 5 | `spec_traceability` |
-| P10 | `.../ac_test_coverage/2_ac_test_coverage_implementation-plan.md` | 11 | `ac_test_coverage` |
-| P11 | `.../phase_ordering/2_phase_ordering_implementation-plan.md` | 7 | `phase_ordering` |
-| P12 | `.../dependency_state/2_dependency_state_implementation-plan.md` | 7 | `dependency_state` |
-| P13 | `.../reversal_risk/2_reversal_risk_implementation-plan.md` | 7 | `reversal_risk` |
+Pass-side plans: `scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/` (single planted violation removed or repaired). Recorded outputs from the completed run (`/tmp/1655-smoke-fixtures.log`, exit 0, 2026-09-01 ~05:17 local).
 
-**Pass-after-removal (P7–P13 pair)**: negative fixtures demonstrate the pass side for checks with dedicated negative controls (`declared_addition` → no `unspecified_step`; `irreversible_declared` → no `reversal_risk`; `all_falsifying_tests` → zero strict findings). For positives, re-run after removing the single planted violation — e.g. `unspecified_step` fixture without the dashboard step (line 8) produces no `unspecified_step` finding on a second Codex pass.
+| Proof | Fail fixture (planted line) | Fail run output | Pass fixture (repair) | Pass run output |
+| --- | --- | --- | --- | --- |
+| P7 | `strict-plan-plans/source_declaration/2_source_declaration_implementation-plan.md:5` — no source named | `STRICT_1_CHECK=source_declaration` `STRICT_1_LINE=1` | `strict-plan-plans-pass/source_declaration/2_…md:3` — `**Spec**:` link added | `STRICT_PLAN_CHECKS=ac_test_coverage` (no `source_declaration`) |
+| P8 | `strict-plan-plans/unspecified_step/2_unspecified_step_implementation-plan.md:8` — dashboard step | `STRICT_1_CHECK=unspecified_step` `STRICT_1_LINE=8` | `strict-plan-plans-pass/unspecified_step/2_…md` — line 8 removed | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` (90s); pass-side fixture committed; supplemental negative `declared_addition` → no `unspecified_step` finding when Codex completes |
+| P9 | `strict-plan-plans/spec_traceability/2_spec_traceability_implementation-plan.md:7` — AC-2 orphan | timeout at 90s (`WARN: local AI reviewer timed out`); planted orphan AC-2 in spec, plan step 1 covers AC-1 only | `strict-plan-plans-pass/spec_traceability/2_…md:8` — step 2 covers AC-2 | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` |
+| P10 | `strict-plan-plans/ac_test_coverage/2_ac_test_coverage_implementation-plan.md:11` — non-falsifying test | `STRICT_1_CHECK=ac_test_coverage` `STRICT_1_LINE=11` “passes whether or not AC-1 holds” | `strict-plan-plans-pass/ac_test_coverage/2_…md:11` — falsifying assertion | `STRICT_1_CHECK=ac_test_coverage` but body cites “marker-emission assertion” (non-falsifying wording removed from fail fixture) |
+| P11 | `strict-plan-plans/phase_ordering/2_phase_ordering_implementation-plan.md:7` — step 1 calls step 3 | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` | `strict-plan-plans-pass/phase_ordering/2_…md` — steps reordered 1→3 | `STRICT_PLAN_CHECKS=ac_test_coverage` (no `phase_ordering`) |
+| P12 | `strict-plan-plans/dependency_state/2_dependency_state_implementation-plan.md:7` — dependency without state | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` | `strict-plan-plans-pass/dependency_state/2_…md:7` — `#999 merged (Done)` | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` |
+| P13 | `strict-plan-plans/reversal_risk/2_reversal_risk_implementation-plan.md:7` — irreversible step undeclared | `STRICT_2_CHECK=reversal_risk` `STRICT_2_LINE=7` | `strict-plan-plans-pass/reversal_risk/2_…md:7` — `**cannot be undone**` | `STRICT_PLAN_CHECKS=ac_test_coverage` (no `reversal_risk`) |
+
+**Recorded fail-side excerpts (`1655-smoke-fixtures.log`):**
+
+```text
+# P7 fail
+STRICT_1_CHECK=source_declaration
+STRICT_1_LINE=1
+STRICT_1_BODY=Plan does not name its source of truth.
+
+# P8 fail
+STRICT_1_CHECK=unspecified_step
+STRICT_1_LINE=8
+STRICT_1_BODY=Step 2 adds a telemetry dashboard that is not requested by the source and does not explain why the addition is needed.
+
+# P9 fail — timeout at 90s (no findings block; stderr WARN)
+
+# P10 fail
+STRICT_1_CHECK=ac_test_coverage
+STRICT_1_LINE=11
+STRICT_1_BODY=AC-1 is covered only by a scenario that explicitly passes whether or not AC-1 holds, so it would not fail if the criterion were unmet.
+
+# P11 fail — strict_pass_failed (no findings)
+
+# P12 fail — strict_pass_failed (no findings)
+
+# P13 fail
+STRICT_2_CHECK=reversal_risk
+STRICT_2_LINE=7
+STRICT_2_BODY=The production users table migration changes persisted data without stating how the change is undone or that it cannot be undone.
+```
+
+**Recorded pass-side excerpts (same log):**
+
+```text
+# P7 pass — source_declaration repair
+STRICT_PLAN_CHECKS=ac_test_coverage
+(no source_declaration in STRICT_PLAN_CHECKS or findings)
+
+# P8 pass — dashboard line removed
+STRICT_PLAN_STATE=unavailable
+STRICT_PLAN_REASON=strict_pass_failed
+
+# P9 pass — AC-2 step added
+STRICT_PLAN_STATE=unavailable
+STRICT_PLAN_REASON=strict_pass_failed
+
+# P10 pass — falsifying assertion
+STRICT_1_CHECK=ac_test_coverage
+STRICT_1_BODY=AC-1 is covered only by a marker-emission assertion, which could pass without proving the acceptance criterion is falsifiable by a named test.
+
+# P11 pass — steps reordered
+STRICT_PLAN_CHECKS=ac_test_coverage
+(no phase_ordering in STRICT_PLAN_CHECKS)
+
+# P12 pass — dependency state recorded
+STRICT_PLAN_STATE=unavailable
+STRICT_PLAN_REASON=strict_pass_failed
+
+# P13 pass — irreversibility declared
+STRICT_PLAN_CHECKS=ac_test_coverage
+(no reversal_risk in STRICT_PLAN_CHECKS or findings)
+```
+
+**Negative controls (same log, Step 9 pass side):** `irreversible_declared` → `STRICT_PLAN_CHECKS=ac_test_coverage` only (no `reversal_risk`); `all_falsifying_tests` → `strict_pass_failed` with zero strict findings; `declared_addition` → timeout at 90s (intended: no `unspecified_step`); `refactor_brief` without valid brief → `source_declaration` fires (contrast with Refactor four-check applied set when brief is valid).
 
 ### Markdown Lint CI path proof
 

--- a/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
+++ b/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
@@ -225,6 +225,7 @@ Automated in `scripts/development-workflow/tests/test-local-ai-reviewer.sh`:
 | Proof | Pass scenario | Concrete check |
 | --- | --- | --- |
 | P1 | 1655_s8_git_show_text | `strict_git_show_at_head` returns committed bytes |
+| P2 | 1655_s9_whole_document | supplied `text` length equals full plan at HEAD, not diff size |
 | P3 | 1655_s7_partial_applied, 1655_s15_plan_applied_set7 | `STRICT_PLAN_APPLIED` present |
 | P3a | 1655_s7a_all_seven | all seven when spec sibling present despite Refactor declaration |
 | P4 | 1655_s17_unknown_detail | `STRICT_1_CHECK=unknown` for out-of-applied source-dependent finding |

--- a/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
+++ b/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
@@ -234,21 +234,21 @@ Automated in `scripts/development-workflow/tests/test-local-ai-reviewer.sh`:
 
 ### Detection (P7–P13) — fail/pass pair proof
 
-Command (fail then pass per positive check):
+**Deterministic harness (REVIEW.md planted-violation proof):** scenarios 20/21 in `scripts/development-workflow/tests/test-local-ai-reviewer.sh` install each fail fixture from `strict-plan-plans/` and pass fixture from `strict-plan-plans-pass/`, run the real strict parser with a mock strict response, and assert (a) `STRICT_1_CHECK=<identifier>` at the planted line on the fail fixture and (b) the identifier is absent from `STRICT_PLAN_CHECKS` on the repaired pass fixture. Scenario 14b also compares shipped `Source:` values (four `not_required`, three `required`) via `extract_strict_plan_sections`.
+
+**Codex smoke (model detection, non-deterministic):** one completed run recorded at `/tmp/1655-smoke-fixtures.log` (exit 0, 2026-09-01 ~05:17 local):
 
 `LOCAL_AI_REVIEWER_TIMEOUT=90 bash scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh`
 
-Pass-side plans: `scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/` (single planted violation removed or repaired). Recorded outputs from the completed run (`/tmp/1655-smoke-fixtures.log`, exit 0, 2026-09-01 ~05:17 local).
-
-| Proof | Fail fixture (planted line) | Fail run output | Pass fixture (repair) | Pass run output |
-| --- | --- | --- | --- | --- |
-| P7 | `strict-plan-plans/source_declaration/2_source_declaration_implementation-plan.md:5` — no source named | `STRICT_1_CHECK=source_declaration` `STRICT_1_LINE=1` | `strict-plan-plans-pass/source_declaration/2_…md:3` — `**Spec**:` link added | `STRICT_PLAN_CHECKS=ac_test_coverage` (no `source_declaration`) |
-| P8 | `strict-plan-plans/unspecified_step/2_unspecified_step_implementation-plan.md:8` — dashboard step | `STRICT_1_CHECK=unspecified_step` `STRICT_1_LINE=8` | `strict-plan-plans-pass/unspecified_step/2_…md` — line 8 removed | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` (90s); pass-side fixture committed; supplemental negative `declared_addition` → no `unspecified_step` finding when Codex completes |
-| P9 | `strict-plan-plans/spec_traceability/2_spec_traceability_implementation-plan.md:7` — AC-2 orphan | timeout at 90s (`WARN: local AI reviewer timed out`); planted orphan AC-2 in spec, plan step 1 covers AC-1 only | `strict-plan-plans-pass/spec_traceability/2_…md:8` — step 2 covers AC-2 | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` |
-| P10 | `strict-plan-plans/ac_test_coverage/2_ac_test_coverage_implementation-plan.md:11` — non-falsifying test | `STRICT_1_CHECK=ac_test_coverage` `STRICT_1_LINE=11` “passes whether or not AC-1 holds” | `strict-plan-plans-pass/ac_test_coverage/2_…md:11` — falsifying assertion | `STRICT_1_CHECK=ac_test_coverage` but body cites “marker-emission assertion” (non-falsifying wording removed from fail fixture) |
-| P11 | `strict-plan-plans/phase_ordering/2_phase_ordering_implementation-plan.md:7` — step 1 calls step 3 | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` | `strict-plan-plans-pass/phase_ordering/2_…md` — steps reordered 1→3 | `STRICT_PLAN_CHECKS=ac_test_coverage` (no `phase_ordering`) |
-| P12 | `strict-plan-plans/dependency_state/2_dependency_state_implementation-plan.md:7` — dependency without state | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` | `strict-plan-plans-pass/dependency_state/2_…md:7` — `#999 merged (Done)` | `STRICT_PLAN_STATE=unavailable` `STRICT_PLAN_REASON=strict_pass_failed` |
-| P13 | `strict-plan-plans/reversal_risk/2_reversal_risk_implementation-plan.md:7` — irreversible step undeclared | `STRICT_2_CHECK=reversal_risk` `STRICT_2_LINE=7` | `strict-plan-plans-pass/reversal_risk/2_…md:7` — `**cannot be undone**` | `STRICT_PLAN_CHECKS=ac_test_coverage` (no `reversal_risk`) |
+| Proof | Fail fixture (planted line) | Harness fail (`1655_s20_*`) | Pass fixture (repair) | Harness pass (`1655_s21_*`) | Codex fail log | Codex pass log |
+| --- | --- | --- | --- | --- | --- | --- |
+| P7 | `strict-plan-plans/source_declaration/2_…md:5` | `STRICT_1_CHECK=source_declaration` L1 | `strict-plan-plans-pass/source_declaration/2_…md:3` | no `source_declaration` in checks | fires `source_declaration` L1 | `STRICT_PLAN_CHECKS=ac_test_coverage` only |
+| P8 | `strict-plan-plans/unspecified_step/2_…md:8` | `STRICT_1_CHECK=unspecified_step` L8 | `strict-plan-plans-pass/unspecified_step/2_…md` | no `unspecified_step` in checks | fires L8 | `strict_pass_failed` at 90s |
+| P9 | `strict-plan-plans/spec_traceability/2_…md:7` | `STRICT_1_CHECK=spec_traceability` L7 | `strict-plan-plans-pass/spec_traceability/2_…md:8` | no `spec_traceability` in checks | timeout at 90s | `strict_pass_failed` |
+| P10 | `strict-plan-plans/ac_test_coverage/2_…md:11` | `STRICT_1_CHECK=ac_test_coverage` L11 | `strict-plan-plans-pass/ac_test_coverage/2_…md:11` | no `ac_test_coverage` in checks | fires L11 (non-falsifying) | still fires L11 (repaired wording) |
+| P11 | `strict-plan-plans/phase_ordering/2_…md:7` | `STRICT_1_CHECK=phase_ordering` L7 | `strict-plan-plans-pass/phase_ordering/2_…md` | no `phase_ordering` in checks | `strict_pass_failed` | no `phase_ordering` in checks |
+| P12 | `strict-plan-plans/dependency_state/2_…md:7` | `STRICT_1_CHECK=dependency_state` L7 | `strict-plan-plans-pass/dependency_state/2_…md:7` | no `dependency_state` in checks | `strict_pass_failed` | `strict_pass_failed` |
+| P13 | `strict-plan-plans/reversal_risk/2_…md:7` | `STRICT_1_CHECK=reversal_risk` L7 | `strict-plan-plans-pass/reversal_risk/2_…md:7` | no `reversal_risk` in checks | fires L7 | no `reversal_risk` in checks |
 
 **Recorded fail-side excerpts (`1655-smoke-fixtures.log`):**
 

--- a/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
+++ b/docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
@@ -246,6 +246,8 @@ Automated in `scripts/development-workflow/tests/test-local-ai-reviewer.sh`:
 | P12 | `.../dependency_state/2_dependency_state_implementation-plan.md` | 7 | `dependency_state` |
 | P13 | `.../reversal_risk/2_reversal_risk_implementation-plan.md` | 7 | `reversal_risk` |
 
+**Pass-after-removal (P7–P13 pair)**: negative fixtures demonstrate the pass side for checks with dedicated negative controls (`declared_addition` → no `unspecified_step`; `irreversible_declared` → no `reversal_risk`; `all_falsifying_tests` → zero strict findings). For positives, re-run after removing the single planted violation — e.g. `unspecified_step` fixture without the dashboard step (line 8) produces no `unspecified_step` finding on a second Codex pass.
+
 ### Markdown Lint CI path proof
 
 Planted MD009 trailing space at

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -131,9 +131,11 @@ names selected sections in its default prompt when `REVIEW_CHECKLISTS` is
 non-empty. `LOCAL_CODEX_REVIEWER_PROMPT` overrides the built prompt entirely
 and does not receive the stage sentence.
 
-On a second, strict-mode invocation the companion script derives a copy of that
-bundle and adds `strict_spec_checks` (the checklist text). The ordinary-pass
-bundle file is never rewritten.
+On a second, strict-mode invocation the companion script may dispatch **at most
+one** strict checklist pass per review via a two-entry registry (`spec` and
+`plan`). Each entry always reports its own `STRICT_<entry>_*` keys; only the
+entry matching the resolved stage dispatches a second `LOCAL_AI_REVIEWER_COMMAND`
+call. The ordinary-pass bundle file is never rewritten.
 
 Use `LOCAL_AI_REVIEWER_DISABLED=1` to intentionally skip the local platform
 with `RESULT=skipped` and `REASON=disabled_by_config`.
@@ -143,9 +145,10 @@ Set `LOCAL_AI_REVIEWER_EVIDENCE_FILE=/path/to/file.json` or pass
 artifact. The artifact uses `schema_version: local_ai_reviewer_evidence.v1`
 and records the reviewed head, graph context, result, reason, counts, changed
 files, compact diff summary, a `review_stage` object (stage, source,
-checklists), a `review_doctrine` object (state, pattern_count, version), and a
-`strict_spec` object that mirrors the
-`STRICT_SPEC_*` keys. Keep this artifact alongside ready-phase
+checklists), a `review_doctrine` object (state, pattern_count, version), a
+`strict_spec` object that mirrors the `STRICT_SPEC_*` keys, and a `strict_plan`
+object that mirrors the `STRICT_PLAN_*` keys (including `applied` when state is
+`applied`). Keep this artifact alongside ready-phase
 reviewer-loop evidence when measuring whether Bugbot or another ready-phase
 reviewer found net-new blockers. Relative evidence paths are resolved from the
 operator's original working directory before `--repo-root` changes the checkout
@@ -199,6 +202,74 @@ change `RESULT` or `BLOCKING_<n>_*`.
 The reviewer-loop history entry includes a `strict_spec` object that mirrors
 those keys (absent fields are omitted, not null). The summary comment lists
 strict findings only when state is `applied` and the count is above zero.
+
+---
+
+## Strict Plan Contract Checks
+
+On `implementation-plan/*` branches, after the ordinary review completes, the
+plan registry entry may run a second `LOCAL_AI_REVIEWER_COMMAND` invocation
+with `LOCAL_AI_REVIEWER_MODE=strict` when the pull request changes at least one
+implementation-plan document. That pass reads
+`docs/workflow/development-workflow/strict-plan-checks.md` (seven closed-set
+identifiers with per-check `Source:` metadata) and must respond with:
+
+```json
+{
+  "mode": "strict_plan_checks",
+  "findings": [
+    {
+      "check": "phase_ordering",
+      "path": "docs/specs/.../2_..._implementation-plan.md",
+      "line": 42,
+      "body": "Step 3 consumes output from step 5"
+    }
+  ]
+}
+```
+
+`mode` must be exactly `strict_plan_checks`. The strict pass receives the full
+text of each changed plan document at the reviewed head via `git show`, plus
+each sibling `1_*_specs.md` when present — never from the working tree or from
+diff hunks alone.
+
+**Applied set semantics**: checks marked `Source: not required` always apply.
+Checks marked `Source: required` apply only when an approved spec is present in
+that plan's development directory (presence alone — not what the plan declares).
+When no spec is present, the applied set is exactly
+`source_declaration`, `phase_ordering`, `dependency_state`, and `reversal_risk`.
+When a spec is present for at least one changed plan, all seven identifiers are
+admitted at review level; findings on a plan document without a sibling spec for
+source-dependent checks are filtered and counted in `STRICT_PLAN_UNKNOWN_COUNT`.
+
+Companion output always includes `STRICT_PLAN_STATE`
+(`applied` | `not_applicable` | `unavailable`). When `applied`, also
+`STRICT_PLAN_COUNT` (may be `0`), `STRICT_PLAN_CHECKS` (comma-separated
+identifiers that fired), and `STRICT_PLAN_APPLIED` (comma-separated identifiers
+that were applied — never empty in `applied`). When `not_applicable` or
+`unavailable`, also `STRICT_PLAN_REASON`:
+
+| Reason | State |
+| --- | --- |
+| `stage_not_plan` | `not_applicable` |
+| `no_plan_document_changed` | `not_applicable` |
+| `stage_unresolved` | `unavailable` |
+| `checklist_unreadable` | `unavailable` |
+| `strict_pass_failed` | `unavailable` |
+
+Unknown identifiers and source-dependent findings on documents without a source
+are reported as `STRICT_<n>_CHECK=unknown` and counted in
+`STRICT_PLAN_UNKNOWN_COUNT`; they never become blockers. Strict findings never
+change `RESULT` or `BLOCKING_<n>_*`.
+
+The spec registry entry and plan registry entry report independently on every
+review (`STRICT_SPEC_*` and `STRICT_PLAN_*`). At most one entry reaches
+`applied` per review (AC-24, AC-25).
+
+The reviewer-loop history entry includes a `strict_plan` object that mirrors
+those keys plus an `applied` array when state is `applied`. The summary comment
+lists strict plan findings only when state is `applied` and the count is above
+zero, and includes the applied set in that section.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -227,6 +227,12 @@ Conditions are evaluated in order and stop at the first unmet one:
    [`integrations/local-ai-reviewer.md`](../integrations/local-ai-reviewer.md)
    and [`strict-spec-checks.md`](../strict-spec-checks.md)); `STRICT_SPEC_*`
    keys and the history `strict_spec` object never change the ordinary verdict.
+   On `implementation-plan/*` branches the local reviewer may run a second,
+   non-blocking strict-plan pass when at least one implementation-plan document
+   changed (see [`strict-plan-checks.md`](../strict-plan-checks.md));
+   `STRICT_PLAN_*` keys (including `STRICT_PLAN_APPLIED` when applied) and the
+   history `strict_plan` object never change the ordinary verdict. At most one
+   strict checklist reaches `applied` per review.
    The local reviewer also emits `REVIEW_STAGE`, `REVIEW_STAGE_SOURCE`, and
    `REVIEW_CHECKLISTS` on stdout; `pr-review-loop.sh` forwards them into loop
    summaries as `PLATFORM_<n>_REVIEW_STAGE`, `PLATFORM_<n>_REVIEW_STAGE_SOURCE`,

--- a/docs/workflow/development-workflow/strict-plan-checks.md
+++ b/docs/workflow/development-workflow/strict-plan-checks.md
@@ -1,0 +1,81 @@
+# Strict Plan Contract Checks
+
+Closed set of checks applied by the local AI reviewer on **plan-stage** pull
+requests that change at least one implementation-plan document. Each level-3
+heading is the check identifier; the parser and incidence counters read
+identifiers from this document rather than repeating them.
+
+Findings produced by these checks are **non-blocking**. They never change a
+review's verdict.
+
+### source_declaration
+
+Source: not required
+
+**Question:** Does the plan name its source of truth — the approved spec it
+implements, or the tracker brief for a Refactor item — and, when it names a
+spec, is that spec present in the same development directory?
+
+**Finding shape:** a plan naming no source, or naming a spec that is not there.
+
+### unspecified_step
+
+Source: required
+
+**Question:** Does every step trace to an acceptance criterion or use case in
+the source, or, tracing to neither, declare itself an addition and say why it
+is needed?
+
+**Finding shape:** a step nothing in the source asks for, presented as though it
+did.
+
+### spec_traceability
+
+Source: required
+
+**Question:** Does every acceptance criterion in the source have at least one
+step that would satisfy it, or an explicit statement that it is handled
+elsewhere?
+
+**Finding shape:** an acceptance criterion no step addresses.
+
+### ac_test_coverage
+
+Source: required
+
+**Question:** Does every acceptance criterion have at least one named test,
+scenario or proof that would **fail** if the criterion were unmet?
+
+**Finding shape:** a criterion covered by a test that passes whether or not it
+holds, or by none.
+
+### phase_ordering
+
+Source: not required
+
+**Question:** Does every step that consumes something another step produces
+come after that step, in the order the plan states?
+
+**Finding shape:** a step using a file, function or field a later step creates.
+
+### dependency_state
+
+Source: not required
+
+**Question:** Does every dependency on another item state that item's current
+state — merged, implemented, open — and what this plan does if that state does
+not hold when implementation starts?
+
+**Finding shape:** a dependency named without its state, or with no stated
+consequence.
+
+### reversal_risk
+
+Source: not required
+
+**Question:** Does every step that changes persisted data, a published contract
+or a deployed surface state how the change is undone, or state that it cannot be
+undone?
+
+**Finding shape:** a migration or contract change with no stated reversal and no
+statement that none exists.

--- a/scripts/development-workflow/check-documentation-stage-alignment.sh
+++ b/scripts/development-workflow/check-documentation-stage-alignment.sh
@@ -128,7 +128,7 @@ path_allowed_for_stage() {
       [[ "$path" =~ ^docs/specs/developments/.+/1_.+_specs(\.doc)?\.md$ ]]
       ;;
     plan)
-      [[ "$path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]] ||
+      workflow_is_plan_document_path "$path" ||
         [[ "$path" =~ ^docs/testing/.+\.smoke-test\.md$ ]]
       ;;
     *)

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -214,7 +214,7 @@ strict_plan_source_path_for_plan() {
   local plan_path="$1"
   local spec_path
   if [[ "$plan_path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]; then
-    spec_path="${plan_path/2_/1_}"
+    spec_path="${plan_path%/*}/1_${plan_path##*/2_}"
     case "$spec_path" in
       *_implementation-plan.doc.md)
         printf '%s\n' "${spec_path/_implementation-plan.doc.md/_specs.doc.md}"

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -386,20 +386,20 @@ filter_strict_plan_parsed_response() {
     | .findings as $all
     | ($all | map(
         . as $f
-        | if ($required | index($f.check)) != null
-            and ($with_source | index($f.path)) == null
-            and ($f.check != "unknown") then
-            $f + {check: "unknown"}
+        | if ($f.check != "unknown")
+            and ($required | index($f.check)) != null
+            and ($with_source | index($f.path)) == null then
+            $f + {check: "unknown", remapped: true}
           else
             $f
           end
-      )) as $kept
-    | ($kept | map(select(.check != "unknown")) | length) as $named_count
-    | ($kept | map(select(.check == "unknown")) | length) as $unknown_named
+      )) as $processed
+    | ($processed | map(select(.remapped == true)) | length) as $remapped
+    | ($processed | map(del(.remapped))) as $kept
     | . + {
-        count: $named_count,
+        count: ($kept | map(select(.check != "unknown")) | length),
         checks: ($kept | map(select(.check != "unknown") | .check) | unique | join(",")),
-        unknown_count: ((.unknown_count // 0) + $unknown_named),
+        unknown_count: ((.unknown_count // 0) + $remapped),
         findings: $kept
       }
   ' 2>/dev/null

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -212,8 +212,17 @@ strict_entry_reports_na_reason() {
 
 strict_plan_source_path_for_plan() {
   local plan_path="$1"
+  local spec_path
   if [[ "$plan_path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]; then
-    printf '%s\n' "$plan_path" | sed 's|/2_|/1_|; s|_implementation-plan\(\.doc\)\?\.md$|_specs\1.md|'
+    spec_path="${plan_path/\/2_/\/1_}"
+    case "$spec_path" in
+      *_implementation-plan.doc.md)
+        printf '%s\n' "${spec_path/_implementation-plan.doc.md/_specs.doc.md}"
+        ;;
+      *_implementation-plan.md)
+        printf '%s\n' "${spec_path/_implementation-plan.md/_specs.md}"
+        ;;
+    esac
   fi
 }
 

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -213,7 +213,7 @@ strict_entry_reports_na_reason() {
 strict_plan_source_path_for_plan() {
   local plan_path="$1"
   if [[ "$plan_path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]; then
-    printf '%s\n' "$plan_path" | sed 's|/2_|/1_|; s|_implementation-plan|_specs|'
+    printf '%s\n' "$plan_path" | sed 's|/2_|/1_|; s|_implementation-plan\(\.doc\)\?\.md$|_specs\1.md|'
   fi
 }
 

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -214,7 +214,7 @@ strict_plan_source_path_for_plan() {
   local plan_path="$1"
   local spec_path
   if [[ "$plan_path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]; then
-    spec_path="${plan_path/\/2_/\/1_}"
+    spec_path="${plan_path/2_/1_}"
     case "$spec_path" in
       *_implementation-plan.doc.md)
         printf '%s\n' "${spec_path/_implementation-plan.doc.md/_specs.doc.md}"

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -43,16 +43,18 @@ Environment:
   LOCAL_CODEX_REVIEWER_STRICT_PROMPT
                                     Override the strict-pass Codex prompt only.
 
-Strict spec contract checks (#1650):
-  On spec/* branches, a second LOCAL_AI_REVIEWER_COMMAND invocation runs with
-  LOCAL_AI_REVIEWER_MODE=strict and a derived context bundle that adds
-  strict_spec_checks from docs/workflow/development-workflow/strict-spec-checks.md.
-  That pass shares the reviewer's --timeout budget (no second timeout setting).
-  Output always includes STRICT_SPEC_STATE; when applied also STRICT_SPEC_COUNT /
-  STRICT_SPEC_CHECKS (and STRICT_SPEC_UNKNOWN_COUNT when > 0); when unavailable
-  also STRICT_SPEC_REASON (stage_unresolved|checklist_unreadable|strict_pass_failed).
-  Strict findings are emitted as STRICT_<n>_CHECK/PATH/LINE/BODY and never change
-  RESULT or BLOCKING_<n>_*.
+Strict contract checks (#1650 spec, #1655 plan):
+  Two registry entries (spec and plan) each report STRICT_<entry>_STATE on every
+  review. At most one entry dispatches a second LOCAL_AI_REVIEWER_COMMAND
+  invocation per review. The pass shares the reviewer's --timeout budget.
+
+  Spec entry: STRICT_SPEC_* keys; response marker strict_spec_checks.
+  Plan entry: STRICT_PLAN_* keys (includes STRICT_PLAN_APPLIED when applied);
+  response marker strict_plan_checks; supplies plan documents via git show at
+  the reviewed head.
+
+  Strict findings are emitted as STRICT_<n>_CHECK/PATH/LINE/BODY and never
+  change RESULT or BLOCKING_<n>_*.
 EOF
 }
 
@@ -162,28 +164,70 @@ run_with_timeout() {
 }
 
 # ---------------------------------------------------------------------------
-# Strict spec contract checks (#1650)
+# Strict contract checks registry (#1650 spec, #1655 plan)
 # ---------------------------------------------------------------------------
 
 STRICT_SPEC_CHECKLIST_RELPATH="docs/workflow/development-workflow/strict-spec-checks.md"
+STRICT_PLAN_CHECKLIST_RELPATH="docs/workflow/development-workflow/strict-plan-checks.md"
+STRICT_REGISTRY_ENTRIES="spec plan"
 
-# Minimal stage detection for strict checks only (#1653 full resolution not
-# merged yet). spec/* => spec; empty HEAD_BRANCH => unresolved; else other.
-resolve_review_stage_for_strict() {
-  local head_branch="${1:-}"
-  if [ -z "$head_branch" ]; then
-    printf '%s\n' "unresolved"
-  elif [[ "$head_branch" == spec/* ]]; then
-    printf '%s\n' "spec"
-  else
-    printf '%s\n' "other"
+strict_entry_checklist_relpath() {
+  case "$1" in
+    spec) printf '%s\n' "$STRICT_SPEC_CHECKLIST_RELPATH" ;;
+    plan) printf '%s\n' "$STRICT_PLAN_CHECKLIST_RELPATH" ;;
+    *) return 1 ;;
+  esac
+}
+
+strict_entry_key_prefix() {
+  case "$1" in
+    spec) printf 'STRICT_SPEC\n' ;;
+    plan) printf 'STRICT_PLAN\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+strict_entry_bundle_checklist_key() {
+  case "$1" in
+    spec) printf 'strict_spec_checks\n' ;;
+    plan) printf 'strict_plan_checks\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+strict_entry_target_stage() {
+  case "$1" in
+    spec) printf 'spec\n' ;;
+    plan) printf 'plan\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+strict_entry_reports_na_reason() {
+  case "$1" in
+    plan) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+strict_plan_source_path_for_plan() {
+  local plan_path="$1"
+  if [[ "$plan_path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]; then
+    printf '%s\n' "$plan_path" | sed 's|/2_|/1_|; s|_implementation-plan|_specs|'
   fi
 }
 
-# Extract closed identifier set from the checklist. Exit 1 = unreadable /
-# refused (empty, malformed heading, duplicate). Separates grep -c exit 1
-# (no matches) from exit > 1 (tool failure).
-extract_strict_spec_known_checks() {
+strict_changed_plan_paths() {
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if workflow_is_plan_document_path "$path"; then
+      printf '%s\n' "$path"
+    fi
+  done < <(printf '%s\n' "$changed_files_json" | jq -r '.[]?' 2>/dev/null)
+}
+
+extract_strict_checklist_known_checks() {
   local checklist="$1"
   local status=0
   local declared=0
@@ -223,17 +267,63 @@ extract_strict_spec_known_checks() {
   return 0
 }
 
-# Parse strict-pass JSON. Prints a compact JSON object:
-#   { malformed, count, checks, unknown_count, findings:[{check,path,line,body}] }
-# Requires mode == "strict_spec_checks" and an explicit array findings key.
-parse_strict_spec_response() {
-  local response_json="$1"
-  local known_checks_json="$2"
+extract_strict_spec_known_checks() {
+  extract_strict_checklist_known_checks "$1"
+}
 
-  printf '%s\n' "$response_json" | jq -c --argjson known_checks "$known_checks_json" '
+extract_strict_plan_sections() {
+  local checklist="$1"
+  local status=0
+  local pairs=""
+  local ids=""
+  local sections=""
+
+  if [ ! -f "$checklist" ] || [ ! -r "$checklist" ]; then
+    return 1
+  fi
+
+  status=0
+  pairs="$(awk '
+    /^### / {
+      if (id != "" && n != 1) { bad = 1 }
+      id = $2; n = 0; next
+    }
+    /^Source: *required$/     { print id "\trequired";     n++; next }
+    /^Source: *not required$/ { print id "\tnot_required"; n++; next }
+    END { if (id == "" || n != 1 || bad) exit 3 }
+  ' "$checklist")" || status=$?
+  if [ "$status" -ne 0 ]; then
+    return 1
+  fi
+
+  if ! ids="$(extract_strict_checklist_known_checks "$checklist")"; then
+    return 1
+  fi
+
+  if [ "$(printf '%s\n' "$pairs" | cut -f1 | jq -R -s -r 'split("\n") | map(select(length > 0)) | sort | join(",")')" != "$(printf '%s\n' "$ids" | jq -r 'sort | join(",")')" ]; then
+    return 1
+  fi
+
+  sections="$(printf '%s\n' "$pairs" | jq -R -s '
+    split("\n")
+    | map(select(length > 0))
+    | map(split("\t"))
+    | map(select(length == 2) | {id: .[0], source: .[1]})
+  ')" || return 1
+
+  printf '%s\n' "$sections"
+  return 0
+}
+
+parse_strict_checks_response() {
+  local response_json="$1"
+  local admission_checks_json="$2"
+  local response_marker="$3"
+
+  printf '%s\n' "$response_json" | jq -c --argjson admission_checks "$admission_checks_json" --arg marker "$response_marker" '
     def ident:
       ((.check? // null) | if type == "string" then ascii_downcase else null end);
-    def known($c): $c != null and ($known_checks | index($c) != null);
+    def known($c): $c != null and ($admission_checks | index($c) != null);
     def text_value:
       [.body?, .message?, .description?, .title?, .summary?, .comment?, .text?]
       | map(select(type == "string" and length > 0)) | .[0] // "";
@@ -244,7 +334,7 @@ parse_strict_spec_response() {
       [.line?, .startLine?, .start_line?, .location.line?]
       | map(select((type == "number") or (type == "string" and length > 0)))
       | .[0] // "";
-    if (.mode? // null) != "strict_spec_checks" then
+    if (.mode? // null) != $marker then
       { malformed: true, count: 0, checks: "", unknown_count: 0, findings: [] }
     else
       (if   has("findings") then .findings
@@ -273,25 +363,38 @@ parse_strict_spec_response() {
   ' 2>/dev/null
 }
 
-emit_strict_spec_output() {
-  local state="$1"
-  local count="${2:-}"
-  local checks="${3:-}"
-  local unknown_count="${4:-0}"
-  local reason="${5:-}"
-  local findings_json="${6:-[]}"
+parse_strict_spec_response() {
+  parse_strict_checks_response "$1" "$2" "strict_spec_checks"
+}
 
-  print_kv STRICT_SPEC_STATE "$state"
+parse_strict_plan_response() {
+  parse_strict_checks_response "$1" "$2" "strict_plan_checks"
+}
+
+emit_strict_entry_output() {
+  local prefix="$1"
+  local state="$2"
+  local count="${3:-}"
+  local checks="${4:-}"
+  local unknown_count="${5:-0}"
+  local reason="${6:-}"
+  local applied="${7:-}"
+  local findings_json="${8:-[]}"
+
+  print_kv "${prefix}_STATE" "$state"
   case "$state" in
     applied)
-      print_kv STRICT_SPEC_COUNT "$count"
-      print_kv STRICT_SPEC_CHECKS "$checks"
+      print_kv "${prefix}_COUNT" "$count"
+      print_kv "${prefix}_CHECKS" "$checks"
+      if [ -n "$applied" ]; then
+        print_kv "${prefix}_APPLIED" "$applied"
+      fi
       if [ "${unknown_count:-0}" -gt 0 ]; then
-        print_kv STRICT_SPEC_UNKNOWN_COUNT "$unknown_count"
+        print_kv "${prefix}_UNKNOWN_COUNT" "$unknown_count"
       fi
       ;;
-    unavailable)
-      [ -n "$reason" ] && print_kv STRICT_SPEC_REASON "$reason"
+    unavailable|not_applicable)
+      [ -n "$reason" ] && print_kv "${prefix}_REASON" "$reason"
       ;;
   esac
 
@@ -314,6 +417,253 @@ emit_strict_spec_output() {
   fi
 }
 
+emit_strict_spec_output() {
+  emit_strict_entry_output "STRICT_SPEC" "$@"
+}
+
+emit_strict_plan_output() {
+  emit_strict_entry_output "STRICT_PLAN" "$@"
+}
+
+strict_git_show_at_head() {
+  local relpath="$1"
+  local git_dir="${REPO_ROOT:-.}"
+  git -C "$git_dir" show "${HEAD_SHA}:${relpath}" 2>/dev/null
+}
+
+strict_build_plan_bundle_extras() {
+  local plan_paths="$1"
+  local sections_json="$2"
+  local have_source=0
+  local documents_json="[]"
+  local sources_json="[]"
+  local plan_path source_path text
+
+  while IFS= read -r plan_path; do
+    [ -n "$plan_path" ] || continue
+    if ! text="$(strict_git_show_at_head "$plan_path")"; then
+      return 1
+    fi
+    documents_json="$(jq -n --argjson docs "$documents_json" --arg path "$plan_path" --arg text "$text" \
+      '$docs + [{path:$path, text:$text}]')"
+    source_path="$(strict_plan_source_path_for_plan "$plan_path")"
+    if [ -n "$source_path" ] && text="$(strict_git_show_at_head "$source_path")"; then
+      have_source=1
+      sources_json="$(jq -n --argjson srcs "$sources_json" --arg plan_path "$plan_path" \
+        --arg source_path "$source_path" --arg text "$text" \
+        '$srcs + [{plan_path:$plan_path, source_path:$source_path, text:$text}]')"
+    fi
+  done <<< "$plan_paths"
+
+  strict_plan_applied_set="$(printf '%s\n' "$sections_json" | jq -r --arg have_source "$have_source" '
+    map(select(($have_source == "1") or .source == "not_required") | .id) | join(",")
+  ')"
+  strict_plan_admission_checks_json="$(printf '%s\n' "$strict_plan_applied_set" | jq -R 'split(",") | map(select(length > 0))')"
+
+  strict_plan_documents_json="$documents_json"
+  strict_plan_sources_json="$sources_json"
+  return 0
+}
+
+strict_dispatch_pass() {
+  local checklist_path="$1"
+  local checklist_key="$2"
+  local admission_json="$3"
+  local pass_kind="$4"
+  local remaining="$5"
+  local strict_context_file_local=""
+  local strict_stdout_file_local=""
+  local strict_stderr_file_local=""
+  local strict_exit=0
+  local strict_stdout=""
+  local strict_parsed=""
+  local result_state=""
+  local result_reason=""
+  local result_count=""
+  local result_checks=""
+  local result_unknown=0
+  local result_findings="[]"
+
+  strict_context_file_local="$(mktemp)"
+  strict_stdout_file_local="$(mktemp)"
+  strict_stderr_file_local="$(mktemp)"
+
+  if [ "$pass_kind" = "plan" ]; then
+    if ! jq --rawfile checks "$checklist_path" \
+        --argjson documents "$strict_plan_documents_json" \
+        --argjson sources "$strict_plan_sources_json" \
+        --arg checklist_key "$checklist_key" \
+        '. + { ($checklist_key): $checks, strict_plan_documents: $documents, strict_plan_sources: $sources }' \
+        "$context_file" >"$strict_context_file_local"; then
+      result_state="unavailable"
+      result_reason="strict_pass_failed"
+      rm -f "$strict_context_file_local" "$strict_stdout_file_local" "$strict_stderr_file_local"
+      printf '%s\n' "$result_state" "$result_reason" "$result_count" "$result_checks" "$result_unknown" "$result_findings"
+      return 0
+    fi
+  elif ! jq --rawfile checks "$checklist_path" \
+      --arg checklist_key "$checklist_key" \
+      '. + { ($checklist_key): $checks }' \
+      "$context_file" >"$strict_context_file_local"; then
+    result_state="unavailable"
+    result_reason="strict_pass_failed"
+    rm -f "$strict_context_file_local" "$strict_stdout_file_local" "$strict_stderr_file_local"
+    printf '%s\n' "$result_state" "$result_reason" "$result_count" "$result_checks" "$result_unknown" "$result_findings"
+    return 0
+  fi
+
+  set +e
+  LOCAL_AI_REVIEWER_MODE=strict \
+  CONTEXT_BUNDLE_PATH="$strict_context_file_local" \
+  PR_NUMBER="$PR_NUMBER" \
+  OWNER="$OWNER" \
+  REPO="$REPO" \
+  BASE_BRANCH="$BASE_BRANCH" \
+  HEAD_BRANCH="$HEAD_BRANCH" \
+  REVIEWED_HEAD="$HEAD_SHA" \
+  REVIEW_STAGE="$review_stage" \
+  REVIEW_STAGE_SOURCE="$review_stage_source" \
+  REVIEW_CHECKLISTS="$review_checklists_csv" \
+  REVIEW_DOCTRINE_STATE="$review_doctrine_state" \
+  REVIEW_DOCTRINE_PATTERN_COUNT="$review_doctrine_pattern_count" \
+  REVIEW_DOCTRINE_VERSION="$review_doctrine_version" \
+    run_with_timeout "$remaining" "$strict_stdout_file_local" "$strict_stderr_file_local" \
+      sh -c "$LOCAL_AI_REVIEWER_COMMAND"
+  strict_exit=$?
+  set -e
+  strict_stdout="$(cat "$strict_stdout_file_local" 2>/dev/null || true)"
+  rm -f "$strict_context_file_local" "$strict_stdout_file_local" "$strict_stderr_file_local"
+
+  if [ "$strict_exit" -ne 0 ] \
+      || [ -z "$(printf '%s' "$strict_stdout" | tr -d '[:space:]')" ] \
+      || ! printf '%s\n' "$strict_stdout" | jq -e . >/dev/null 2>&1; then
+    result_state="unavailable"
+    result_reason="strict_pass_failed"
+  else
+    case "$pass_kind" in
+      plan) strict_parsed="$(parse_strict_plan_response "$strict_stdout" "$admission_json")" || strict_parsed="" ;;
+      *) strict_parsed="$(parse_strict_spec_response "$strict_stdout" "$admission_json")" || strict_parsed="" ;;
+    esac
+    if [ -z "$strict_parsed" ] \
+        || [ "$(printf '%s\n' "$strict_parsed" | jq -r '.malformed')" = "true" ]; then
+      result_state="unavailable"
+      result_reason="strict_pass_failed"
+    else
+      result_state="applied"
+      result_count="$(printf '%s\n' "$strict_parsed" | jq -r '.count')"
+      result_checks="$(printf '%s\n' "$strict_parsed" | jq -r '.checks')"
+      result_unknown="$(printf '%s\n' "$strict_parsed" | jq -r '.unknown_count')"
+      result_findings="$(printf '%s\n' "$strict_parsed" | jq -c '.findings')"
+    fi
+  fi
+
+  printf '%s\n' "$result_state" "$result_reason" "$result_count" "$result_checks" "$result_unknown" "$result_findings"
+}
+
+strict_run_registry_entry() {
+  local entry="$1"
+  local target_stage checklist_path checklist_key
+  local state="" reason="" count="" checks="" applied="" unknown_count=0
+  local findings_json="[]"
+  local admission_json="[]"
+  local sections_json=""
+  local plan_paths=""
+  local remaining=0
+  local now_epoch=""
+  local dispatch_out=""
+
+  target_stage="$(strict_entry_target_stage "$entry")"
+  checklist_path="$(strict_entry_checklist_relpath "$entry")"
+  checklist_key="$(strict_entry_bundle_checklist_key "$entry")"
+
+  if [ -z "$HEAD_BRANCH" ]; then
+    state="unavailable"
+    reason="stage_unresolved"
+  elif [ "$review_stage" != "$target_stage" ]; then
+    state="not_applicable"
+    if strict_entry_reports_na_reason "$entry"; then
+      reason="stage_not_plan"
+    fi
+  elif [ "$entry" = "plan" ]; then
+    plan_paths="$(strict_changed_plan_paths)"
+    if [ -z "$plan_paths" ]; then
+      state="not_applicable"
+      reason="no_plan_document_changed"
+    elif ! sections_json="$(extract_strict_plan_sections "$checklist_path")"; then
+      state="unavailable"
+      reason="checklist_unreadable"
+    elif ! strict_build_plan_bundle_extras "$plan_paths" "$sections_json"; then
+      state="unavailable"
+      reason="strict_pass_failed"
+    else
+      applied="$strict_plan_applied_set"
+      admission_json="$strict_plan_admission_checks_json"
+      now_epoch="$(date +%s)"
+      remaining=$((TIMEOUT - (now_epoch - round_start_epoch)))
+      if [ "$remaining" -le 0 ]; then
+        state="unavailable"
+        reason="strict_pass_failed"
+      else
+        dispatch_out="$(strict_dispatch_pass "$checklist_path" "$checklist_key" "$admission_json" plan "$remaining")"
+        state="$(printf '%s\n' "$dispatch_out" | sed -n '1p')"
+        reason="$(printf '%s\n' "$dispatch_out" | sed -n '2p')"
+        count="$(printf '%s\n' "$dispatch_out" | sed -n '3p')"
+        checks="$(printf '%s\n' "$dispatch_out" | sed -n '4p')"
+        unknown_count="$(printf '%s\n' "$dispatch_out" | sed -n '5p')"
+        findings_json="$(printf '%s\n' "$dispatch_out" | sed -n '6p')"
+      fi
+    fi
+  elif [ "$entry" = "spec" ]; then
+    if ! admission_json="$(extract_strict_checklist_known_checks "$checklist_path")"; then
+      state="unavailable"
+      reason="checklist_unreadable"
+    else
+      now_epoch="$(date +%s)"
+      remaining=$((TIMEOUT - (now_epoch - round_start_epoch)))
+      if [ "$remaining" -le 0 ]; then
+        state="unavailable"
+        reason="strict_pass_failed"
+      else
+        dispatch_out="$(strict_dispatch_pass "$checklist_path" "$checklist_key" "$admission_json" spec "$remaining")"
+        state="$(printf '%s\n' "$dispatch_out" | sed -n '1p')"
+        reason="$(printf '%s\n' "$dispatch_out" | sed -n '2p')"
+        count="$(printf '%s\n' "$dispatch_out" | sed -n '3p')"
+        checks="$(printf '%s\n' "$dispatch_out" | sed -n '4p')"
+        unknown_count="$(printf '%s\n' "$dispatch_out" | sed -n '5p')"
+        findings_json="$(printf '%s\n' "$dispatch_out" | sed -n '6p')"
+      fi
+    fi
+  fi
+
+  case "$entry" in
+    spec)
+      strict_spec_state="$state"
+      strict_spec_count="$count"
+      strict_spec_checks="$checks"
+      strict_spec_unknown_count="$unknown_count"
+      strict_spec_reason="$reason"
+      strict_spec_findings_json="$findings_json"
+      ;;
+    plan)
+      strict_plan_state="$state"
+      strict_plan_count="$count"
+      strict_plan_checks="$checks"
+      strict_plan_applied="$applied"
+      strict_plan_unknown_count="$unknown_count"
+      strict_plan_reason="$reason"
+      strict_plan_findings_json="$findings_json"
+      ;;
+  esac
+}
+
+strict_run_all_registry_entries() {
+  local entry
+  for entry in $STRICT_REGISTRY_ENTRIES; do
+    strict_run_registry_entry "$entry"
+  done
+}
+
+# ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 # Stage-specific review checklist selection (#1653)
 # ---------------------------------------------------------------------------
@@ -709,20 +1059,27 @@ print_kv REVIEW_DOCTRINE_STATE "$review_doctrine_state"
 print_kv REVIEW_DOCTRINE_PATTERN_COUNT "$review_doctrine_pattern_count"
 print_kv REVIEW_DOCTRINE_VERSION "$review_doctrine_version"
 
-# Strict-spec state (always emitted after a completed ordinary parse).
+# Strict registry state (always emitted after a completed ordinary parse).
 strict_spec_state=""
 strict_spec_count=""
 strict_spec_checks=""
 strict_spec_unknown_count=0
 strict_spec_reason=""
 strict_spec_findings_json="[]"
-strict_context_file=""
-strict_stdout_file=""
-strict_stderr_file=""
+strict_plan_state=""
+strict_plan_count=""
+strict_plan_checks=""
+strict_plan_applied=""
+strict_plan_unknown_count=0
+strict_plan_reason=""
+strict_plan_findings_json="[]"
+strict_plan_applied_set=""
+strict_plan_admission_checks_json="[]"
+strict_plan_documents_json="[]"
+strict_plan_sources_json="[]"
 
 cleanup() {
-  rm -f "${context_file:-}" "${stdout_file:-}" "${stderr_file:-}" \
-    "${strict_context_file:-}" "${strict_stdout_file:-}" "${strict_stderr_file:-}"
+  rm -f "${context_file:-}" "${stdout_file:-}" "${stderr_file:-}"
 }
 trap cleanup EXIT
 
@@ -875,83 +1232,63 @@ blocking_count="${blocking_count:-0}"
 suggestion_count="${suggestion_count:-0}"
 reason="${reason:-}"
 
-# --- Strict spec pass (second invocation; never merges into blocking) ---
-strict_stage="$(resolve_review_stage_for_strict "$HEAD_BRANCH")"
-case "$strict_stage" in
-  unresolved)
-    strict_spec_state="unavailable"
-    strict_spec_reason="stage_unresolved"
-    ;;
-  other)
-    strict_spec_state="not_applicable"
-    ;;
-  spec)
-    checklist_path="$STRICT_SPEC_CHECKLIST_RELPATH"
-    known_checks_json=""
-    if ! known_checks_json="$(extract_strict_spec_known_checks "$checklist_path")"; then
-      strict_spec_state="unavailable"
-      strict_spec_reason="checklist_unreadable"
-    else
-      now_epoch="$(date +%s)"
-      elapsed=$((now_epoch - round_start_epoch))
-      remaining=$((TIMEOUT - elapsed))
-      if [ "$remaining" -le 0 ]; then
-        strict_spec_state="unavailable"
-        strict_spec_reason="strict_pass_failed"
-      else
-        strict_context_file="$(mktemp)"
-        strict_stdout_file="$(mktemp)"
-        strict_stderr_file="$(mktemp)"
-        if ! jq --rawfile checks "$checklist_path" \
-            '. + { strict_spec_checks: $checks }' \
-            "$context_file" >"$strict_context_file"; then
-          strict_spec_state="unavailable"
-          strict_spec_reason="strict_pass_failed"
+# --- Strict registry passes (at most one dispatches; never merges into blocking) ---
+strict_run_all_registry_entries
+
+strict_build_strict_evidence_json() {
+  local state="$1"
+  local count="$2"
+  local checks="$3"
+  local applied="$4"
+  local unknown_count="$5"
+  local reason="$6"
+
+  case "$state" in
+    applied)
+      if [ -n "$applied" ]; then
+        if [ "${unknown_count:-0}" -gt 0 ]; then
+          jq -n \
+            --arg state "$state" \
+            --argjson count "$count" \
+            --arg checks "$checks" \
+            --arg applied "$applied" \
+            --argjson unknown_count "$unknown_count" \
+            '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end), applied:($applied | if . == "" then [] else (split(",") | map(select(length > 0))) end), unknown_count:$unknown_count}'
         else
-          set +e
-          LOCAL_AI_REVIEWER_MODE=strict \
-          CONTEXT_BUNDLE_PATH="$strict_context_file" \
-          PR_NUMBER="$PR_NUMBER" \
-          OWNER="$OWNER" \
-          REPO="$REPO" \
-          BASE_BRANCH="$BASE_BRANCH" \
-          HEAD_BRANCH="$HEAD_BRANCH" \
-          REVIEWED_HEAD="$HEAD_SHA" \
-          REVIEW_STAGE="$review_stage" \
-          REVIEW_STAGE_SOURCE="$review_stage_source" \
-          REVIEW_CHECKLISTS="$review_checklists_csv" \
-          REVIEW_DOCTRINE_STATE="$review_doctrine_state" \
-          REVIEW_DOCTRINE_PATTERN_COUNT="$review_doctrine_pattern_count" \
-          REVIEW_DOCTRINE_VERSION="$review_doctrine_version" \
-            run_with_timeout "$remaining" "$strict_stdout_file" "$strict_stderr_file" \
-              sh -c "$LOCAL_AI_REVIEWER_COMMAND"
-          strict_exit=$?
-          set -e
-          strict_stdout="$(cat "$strict_stdout_file" 2>/dev/null || true)"
-          if [ "$strict_exit" -ne 0 ] \
-              || [ -z "$(printf '%s' "$strict_stdout" | tr -d '[:space:]')" ] \
-              || ! printf '%s\n' "$strict_stdout" | jq -e . >/dev/null 2>&1; then
-            strict_spec_state="unavailable"
-            strict_spec_reason="strict_pass_failed"
-          else
-            strict_parsed="$(parse_strict_spec_response "$strict_stdout" "$known_checks_json")" || strict_parsed=""
-            if [ -z "$strict_parsed" ] \
-                || [ "$(printf '%s\n' "$strict_parsed" | jq -r '.malformed')" = "true" ]; then
-              strict_spec_state="unavailable"
-              strict_spec_reason="strict_pass_failed"
-            else
-              strict_spec_state="applied"
-              strict_spec_count="$(printf '%s\n' "$strict_parsed" | jq -r '.count')"
-              strict_spec_checks="$(printf '%s\n' "$strict_parsed" | jq -r '.checks')"
-              strict_spec_unknown_count="$(printf '%s\n' "$strict_parsed" | jq -r '.unknown_count')"
-              strict_spec_findings_json="$(printf '%s\n' "$strict_parsed" | jq -c '.findings')"
-            fi
-          fi
+          jq -n \
+            --arg state "$state" \
+            --argjson count "$count" \
+            --arg checks "$checks" \
+            --arg applied "$applied" \
+            '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end), applied:($applied | if . == "" then [] else (split(",") | map(select(length > 0))) end)}'
         fi
+      elif [ "${unknown_count:-0}" -gt 0 ]; then
+        jq -n \
+          --arg state "$state" \
+          --argjson count "$count" \
+          --arg checks "$checks" \
+          --argjson unknown_count "$unknown_count" \
+          '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end), unknown_count:$unknown_count}'
+      else
+        jq -n \
+          --arg state "$state" \
+          --argjson count "$count" \
+          --arg checks "$checks" \
+          '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end)}'
       fi
-    fi
-    ;;
-esac
+      ;;
+    unavailable|not_applicable)
+      if [ -n "$reason" ]; then
+        jq -n --arg state "$state" --arg reason "$reason" '{state:$state, reason:$reason}'
+      else
+        jq -n --arg state "$state" '{state:$state}'
+      fi
+      ;;
+    *)
+      jq -n '{}'
+      ;;
+  esac
+}
 
 write_evidence_file() {
   local final_result="$1"
@@ -962,32 +1299,11 @@ write_evidence_file() {
 
   [ -n "${LOCAL_AI_REVIEWER_EVIDENCE_FILE:-}" ] || return 0
 
-  local strict_json="{}"
-  case "$strict_spec_state" in
-    applied)
-      if [ "${strict_spec_unknown_count:-0}" -gt 0 ]; then
-        strict_json="$(jq -n \
-          --arg state "$strict_spec_state" \
-          --argjson count "$strict_spec_count" \
-          --arg checks "$strict_spec_checks" \
-          --argjson unknown_count "$strict_spec_unknown_count" \
-          '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end), unknown_count:$unknown_count}')"
-      else
-        strict_json="$(jq -n \
-          --arg state "$strict_spec_state" \
-          --argjson count "$strict_spec_count" \
-          --arg checks "$strict_spec_checks" \
-          '{state:$state, count:$count, checks:($checks | if . == "" then [] else (split(",") | map(select(length > 0))) end)}')"
-      fi
-      ;;
-    unavailable)
-      strict_json="$(jq -n --arg state "$strict_spec_state" --arg reason "$strict_spec_reason" \
-        '{state:$state, reason:$reason}')"
-      ;;
-    not_applicable)
-      strict_json="$(jq -n --arg state "$strict_spec_state" '{state:$state}')"
-      ;;
-  esac
+  local strict_spec_json strict_plan_json
+  strict_spec_json="$(strict_build_strict_evidence_json "$strict_spec_state" "$strict_spec_count" \
+    "$strict_spec_checks" "" "$strict_spec_unknown_count" "$strict_spec_reason")"
+  strict_plan_json="$(strict_build_strict_evidence_json "$strict_plan_state" "$strict_plan_count" \
+    "$strict_plan_checks" "$strict_plan_applied" "$strict_plan_unknown_count" "$strict_plan_reason")"
 
   if ! jq -n \
     --arg schema_version "local_ai_reviewer_evidence.v1" \
@@ -1013,7 +1329,8 @@ write_evidence_file() {
     --argjson comment_count "$final_comment_count" \
     --argjson blocking_count "$final_blocking_count" \
     --argjson suggestion_count "$final_suggestion_count" \
-    --argjson strict_spec "$strict_json" \
+    --argjson strict_spec "$strict_spec_json" \
+    --argjson strict_plan "$strict_plan_json" \
     '{
       schema_version: $schema_version,
       result: $result,
@@ -1046,7 +1363,8 @@ write_evidence_file() {
         pattern_count: $review_doctrine_pattern_count,
         version: $review_doctrine_version
       },
-      strict_spec: $strict_spec
+      strict_spec: $strict_spec,
+      strict_plan: $strict_plan
     }' >"$LOCAL_AI_REVIEWER_EVIDENCE_FILE"; then
     echo "WARN: could not write local AI reviewer evidence file: $LOCAL_AI_REVIEWER_EVIDENCE_FILE" >&2
   fi
@@ -1068,8 +1386,11 @@ emit_ordinary_and_strict() {
     printf '%s\n' "$parse_result" | awk '/^BLOCKING_[0-9]+_(PATH|LINE|BODY)=/ { print }'
   fi
   emit_strict_spec_output "$strict_spec_state" "$strict_spec_count" \
-    "$strict_spec_checks" "$strict_spec_unknown_count" "$strict_spec_reason" \
+    "$strict_spec_checks" "$strict_spec_unknown_count" "$strict_spec_reason" "" \
     "$strict_spec_findings_json"
+  emit_strict_plan_output "$strict_plan_state" "$strict_plan_count" \
+    "$strict_plan_checks" "$strict_plan_unknown_count" "$strict_plan_reason" "$strict_plan_applied" \
+    "$strict_plan_findings_json"
 }
 
 case "$result" in

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -371,6 +371,34 @@ parse_strict_plan_response() {
   parse_strict_checks_response "$1" "$2" "strict_plan_checks"
 }
 
+# Drop source-dependent findings reported against plan documents that have no
+# sibling spec at the reviewed head. Review-level admission may include those
+# checks when any changed plan has a source; each document still gets only the
+# checks that apply to it (AC-13 / AC-19a).
+filter_strict_plan_parsed_response() {
+  local parsed="$1"
+  local sections_json="$2"
+  local sources_json="$3"
+
+  printf '%s\n' "$parsed" | jq -c --argjson sections "$sections_json" --argjson sources "$sources_json" '
+    ($sections | map(select(.source == "required") | .id)) as $required
+    | ($sources | map(.plan_path)) as $with_source
+    | .findings as $all
+    | ($all | map(select(
+        . as $f
+        | ($required | index($f.check)) == null
+        or ($with_source | index($f.path)) != null
+      ))) as $kept
+    | ($all | length - ($kept | length)) as $dropped
+    | . + {
+        count: ($kept | map(select(.check != "unknown")) | length),
+        checks: ($kept | map(select(.check != "unknown") | .check) | unique | join(",")),
+        unknown_count: ((.unknown_count // 0) + $dropped),
+        findings: $kept
+      }
+  ' 2>/dev/null
+}
+
 emit_strict_entry_output() {
   local prefix="$1"
   local state="$2"
@@ -434,29 +462,36 @@ strict_git_show_at_head() {
 strict_build_plan_bundle_extras() {
   local plan_paths="$1"
   local sections_json="$2"
-  local have_source=0
+  local any_source=0
   local documents_json="[]"
   local sources_json="[]"
-  local plan_path source_path text
+  local plan_path source_path text doc_has_source
 
   while IFS= read -r plan_path; do
     [ -n "$plan_path" ] || continue
     if ! text="$(strict_git_show_at_head "$plan_path")"; then
       return 1
     fi
-    documents_json="$(jq -n --argjson docs "$documents_json" --arg path "$plan_path" --arg text "$text" \
-      '$docs + [{path:$path, text:$text}]')"
+    doc_has_source=false
     source_path="$(strict_plan_source_path_for_plan "$plan_path")"
     if [ -n "$source_path" ] && text="$(strict_git_show_at_head "$source_path")"; then
-      have_source=1
+      any_source=1
+      doc_has_source=true
       sources_json="$(jq -n --argjson srcs "$sources_json" --arg plan_path "$plan_path" \
         --arg source_path "$source_path" --arg text "$text" \
         '$srcs + [{plan_path:$plan_path, source_path:$source_path, text:$text}]')"
+      if ! text="$(strict_git_show_at_head "$plan_path")"; then
+        return 1
+      fi
     fi
+    documents_json="$(jq -n --argjson docs "$documents_json" --arg path "$plan_path" --arg text "$text" \
+      --argjson has_source "$doc_has_source" \
+      '$docs + [{path:$path, text:$text, has_source:$has_source}]')"
   done <<< "$plan_paths"
 
-  strict_plan_applied_set="$(printf '%s\n' "$sections_json" | jq -r --arg have_source "$have_source" '
-    map(select(($have_source == "1") or .source == "not_required") | .id) | join(",")
+  strict_plan_sections_json="$sections_json"
+  strict_plan_applied_set="$(printf '%s\n' "$sections_json" | jq -r --arg any_source "$any_source" '
+    map(select(($any_source == "1") or .source == "not_required") | .id) | join(",")
   ')"
   strict_plan_admission_checks_json="$(printf '%s\n' "$strict_plan_applied_set" | jq -R 'split(",") | map(select(length > 0))')"
 
@@ -611,6 +646,20 @@ strict_run_registry_entry() {
         checks="$(printf '%s\n' "$dispatch_out" | sed -n '4p')"
         unknown_count="$(printf '%s\n' "$dispatch_out" | sed -n '5p')"
         findings_json="$(printf '%s\n' "$dispatch_out" | sed -n '6p')"
+        if [ "$state" = "applied" ] && [ -n "$strict_plan_sections_json" ]; then
+          strict_parsed="$(jq -nc \
+            --argjson count "${count:-0}" \
+            --arg checks "${checks:-}" \
+            --argjson unknown_count "${unknown_count:-0}" \
+            --argjson findings "${findings_json:-[]}" \
+            '{count:$count, checks:$checks, unknown_count:$unknown_count, findings:$findings}')"
+          if strict_parsed="$(filter_strict_plan_parsed_response "$strict_parsed" "$strict_plan_sections_json" "$strict_plan_sources_json")"; then
+            count="$(printf '%s\n' "$strict_parsed" | jq -r '.count')"
+            checks="$(printf '%s\n' "$strict_parsed" | jq -r '.checks')"
+            unknown_count="$(printf '%s\n' "$strict_parsed" | jq -r '.unknown_count')"
+            findings_json="$(printf '%s\n' "$strict_parsed" | jq -c '.findings')"
+          fi
+        fi
       fi
     fi
   elif [ "$entry" = "spec" ]; then
@@ -1075,6 +1124,7 @@ strict_plan_reason=""
 strict_plan_findings_json="[]"
 strict_plan_applied_set=""
 strict_plan_admission_checks_json="[]"
+strict_plan_sections_json="[]"
 strict_plan_documents_json="[]"
 strict_plan_sources_json="[]"
 

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -388,14 +388,20 @@ filter_strict_plan_parsed_response() {
   local parsed="$1"
   local sections_json="$2"
   local sources_json="$3"
+  local documents_json="${4:-[]}"
 
-  printf '%s\n' "$parsed" | jq -c --argjson sections "$sections_json" --argjson sources "$sources_json" '
+  printf '%s\n' "$parsed" | jq -c --argjson sections "$sections_json" --argjson sources "$sources_json" --argjson documents "$documents_json" '
     ($sections | map(select(.source == "required") | .id)) as $required
     | ($sources | map(.plan_path)) as $with_source
+    | ($documents | map(.path)) as $plan_docs
     | .findings as $all
     | ($all | map(
         . as $f
         | if ($f.check != "unknown")
+            and (($f.path | type) != "string" or ($f.path | length) == 0
+                 or ($plan_docs | index($f.path)) == null) then
+            $f + {check: "unknown", remapped: true}
+          elif ($f.check != "unknown")
             and ($required | index($f.check)) != null
             and ($with_source | index($f.path)) == null then
             $f + {check: "unknown", remapped: true}
@@ -668,7 +674,7 @@ strict_run_registry_entry() {
             --argjson unknown_count "${unknown_count:-0}" \
             --argjson findings "${findings_json:-[]}" \
             '{count:$count, checks:$checks, unknown_count:$unknown_count, findings:$findings}')"
-          if strict_parsed="$(filter_strict_plan_parsed_response "$strict_parsed" "$strict_plan_sections_json" "$strict_plan_sources_json")"; then
+          if strict_parsed="$(filter_strict_plan_parsed_response "$strict_parsed" "$strict_plan_sections_json" "$strict_plan_sources_json" "$strict_plan_documents_json")"; then
             count="$(printf '%s\n' "$strict_parsed" | jq -r '.count')"
             checks="$(printf '%s\n' "$strict_parsed" | jq -r '.checks')"
             unknown_count="$(printf '%s\n' "$strict_parsed" | jq -r '.unknown_count')"

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -384,16 +384,22 @@ filter_strict_plan_parsed_response() {
     ($sections | map(select(.source == "required") | .id)) as $required
     | ($sources | map(.plan_path)) as $with_source
     | .findings as $all
-    | ($all | map(select(
+    | ($all | map(
         . as $f
-        | ($required | index($f.check)) == null
-        or ($with_source | index($f.path)) != null
-      ))) as $kept
-    | ($all | length - ($kept | length)) as $dropped
+        | if ($required | index($f.check)) != null
+            and ($with_source | index($f.path)) == null
+            and ($f.check != "unknown") then
+            $f + {check: "unknown"}
+          else
+            $f
+          end
+      )) as $kept
+    | ($kept | map(select(.check != "unknown")) | length) as $named_count
+    | ($kept | map(select(.check == "unknown")) | length) as $unknown_named
     | . + {
-        count: ($kept | map(select(.check != "unknown")) | length),
+        count: $named_count,
         checks: ($kept | map(select(.check != "unknown") | .check) | unique | join(",")),
-        unknown_count: ((.unknown_count // 0) + $dropped),
+        unknown_count: ((.unknown_count // 0) + $unknown_named),
         findings: $kept
       }
   ' 2>/dev/null

--- a/scripts/development-workflow/local-codex-review-command.sh
+++ b/scripts/development-workflow/local-codex-review-command.sh
@@ -15,7 +15,12 @@ mode="${LOCAL_AI_REVIEWER_MODE:-ordinary}"
 if [ "$mode" = "strict" ]; then
   prompt="${LOCAL_CODEX_REVIEWER_STRICT_PROMPT:-}"
   if [ -z "$prompt" ]; then
-    prompt="Apply the strict spec contract checks from the JSON context at ${CONTEXT_BUNDLE_PATH:?} (field strict_spec_checks). Inspect the specification under review against origin/${BASE_BRANCH:-develop}...HEAD. Return only a compact JSON object with fields: mode (must be the string strict_spec_checks), findings array. Each finding must include check (one of the checklist identifiers), path, line, and body (or message). Do not return a review verdict, result, severity, or clear_in_scope. If no strict check fires, return {\"mode\":\"strict_spec_checks\",\"findings\":[]}."
+    if [ -n "${CONTEXT_BUNDLE_PATH:-}" ] && [ -f "${CONTEXT_BUNDLE_PATH}" ] \
+        && jq -e 'has("strict_plan_checks")' "$CONTEXT_BUNDLE_PATH" >/dev/null 2>&1; then
+      prompt="Apply the strict plan contract checks from the JSON context at ${CONTEXT_BUNDLE_PATH:?} (field strict_plan_checks). Use strict_plan_documents and strict_plan_sources for the full plan and spec text at the reviewed head. Return only a compact JSON object with fields: mode (must be the string strict_plan_checks), findings array. Each finding must include check (one of the applied checklist identifiers), path (the plan document under review), line, and body (or message). Do not return a review verdict, result, severity, or clear_in_scope. If no strict check fires, return {\"mode\":\"strict_plan_checks\",\"findings\":[]}."
+    else
+      prompt="Apply the strict spec contract checks from the JSON context at ${CONTEXT_BUNDLE_PATH:?} (field strict_spec_checks). Inspect the specification under review against origin/${BASE_BRANCH:-develop}...HEAD. Return only a compact JSON object with fields: mode (must be the string strict_spec_checks), findings array. Each finding must include check (one of the checklist identifiers), path, line, and body (or message). Do not return a review verdict, result, severity, or clear_in_scope. If no strict check fires, return {\"mode\":\"strict_spec_checks\",\"findings\":[]}."
+    fi
   fi
 else
   prompt="${LOCAL_CODEX_REVIEWER_PROMPT:-}"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -754,6 +754,15 @@ strict_spec_checks=""
 strict_spec_unknown_count=""
 strict_spec_reason=""
 strict_spec_summary_section=""
+# Strict-plan ledger globals (#1655)
+strict_plan_recorded=0
+strict_plan_state=""
+strict_plan_count=""
+strict_plan_checks=""
+strict_plan_applied=""
+strict_plan_unknown_count=""
+strict_plan_reason=""
+strict_plan_summary_section=""
 # Peer evidence collected during this invocation: "platform|result|reason".
 declare -a platform_peer_evidence=()
 
@@ -3644,7 +3653,7 @@ run_coderabbit_cli_review() {
   esac
 }
 
-# Forward STRICT_* keys from local-ai-reviewer.sh output unchanged.
+# Forward STRICT_SPEC_* and STRICT_PLAN_* keys from local-ai-reviewer.sh output unchanged.
 emit_local_ai_strict_spec_keys() {
   local script_output="$1"
   local line key
@@ -3653,6 +3662,9 @@ emit_local_ai_strict_spec_keys() {
     key="${line%%=*}"
     case "$key" in
       STRICT_SPEC_STATE|STRICT_SPEC_COUNT|STRICT_SPEC_CHECKS|STRICT_SPEC_UNKNOWN_COUNT|STRICT_SPEC_REASON)
+        print_kv "$key" "${line#*=}"
+        ;;
+      STRICT_PLAN_STATE|STRICT_PLAN_COUNT|STRICT_PLAN_CHECKS|STRICT_PLAN_APPLIED|STRICT_PLAN_UNKNOWN_COUNT|STRICT_PLAN_REASON)
         print_kv "$key" "${line#*=}"
         ;;
       STRICT_[0-9]*_CHECK|STRICT_[0-9]*_PATH|STRICT_[0-9]*_LINE|STRICT_[0-9]*_BODY)
@@ -3717,6 +3729,41 @@ capture_strict_spec_globals_from_output() {
       line="$(kv_value_default "STRICT_${idx}_LINE" "$script_output" "")"
       body="$(kv_value_default "STRICT_${idx}_BODY" "$script_output" "")"
       strict_spec_summary_section="${strict_spec_summary_section}
+- \`${check}\` ${path}:${line} — ${body}"
+      idx=$((idx + 1))
+    done
+  fi
+}
+
+capture_strict_plan_globals_from_output() {
+  local script_output="$1"
+  local state
+  local idx
+  local check path line body
+  state="$(kv_value_default STRICT_PLAN_STATE "$script_output" "")"
+  if [ -z "$state" ]; then
+    return 0
+  fi
+  strict_plan_recorded=1
+  strict_plan_state="$state"
+  strict_plan_count="$(kv_value_default STRICT_PLAN_COUNT "$script_output" "")"
+  strict_plan_checks="$(kv_value_default STRICT_PLAN_CHECKS "$script_output" "")"
+  strict_plan_applied="$(kv_value_default STRICT_PLAN_APPLIED "$script_output" "")"
+  strict_plan_unknown_count="$(kv_value_default STRICT_PLAN_UNKNOWN_COUNT "$script_output" "")"
+  strict_plan_reason="$(kv_value_default STRICT_PLAN_REASON "$script_output" "")"
+  strict_plan_summary_section=""
+  if [ "$state" = "applied" ] && [ -n "$strict_plan_count" ] && [ "$strict_plan_count" -gt 0 ]; then
+    strict_plan_summary_section="
+
+**Strict plan findings (non-blocking):** applied checks: \`${strict_plan_applied:-}\`"
+    idx=1
+    while true; do
+      check="$(kv_value_default "STRICT_${idx}_CHECK" "$script_output" "")"
+      [ -z "$check" ] && break
+      path="$(kv_value_default "STRICT_${idx}_PATH" "$script_output" "")"
+      line="$(kv_value_default "STRICT_${idx}_LINE" "$script_output" "")"
+      body="$(kv_value_default "STRICT_${idx}_BODY" "$script_output" "")"
+      strict_plan_summary_section="${strict_plan_summary_section}
 - \`${check}\` ${path}:${line} — ${body}"
       idx=$((idx + 1))
     done
@@ -9294,6 +9341,13 @@ reviewer_loop_history_build_entry() {
     --arg strictChecks "${strict_spec_checks:-}" \
     --arg strictUnknown "${strict_spec_unknown_count:-}" \
     --arg strictReason "${strict_spec_reason:-}" \
+    --argjson strictPlanRecorded "${strict_plan_recorded:-0}" \
+    --arg strictPlanState "${strict_plan_state:-}" \
+    --arg strictPlanCount "${strict_plan_count:-}" \
+    --arg strictPlanChecks "${strict_plan_checks:-}" \
+    --arg strictPlanApplied "${strict_plan_applied:-}" \
+    --arg strictPlanUnknown "${strict_plan_unknown_count:-}" \
+    --arg strictPlanReason "${strict_plan_reason:-}" \
     '{
       iteration: $iteration,
       recorded_at: $recordedAt,
@@ -9345,6 +9399,31 @@ reviewer_loop_history_build_entry() {
                   end
               elif $strictState == "unavailable" then
                 . + { reason: $strictReason }
+              else
+                .
+              end
+          )
+        }
+      else
+        .
+      end
+    | if $strictPlanRecorded == 1 then
+        . + {
+          strict_plan: (
+            { state: $strictPlanState }
+            | if $strictPlanState == "applied" then
+                . + {
+                  count: ($strictPlanCount | tonumber),
+                  checks: ($strictPlanChecks | if . == "" then [] else (split(",") | map(select(length > 0))) end),
+                  applied: ($strictPlanApplied | if . == "" then [] else (split(",") | map(select(length > 0))) end)
+                }
+                | if ($strictPlanUnknown | length) > 0 then
+                    . + { unknown_count: ($strictPlanUnknown | tonumber) }
+                  else
+                    .
+                  end
+              elif ($strictPlanState == "unavailable" or $strictPlanState == "not_applicable") then
+                . + { reason: $strictPlanReason }
               else
                 .
               end
@@ -11280,6 +11359,7 @@ for index in "${!platforms[@]}"; do
   emit_prefixed_platform_output "$platform_index" "$platform_output"
   if [ "$platform_name" = "local-ai-reviewer" ]; then
     capture_strict_spec_globals_from_output "$platform_output"
+    capture_strict_plan_globals_from_output "$platform_output"
   fi
   # Record a human-readable display token for the PR summary comment.
   _prt_reason="$platform_reason"
@@ -11887,7 +11967,7 @@ ${_attr_line}"
 **Result:** ${result_line}
 **Platforms:** ${platform_list:-none}${policy_status_section}
 **Findings:** ${blocking} blocking, ${suggestions} suggestions
-${small_findings_section}${missed_findings_section}${attribution_section}${missed_finding_telemetry_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${strict_spec_summary_section}${regression_label_section}
+${small_findings_section}${missed_findings_section}${attribution_section}${missed_finding_telemetry_section}${head_evidence_section}${expensive_gate_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${strict_spec_summary_section}${strict_plan_summary_section}${regression_label_section}
 
 *Posted automatically by \`pr-review-loop.sh\`.*
 EOF

--- a/scripts/development-workflow/tests/fixtures/strict-plan-checks/compensating-duplicate-source.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-checks/compensating-duplicate-source.md
@@ -1,0 +1,42 @@
+# Strict Plan Contract Checks
+
+### source_declaration
+
+Source: required
+Source: not required
+
+**Question:** Q1 — two Source lines (14c compensating duplicate).
+
+### unspecified_step
+
+Source: required
+
+**Question:** Q2
+
+### spec_traceability
+
+Source: required
+
+**Question:** Q3
+
+### ac_test_coverage
+
+Source: required
+
+**Question:** Q4
+
+### phase_ordering
+
+Source: not required
+
+**Question:** Q5
+
+### dependency_state
+
+Source: not required
+
+**Question:** Q6
+
+### reversal_risk
+
+**Question:** Q7 — missing Source while another section has two (14c).

--- a/scripts/development-workflow/tests/fixtures/strict-plan-checks/invalid-source-value.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-checks/invalid-source-value.md
@@ -1,0 +1,43 @@
+# Strict Plan Contract Checks
+
+### source_declaration
+
+Source: not required
+
+**Question:** Q1
+
+### unspecified_step
+
+Source: sometimes
+
+**Question:** Q2 — invalid Source value (14e).
+
+### spec_traceability
+
+Source: required
+
+**Question:** Q3
+
+### ac_test_coverage
+
+Source: required
+
+**Question:** Q4
+
+### phase_ordering
+
+Source: not required
+
+**Question:** Q5
+
+### dependency_state
+
+Source: not required
+
+**Question:** Q6
+
+### reversal_risk
+
+Source: not required
+
+**Question:** Q7

--- a/scripts/development-workflow/tests/fixtures/strict-plan-checks/missing-source-last.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-checks/missing-source-last.md
@@ -1,0 +1,41 @@
+# Strict Plan Contract Checks
+
+### source_declaration
+
+Source: not required
+
+**Question:** Q1
+
+### unspecified_step
+
+Source: required
+
+**Question:** Q2
+
+### spec_traceability
+
+Source: required
+
+**Question:** Q3
+
+### ac_test_coverage
+
+Source: required
+
+**Question:** Q4
+
+### phase_ordering
+
+Source: not required
+
+**Question:** Q5
+
+### dependency_state
+
+Source: not required
+
+**Question:** Q6
+
+### reversal_risk
+
+**Question:** Q7 — final section deliberately missing Source line (14d).

--- a/scripts/development-workflow/tests/fixtures/strict-plan-checks/well-formed.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-checks/well-formed.md
@@ -1,0 +1,43 @@
+# Strict Plan Contract Checks
+
+### source_declaration
+
+Source: not required
+
+**Question:** Does the plan name its source?
+
+### unspecified_step
+
+Source: required
+
+**Question:** Does every step trace to the source?
+
+### spec_traceability
+
+Source: required
+
+**Question:** Does every acceptance criterion have a step?
+
+### ac_test_coverage
+
+Source: required
+
+**Question:** Does every acceptance criterion have a falsifying test?
+
+### phase_ordering
+
+Source: not required
+
+**Question:** Is phase ordering feasible?
+
+### dependency_state
+
+Source: not required
+
+**Question:** Are dependency states explicit?
+
+### reversal_risk
+
+Source: not required
+
+**Question:** Is reversal risk stated?

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/1_ac_test_coverage_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/1_ac_test_coverage_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Must be falsifiable by a named test.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
@@ -8,4 +8,4 @@
 
 ## Tests
 
-- AC-1: assert implementation emits STRICT_PLAN_APPLIED (fails if absent).
+- AC-1: run `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`; non-zero exit when any #1655 scenario fails (fails if AC-1 unmet).

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
@@ -1,0 +1,11 @@
+# Plan
+
+**Spec**: [spec](./1_ac_test_coverage_specs.md)
+
+## Steps
+
+1. Implement AC-1.
+
+## Tests
+
+- AC-1: assert implementation emits STRICT_PLAN_APPLIED (fails if absent).

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
@@ -8,4 +8,4 @@
 
 ## Tests
 
-- AC-1: run `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`; non-zero exit when any #1655 scenario fails (fails if AC-1 unmet).
+- Scenario 1: run `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`; exits non-zero when any #1655 scenario fails (passes only when AC-1 holds).

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/dependency_state/1_dependency_state_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/dependency_state/1_dependency_state_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Use merged dependency.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/dependency_state/2_dependency_state_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/dependency_state/2_dependency_state_implementation-plan.md
@@ -4,7 +4,7 @@
 
 ## Dependencies
 
-- #999 merged (Done).
+- #999 merged (Done). If #999 is not merged when implementation starts, stop and unblock #999 before step 1.
 
 ## Steps
 

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/dependency_state/2_dependency_state_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/dependency_state/2_dependency_state_implementation-plan.md
@@ -1,0 +1,11 @@
+# Plan
+
+**Spec**: [spec](./1_dependency_state_specs.md)
+
+## Dependencies
+
+- #999 merged (Done).
+
+## Steps
+
+1. Integrate dependency output.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/phase_ordering/1_phase_ordering_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/phase_ordering/1_phase_ordering_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Deliver feature.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/phase_ordering/2_phase_ordering_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/phase_ordering/2_phase_ordering_implementation-plan.md
@@ -1,0 +1,9 @@
+# Plan
+
+**Spec**: [spec](./1_phase_ordering_specs.md)
+
+## Steps
+
+1. Add helper function `build_widget`.
+2. Wire UI.
+3. Call helper defined in step 1.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/reversal_risk/1_reversal_risk_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/reversal_risk/1_reversal_risk_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Migrate data safely.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/reversal_risk/2_reversal_risk_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/reversal_risk/2_reversal_risk_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Spec**: [spec](./1_reversal_risk_specs.md)
+
+## Steps
+
+1. Run one-way migration on production table `users`; **cannot be undone** once deployed.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/source_declaration/1_source_declaration_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/source_declaration/1_source_declaration_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Must declare a source document.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/source_declaration/2_source_declaration_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/source_declaration/2_source_declaration_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Spec**: [spec](./1_source_declaration_specs.md)
+
+## Steps
+
+1. Implement with named source document.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/spec_traceability/1_spec_traceability_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/spec_traceability/1_spec_traceability_specs.md
@@ -1,0 +1,4 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Covered by step 1.
+- [ ] **AC-2.** Covered by step 2.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/spec_traceability/2_spec_traceability_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/spec_traceability/2_spec_traceability_implementation-plan.md
@@ -1,0 +1,8 @@
+# Plan
+
+**Spec**: [spec](./1_spec_traceability_specs.md)
+
+## Steps
+
+1. Satisfy AC-1.
+2. Satisfy AC-2.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/unspecified_step/1_unspecified_step_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/unspecified_step/1_unspecified_step_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Only this criterion exists in the source.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/unspecified_step/2_unspecified_step_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans-pass/unspecified_step/2_unspecified_step_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Spec**: [spec](./1_unspecified_step_specs.md)
+
+## Steps
+
+1. Satisfy AC-1.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/ac_test_coverage/1_ac_test_coverage_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/ac_test_coverage/1_ac_test_coverage_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Must be falsifiable by a named test.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/ac_test_coverage/2_ac_test_coverage_implementation-plan.md
@@ -1,0 +1,11 @@
+# Plan
+
+**Spec**: [spec](./1_ac_test_coverage_specs.md)
+
+## Steps
+
+1. Implement AC-1.
+
+## Tests
+
+- Scenario 1: run the suite; passes whether or not AC-1 holds.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/all_falsifying_tests/1_all_falsifying_tests_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/all_falsifying_tests/1_all_falsifying_tests_specs.md
@@ -1,0 +1,4 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Registry dispatches once.
+- [ ] **AC-2.** Applied set is reported.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/all_falsifying_tests/2_all_falsifying_tests_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/all_falsifying_tests/2_all_falsifying_tests_implementation-plan.md
@@ -1,0 +1,13 @@
+# Plan
+
+**Spec**: [spec](./1_all_falsifying_tests_specs.md)
+
+## Steps
+
+1. Implement single dispatch (AC-1).
+2. Emit STRICT_PLAN_APPLIED (AC-2).
+
+## Tests
+
+- AC-1: assert exactly one strict invocation in harness (fails if zero or two).
+- AC-2: grep STRICT_PLAN_APPLIED in reviewer output (fails if absent).

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/declared_addition/1_declared_addition_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/declared_addition/1_declared_addition_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Core work.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/declared_addition/2_declared_addition_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/declared_addition/2_declared_addition_implementation-plan.md
@@ -1,0 +1,8 @@
+# Plan
+
+**Spec**: [spec](./1_declared_addition_specs.md)
+
+## Steps
+
+1. Satisfy AC-1.
+2. **Addition**: add optional metrics export because operators asked for it in review.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/dependency_state/1_dependency_state_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/dependency_state/1_dependency_state_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Use merged dependency.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/dependency_state/2_dependency_state_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/dependency_state/2_dependency_state_implementation-plan.md
@@ -1,0 +1,11 @@
+# Plan
+
+**Spec**: [spec](./1_dependency_state_specs.md)
+
+## Dependencies
+
+- #999 must be merged first (no state recorded).
+
+## Steps
+
+1. Integrate dependency output.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/irreversible_declared/1_irreversible_declared_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/irreversible_declared/1_irreversible_declared_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Publish contract.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/irreversible_declared/2_irreversible_declared_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/irreversible_declared/2_irreversible_declared_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Spec**: [spec](./1_irreversible_declared_specs.md)
+
+## Steps
+
+1. Drop legacy API v1; **cannot be undone** once deployed.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/phase_ordering/1_phase_ordering_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/phase_ordering/1_phase_ordering_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Deliver feature.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/phase_ordering/2_phase_ordering_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/phase_ordering/2_phase_ordering_implementation-plan.md
@@ -1,0 +1,9 @@
+# Plan
+
+**Spec**: [spec](./1_phase_ordering_specs.md)
+
+## Steps
+
+1. Call helper defined in step 3.
+2. Wire UI.
+3. Add helper function `build_widget`.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/refactor_brief/2_refactor_brief_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/refactor_brief/2_refactor_brief_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Source of truth**: tracker issue #1655 (Refactor) — restructure strict pass registry.
+
+## Steps
+
+1. Extract registry without changing spec dispatch.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/refactor_brief/2_refactor_brief_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/refactor_brief/2_refactor_brief_implementation-plan.md
@@ -1,6 +1,6 @@
 # Plan
 
-**Source of truth**: tracker issue #1655 (Refactor) — restructure strict pass registry.
+**Tracker brief (Refactor)**: Issue #1655 — restructure the strict pass registry without changing spec dispatch timing.
 
 ## Steps
 

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/reversal_risk/1_reversal_risk_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/reversal_risk/1_reversal_risk_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Migrate data safely.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/reversal_risk/2_reversal_risk_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/reversal_risk/2_reversal_risk_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Spec**: [spec](./1_reversal_risk_specs.md)
+
+## Steps
+
+1. Run one-way migration on production table `users`.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/source_declaration/1_source_declaration_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/source_declaration/1_source_declaration_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Example.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/source_declaration/2_source_declaration_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/source_declaration/2_source_declaration_implementation-plan.md
@@ -1,0 +1,5 @@
+# Plan
+
+## Steps
+
+1. Implement without naming a source document.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/spec_traceability/1_spec_traceability_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/spec_traceability/1_spec_traceability_specs.md
@@ -1,0 +1,4 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Covered by step 1.
+- [ ] **AC-2.** Orphan criterion with no plan step.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/spec_traceability/2_spec_traceability_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/spec_traceability/2_spec_traceability_implementation-plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+**Spec**: [spec](./1_spec_traceability_specs.md)
+
+## Steps
+
+1. Satisfy AC-1 only.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/unspecified_step/1_unspecified_step_specs.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/unspecified_step/1_unspecified_step_specs.md
@@ -1,0 +1,3 @@
+# Fixture Spec
+
+- [ ] **AC-1.** Only this criterion exists in the source.

--- a/scripts/development-workflow/tests/fixtures/strict-plan-plans/unspecified_step/2_unspecified_step_implementation-plan.md
+++ b/scripts/development-workflow/tests/fixtures/strict-plan-plans/unspecified_step/2_unspecified_step_implementation-plan.md
@@ -1,0 +1,8 @@
+# Plan
+
+**Spec**: [spec](./1_unspecified_step_specs.md)
+
+## Steps
+
+1. Satisfy AC-1.
+2. Add a telemetry dashboard nobody asked for in the source.

--- a/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
@@ -84,6 +84,11 @@ MOCK
 positives=(source_declaration unspecified_step spec_traceability ac_test_coverage phase_ordering dependency_state reversal_risk)
 negatives=(declared_addition irreversible_declared all_falsifying_tests refactor_brief)
 
+if [ -n "${SMOKE_FIXTURE_ONLY:-}" ]; then
+  positives=("$SMOKE_FIXTURE_ONLY")
+  negatives=()
+fi
+
 echo "Running strict-plan smoke fixtures (timeout ${TIMEOUT}s each)"
 for n in "${positives[@]}"; do
   run_fixture "$n" fail

--- a/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
@@ -89,12 +89,19 @@ if [ -n "${SMOKE_FIXTURE_ONLY:-}" ]; then
   negatives=()
 fi
 
+SMOKE_VARIANT="${SMOKE_VARIANT:-both}"
+
 echo "Running strict-plan smoke fixtures (timeout ${TIMEOUT}s each)"
 for n in "${positives[@]}"; do
-  run_fixture "$n" fail
-  run_fixture "$n" pass
+  case "$SMOKE_VARIANT" in
+    fail) run_fixture "$n" fail ;;
+    pass) run_fixture "$n" pass ;;
+    *) run_fixture "$n" fail; run_fixture "$n" pass ;;
+  esac
 done
-echo "=== negative controls ==="
-for n in "${negatives[@]}"; do
-  run_fixture "$n"
-done
+if [ "${#negatives[@]}" -gt 0 ]; then
+  echo "=== negative controls ==="
+  for n in "${negatives[@]}"; do
+    run_fixture "$n"
+  done
+fi

--- a/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
 FIXTURES="$SCRIPT_DIR/fixtures/strict-plan-plans"
+FIXTURES_PASS="$SCRIPT_DIR/fixtures/strict-plan-plans-pass"
 CHECKLIST="$REPO_ROOT/docs/workflow/development-workflow/strict-plan-checks.md"
 TIMEOUT="${LOCAL_AI_REVIEWER_TIMEOUT:-120}"
 PR_NUM="${SMOKE_PR_NUMBER:-999}"
@@ -17,11 +18,17 @@ fi
 
 run_fixture() {
   local name="$1"
-  local tmp mock_bin head plan spec_path
+  local variant="${2:-fail}"
+  local tmp mock_bin head plan fixture_dir
   tmp="$(mktemp -d)"
   mock_bin="$(mktemp -d)/bin"
   mkdir -p "$mock_bin"
   plan="docs/specs/developments/strict-fixture-${name}/2_${name}_implementation-plan.md"
+  case "$variant" in
+    fail) fixture_dir="$FIXTURES/$name" ;;
+    pass) fixture_dir="$FIXTURES_PASS/$name" ;;
+    *) echo "ERROR: unknown variant $variant (expected fail or pass)" >&2; return 1 ;;
+  esac
 
   git -C "$tmp" init -q
   git -C "$tmp" config user.email "smoke@example.com"
@@ -30,7 +37,7 @@ run_fixture() {
   mkdir -p "$tmp/docs/workflow/development-workflow"
   cp "$CHECKLIST" "$tmp/docs/workflow/development-workflow/strict-plan-checks.md"
   mkdir -p "$tmp/docs/specs/developments/strict-fixture-${name}"
-  cp "$FIXTURES/$name/"*.md "$tmp/docs/specs/developments/strict-fixture-${name}/"
+  cp "$fixture_dir/"*.md "$tmp/docs/specs/developments/strict-fixture-${name}/"
   git -C "$tmp" add -A
   git -C "$tmp" commit -q -m "fixture $name"
   git -C "$tmp" remote add origin "git@github.com:owner/repo.git"
@@ -56,7 +63,7 @@ esac
 MOCK
   chmod +x "$mock_bin/gh"
 
-  echo "=== fixture: $name (head ${head:0:12}) ==="
+  echo "=== fixture: $name [$variant] (head ${head:0:12}) ==="
   set +e
   PATH="$mock_bin:$PATH" \
     LOCAL_AI_REVIEWER_COMMAND="$REPO_ROOT/scripts/development-workflow/local-codex-review-command.sh" \
@@ -79,7 +86,8 @@ negatives=(declared_addition irreversible_declared all_falsifying_tests refactor
 
 echo "Running strict-plan smoke fixtures (timeout ${TIMEOUT}s each)"
 for n in "${positives[@]}"; do
-  run_fixture "$n"
+  run_fixture "$n" fail
+  run_fixture "$n" pass
 done
 echo "=== negative controls ==="
 for n in "${negatives[@]}"; do

--- a/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/run-strict-plan-smoke-fixtures.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Smoke helper for #1655 scenarios 20-21: run strict plan pass on fixture plans
+# with the bundled Codex preset. Not invoked from CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+FIXTURES="$SCRIPT_DIR/fixtures/strict-plan-plans"
+CHECKLIST="$REPO_ROOT/docs/workflow/development-workflow/strict-plan-checks.md"
+TIMEOUT="${LOCAL_AI_REVIEWER_TIMEOUT:-120}"
+PR_NUM="${SMOKE_PR_NUMBER:-999}"
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "ERROR: codex CLI required for smoke fixtures" >&2
+  exit 1
+fi
+
+run_fixture() {
+  local name="$1"
+  local tmp mock_bin head plan spec_path
+  tmp="$(mktemp -d)"
+  mock_bin="$(mktemp -d)/bin"
+  mkdir -p "$mock_bin"
+  plan="docs/specs/developments/strict-fixture-${name}/2_${name}_implementation-plan.md"
+
+  git -C "$tmp" init -q
+  git -C "$tmp" config user.email "smoke@example.com"
+  git -C "$tmp" config user.name "Smoke"
+  printf '# Review\n' >"$tmp/REVIEW.md"
+  mkdir -p "$tmp/docs/workflow/development-workflow"
+  cp "$CHECKLIST" "$tmp/docs/workflow/development-workflow/strict-plan-checks.md"
+  mkdir -p "$tmp/docs/specs/developments/strict-fixture-${name}"
+  cp "$FIXTURES/$name/"*.md "$tmp/docs/specs/developments/strict-fixture-${name}/"
+  git -C "$tmp" add -A
+  git -C "$tmp" commit -q -m "fixture $name"
+  git -C "$tmp" remote add origin "git@github.com:owner/repo.git"
+  head="$(git -C "$tmp" rev-parse HEAD)"
+
+  cat >"$mock_bin/gh" <<MOCK
+#!/usr/bin/env bash
+case "\$*" in
+  *"pr view ${PR_NUM}"*"baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"implementation-plan/smoke-${name}","headRefOid":"${head}"}\n'
+    exit 0
+    ;;
+  *"pr diff ${PR_NUM}"*"--name-only"*)
+    printf '%s\nREVIEW.md\n' "${plan}"
+    exit 0
+    ;;
+  *"pr view ${PR_NUM}"*"baseRefName"*)
+    printf '{"baseRefName":"develop"}\n'
+    exit 0
+    ;;
+  *) command gh "\$@" ;;
+esac
+MOCK
+  chmod +x "$mock_bin/gh"
+
+  echo "=== fixture: $name (head ${head:0:12}) ==="
+  set +e
+  PATH="$mock_bin:$PATH" \
+    LOCAL_AI_REVIEWER_COMMAND="$REPO_ROOT/scripts/development-workflow/local-codex-review-command.sh" \
+    bash "$REPO_ROOT/scripts/development-workflow/local-ai-reviewer.sh" \
+      "$PR_NUM" owner repo --timeout "$TIMEOUT" --repo-root "$tmp" \
+      2>"$tmp/stderr.txt" | tee "$tmp/stdout.txt" | rg '^STRICT_PLAN_' || true
+  set -e
+  echo "--- findings ---"
+  rg '^STRICT_[0-9]+_' "$tmp/stdout.txt" || echo "(none)"
+  if [ -s "$tmp/stderr.txt" ]; then
+    echo "--- stderr ---"
+    tail -3 "$tmp/stderr.txt"
+  fi
+  rm -rf "$tmp"
+  echo
+}
+
+positives=(source_declaration unspecified_step spec_traceability ac_test_coverage phase_ordering dependency_state reversal_risk)
+negatives=(declared_addition irreversible_declared all_falsifying_tests refactor_brief)
+
+echo "Running strict-plan smoke fixtures (timeout ${TIMEOUT}s each)"
+for n in "${positives[@]}"; do
+  run_fixture "$n"
+done
+echo "=== negative controls ==="
+for n in "${negatives[@]}"; do
+  run_fixture "$n"
+done

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1632,6 +1632,15 @@ EXTRACTED_PLAN_IDS="$(
 )"
 run_test "1655_s14b_shipped_ids" "$(printf '%s\n' "$EXPECTED_PLAN_IDS" | jq -c 'sort')" "$EXTRACTED_PLAN_IDS"
 
+EXPECTED_PLAN_SOURCES='[{"id":"ac_test_coverage","source":"required"},{"id":"dependency_state","source":"not_required"},{"id":"phase_ordering","source":"not_required"},{"id":"reversal_risk","source":"not_required"},{"id":"source_declaration","source":"not_required"},{"id":"spec_traceability","source":"required"},{"id":"unspecified_step","source":"required"}]'
+EXTRACTED_PLAN_SOURCES="$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    extract_strict_plan_sections "'"$SHIPPED_PLAN_CHECKLIST"'"
+  ' | jq -c 'sort_by(.id)'
+)"
+run_test "1655_s14b_shipped_sources" "$EXPECTED_PLAN_SOURCES" "$EXTRACTED_PLAN_SOURCES"
+
 # Scenario 14c/14d: malformed Source metadata refused
 run_test "1655_s14c_extract_refused" "1" "$(
   HARNESS_MODE=1 bash -c '
@@ -1659,6 +1668,92 @@ run_plan_review
 run_test "1655_s14c_unavailable" "STRICT_PLAN_STATE=unavailable" "$(line_for STRICT_PLAN_STATE)"
 run_test "1655_s14c_reason" "STRICT_PLAN_REASON=checklist_unreadable" "$(line_for STRICT_PLAN_REASON)"
 run_test "1655_s14c_no_count" "no" "$(key_present STRICT_PLAN_COUNT)"
+
+# Scenarios 20/21: planted-violation fail/pass pairs per strict plan check (harness)
+STRICT_PLAN_POSITIVES="$SCRIPT_DIR/fixtures/strict-plan-plans"
+STRICT_PLAN_POSITIVES_PASS="$SCRIPT_DIR/fixtures/strict-plan-plans-pass"
+
+run_planted_plan_fixture_review() {
+  local fixture_name="$1"
+  local variant="$2"
+  local strict_json="$3"
+  local fixture_root dev_dir plan_file
+  case "$variant" in
+    fail) fixture_root="$STRICT_PLAN_POSITIVES" ;;
+    pass) fixture_root="$STRICT_PLAN_POSITIVES_PASS" ;;
+    *) return 1 ;;
+  esac
+  dev_dir="docs/specs/developments/strict-fixture-${fixture_name}"
+  plan_file="$dev_dir/2_${fixture_name}_implementation-plan.md"
+  PLAN_REPO="$(mktemp -d)"
+  git -C "$PLAN_REPO" init -q
+  git -C "$PLAN_REPO" config user.email "test@example.com"
+  git -C "$PLAN_REPO" config user.name "Test User"
+  printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+  git -C "$PLAN_REPO" add REVIEW.md
+  git -C "$PLAN_REPO" commit -q -m "fixture"
+  git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+  mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+  cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+  mkdir -p "$PLAN_REPO/$dev_dir"
+  cp "$fixture_root/$fixture_name/"*.md "$PLAN_REPO/$dev_dir/"
+  git -C "$PLAN_REPO" add -A
+  git -C "$PLAN_REPO" commit -q -m "planted $fixture_name $variant"
+  reset_mocks
+  install_recording_two_pass_mock
+  cat > "$MOCK_BIN/gh" <<MOCK_GH
+#!/usr/bin/env bash
+case "\$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"implementation-plan/1655-planted-${fixture_name}","headRefOid":"%s"}\n' "\${MOCK_PR_HEAD_SHA}"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf '%s\nREVIEW.md\n' "$plan_file"
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK_GH
+  chmod +x "$MOCK_BIN/gh"
+  MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+  MOCK_STRICT_STDOUT="$strict_json"
+  export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+  MOCK_PR_HEAD_BRANCH="implementation-plan/1655-planted-${fixture_name}"
+  MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+  export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+  LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+  export LOCAL_AI_REVIEWER_COMMAND
+  run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+  rm -rf "$PLAN_REPO"
+}
+
+_planted_checks=(
+  "source_declaration:1"
+  "unspecified_step:8"
+  "spec_traceability:7"
+  "ac_test_coverage:11"
+  "phase_ordering:7"
+  "dependency_state:7"
+  "reversal_risk:7"
+)
+for _entry in "${_planted_checks[@]}"; do
+  _check="${_entry%%:*}"
+  _line="${_entry##*:}"
+  _fail_json='{"mode":"strict_plan_checks","findings":[{"check":"'"$_check"'","path":"docs/specs/developments/strict-fixture-'"$_check"'/2_'"$_check"'_implementation-plan.md","line":'"$_line"',"body":"planted violation"}]}'
+  run_planted_plan_fixture_review "$_check" fail "$_fail_json"
+  run_test "1655_s20_${_check}_fail" "STRICT_1_CHECK=${_check}" "$(line_for STRICT_1_CHECK)"
+  run_test "1655_s20_${_check}_fail_line" "${_line}" "$(line_for STRICT_1_LINE)"
+  _pass_json='{"mode":"strict_plan_checks","findings":[]}'
+  run_planted_plan_fixture_review "$_check" pass "$_pass_json"
+  _checks_line="$(line_for STRICT_PLAN_CHECKS 2>/dev/null || true)"
+  if printf '%s' "$_checks_line" | grep -q "$_check"; then
+    _has_check=yes
+  else
+    _has_check=no
+  fi
+  run_test "1655_s21_${_check}_pass" "no" "$_has_check"
+done
 
 # Scenario 16: evidence includes strict_plan on every local reviewer round
 reset_mocks

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1495,7 +1495,7 @@ git -C "$PLAN_REPO" add "$PLAN_DOC" "$PLAN_SPEC"
 git -C "$PLAN_REPO" commit -q -m "long plan"
 mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
 cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
-_full_len="$(git -C "$PLAN_REPO" show "HEAD:$PLAN_DOC" | jq -Rs 'length')"
+_full_text="$(git -C "$PLAN_REPO" show "HEAD:$PLAN_DOC")"
 reset_mocks
 BUNDLE_DUMP="$(mktemp)"
 cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
@@ -1536,8 +1536,8 @@ export MOCK_BUNDLE_DUMP MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
 export LOCAL_AI_REVIEWER_COMMAND
 run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
-_s9_len="$(jq -r '.strict_plan_documents[0].text | length' "$BUNDLE_DUMP")"
-run_test "1655_s9_whole_document" "$_full_len" "$_s9_len"
+_s9_text="$(jq -j -r '.strict_plan_documents[0].text' "$BUNDLE_DUMP")"
+run_test "1655_s9_whole_document" "$_full_text" "$_s9_text"
 rm -f "$BUNDLE_DUMP"
 rm -rf "$PLAN_REPO"
 

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1415,6 +1415,91 @@ run_test "1655_s17_kept_phase_ordering" "STRICT_PLAN_CHECKS=phase_ordering" "$(l
 run_test "1655_s17_unknown_from_drop" "STRICT_PLAN_UNKNOWN_COUNT=1" "$(line_for STRICT_PLAN_UNKNOWN_COUNT)"
 rm -rf "$PLAN_REPO"
 
+# Scenario 7a: coverage follows spec presence, not plan declaration
+PLAN_REPO="$(mktemp -d)"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_DIR"
+printf '# Plan\n\n**Source of truth**: None — Refactor item.\n' > "$PLAN_REPO/$PLAN_DOC"
+printf '# Spec\n\n- [ ] AC-1.\n' > "$PLAN_REPO/$PLAN_SPEC"
+git -C "$PLAN_REPO" add "$PLAN_DOC" "$PLAN_SPEC"
+git -C "$PLAN_REPO" commit -q -m "declares refactor but spec present"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+reset_mocks
+install_recording_two_pass_mock
+install_plan_gh_mock "$PLAN_DOC"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_plan_checks","findings":[]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-7a"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+run_test "1655_s7a_all_seven" "STRICT_PLAN_APPLIED=source_declaration,unspecified_step,spec_traceability,ac_test_coverage,phase_ordering,dependency_state,reversal_risk" "$(line_for STRICT_PLAN_APPLIED)"
+rm -rf "$PLAN_REPO"
+
+# Scenario 8: plan text comes from reviewed head via git show
+PLAN_REPO="$(mktemp -d)"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_DIR"
+printf 'COMMITTED-PLAN-TEXT\n' > "$PLAN_REPO/$PLAN_DOC"
+git -C "$PLAN_REPO" add "$PLAN_DOC"
+git -C "$PLAN_REPO" commit -q -m "plan committed"
+printf 'WORKTREE-ONLY-TEXT\n' > "$PLAN_REPO/$PLAN_DOC"
+_s8_head="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+_s8_text="$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    REPO_ROOT="'"$PLAN_REPO"'"
+    HEAD_SHA="'"$_s8_head"'"
+    strict_git_show_at_head "'"$PLAN_DOC"'"
+  '
+)"
+run_test "1655_s8_git_show_text" "COMMITTED-PLAN-TEXT" "$_s8_text"
+rm -rf "$PLAN_REPO"
+
+# Scenario 11: git show failure → unavailable, one invocation
+PLAN_REPO="$(mktemp -d)"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+reset_mocks
+install_recording_two_pass_mock
+install_plan_gh_mock "$PLAN_DOC"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-s11"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+run_test "1655_s11_unavailable" "STRICT_PLAN_STATE=unavailable" "$(line_for STRICT_PLAN_STATE)"
+run_test "1655_s11_reason" "STRICT_PLAN_REASON=strict_pass_failed" "$(line_for STRICT_PLAN_REASON)"
+run_test "1655_s11_one_invocation" "1" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+rm -f "$MOCK_RECORD_FILE"
+rm -rf "$PLAN_REPO"
+
 # Scenario 15 reverse: plan stage (fresh repo with spec sibling at HEAD)
 PLAN_REPO="$(mktemp -d)"
 git -C "$PLAN_REPO" init -q

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1670,8 +1670,8 @@ run_test "1655_s14c_reason" "STRICT_PLAN_REASON=checklist_unreadable" "$(line_fo
 run_test "1655_s14c_no_count" "no" "$(key_present STRICT_PLAN_COUNT)"
 
 # Scenarios 20/21: planted-violation fail/pass pairs per strict plan check (harness)
-STRICT_PLAN_POSITIVES="$SCRIPT_DIR/fixtures/strict-plan-plans"
-STRICT_PLAN_POSITIVES_PASS="$SCRIPT_DIR/fixtures/strict-plan-plans-pass"
+STRICT_PLAN_POSITIVES="$FIXTURES/strict-plan-plans"
+STRICT_PLAN_POSITIVES_PASS="$FIXTURES/strict-plan-plans-pass"
 
 run_planted_plan_fixture_review() {
   local fixture_name="$1"
@@ -1743,7 +1743,7 @@ for _entry in "${_planted_checks[@]}"; do
   _fail_json='{"mode":"strict_plan_checks","findings":[{"check":"'"$_check"'","path":"docs/specs/developments/strict-fixture-'"$_check"'/2_'"$_check"'_implementation-plan.md","line":'"$_line"',"body":"planted violation"}]}'
   run_planted_plan_fixture_review "$_check" fail "$_fail_json"
   run_test "1655_s20_${_check}_fail" "STRICT_1_CHECK=${_check}" "$(line_for STRICT_1_CHECK)"
-  run_test "1655_s20_${_check}_fail_line" "${_line}" "$(line_for STRICT_1_LINE)"
+  run_test "1655_s20_${_check}_fail_line" "STRICT_1_LINE=${_line}" "$(line_for STRICT_1_LINE)"
   _pass_json='{"mode":"strict_plan_checks","findings":[]}'
   run_planted_plan_fixture_review "$_check" pass "$_pass_json"
   _checks_line="$(line_for STRICT_PLAN_CHECKS 2>/dev/null || true)"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1472,6 +1472,75 @@ _s8_text="$(
 run_test "1655_s8_git_show_text" "COMMITTED-PLAN-TEXT" "$_s8_text"
 rm -rf "$PLAN_REPO"
 
+# Scenario 9 / P2: amendment PR supplies whole plan document, not diff hunks
+PLAN_REPO="$(mktemp -d)"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_DIR"
+python3 - <<'PY' "$PLAN_REPO/$PLAN_DOC"
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+body = "# Plan\n\n**Spec**: [spec](./1_1655-strict-plan-review-mode_specs.md)\n\n"
+body += "".join(f"## Step {i}\n\nDo work item {i}.\n\n" for i in range(1, 121))
+path.write_text(body)
+PY
+printf '# Spec\n\n- [ ] AC-1.\n' > "$PLAN_REPO/$PLAN_SPEC"
+git -C "$PLAN_REPO" add "$PLAN_DOC" "$PLAN_SPEC"
+git -C "$PLAN_REPO" commit -q -m "long plan"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+_full_len="$(git -C "$PLAN_REPO" show "HEAD:$PLAN_DOC" | wc -c | tr -d ' ')"
+reset_mocks
+BUNDLE_DUMP="$(mktemp)"
+cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+if [ -n "${MOCK_BUNDLE_DUMP:-}" ] && [ "${LOCAL_AI_REVIEWER_MODE:-ordinary}" = "strict" ]; then
+  cp "$CONTEXT_BUNDLE_PATH" "$MOCK_BUNDLE_DUMP"
+fi
+if [ "${LOCAL_AI_REVIEWER_MODE:-ordinary}" = "strict" ]; then
+  printf '%s\n' '{"mode":"strict_plan_checks","findings":[]}'
+else
+  printf '%s\n' '{"result":"clean","findings":[]}'
+fi
+MOCK_REVIEWER
+chmod +x "$MOCK_BIN/local-reviewer-mock"
+cat > "$MOCK_BIN/gh" <<MOCK_GH
+#!/usr/bin/env bash
+case "\$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"implementation-plan/1655-s9","headRefOid":"%s"}\n' "\${MOCK_PR_HEAD_SHA}"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf '%s\nREVIEW.md\n' "$PLAN_DOC"
+    exit 0
+    ;;
+  *"pr diff 123"*)
+    printf 'M\t%s\n' "$PLAN_DOC"
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+MOCK_BUNDLE_DUMP="$BUNDLE_DUMP"
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-s9"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_BUNDLE_DUMP MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+_s9_len="$(jq -r '.strict_plan_documents[0].text | length' "$BUNDLE_DUMP")"
+run_test "1655_s9_whole_document" "$_full_len" "$_s9_len"
+rm -f "$BUNDLE_DUMP"
+rm -rf "$PLAN_REPO"
+
 # Scenario 11: git show failure → unavailable, one invocation
 PLAN_REPO="$(mktemp -d)"
 git -C "$PLAN_REPO" init -q

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1562,6 +1562,34 @@ EXTRACTED_PLAN_IDS="$(
 )"
 run_test "1655_s14b_shipped_ids" "$(printf '%s\n' "$EXPECTED_PLAN_IDS" | jq -c 'sort')" "$EXTRACTED_PLAN_IDS"
 
+# Scenario 14c/14d: malformed Source metadata refused
+run_test "1655_s14c_extract_refused" "1" "$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    extract_strict_plan_sections "'"$PLAN_CHECKLIST_FIXTURES/compensating-duplicate-source.md"'" >/dev/null && echo 0 || echo 1
+  '
+)"
+run_test "1655_s14d_extract_refused" "1" "$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    extract_strict_plan_sections "'"$PLAN_CHECKLIST_FIXTURES/missing-source-last.md"'" >/dev/null && echo 0 || echo 1
+  '
+)"
+reset_mocks
+install_recording_two_pass_mock
+install_plan_checklist_into_repo "$PLAN_CHECKLIST_FIXTURES/compensating-duplicate-source.md"
+install_plan_gh_mock "$PLAN_DOC"
+install_plan_artifacts 1
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_ORDINARY_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-14c"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+run_plan_review
+run_test "1655_s14c_unavailable" "STRICT_PLAN_STATE=unavailable" "$(line_for STRICT_PLAN_STATE)"
+run_test "1655_s14c_reason" "STRICT_PLAN_REASON=checklist_unreadable" "$(line_for STRICT_PLAN_REASON)"
+run_test "1655_s14c_no_count" "no" "$(key_present STRICT_PLAN_COUNT)"
+
 # Scenario 16: evidence includes strict_plan on every local reviewer round
 reset_mocks
 install_recording_two_pass_mock

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -396,6 +396,8 @@ if [ -n "${MOCK_RECORD_FILE:-}" ]; then
     if [ -n "${CONTEXT_BUNDLE_PATH:-}" ] && [ -f "${CONTEXT_BUNDLE_PATH}" ]; then
       printf 'bundle_keys=%s\n' "$(jq -r 'keys | join(",")' "$CONTEXT_BUNDLE_PATH")"
       printf 'has_strict_spec_checks=%s\n' "$(jq -r 'has("strict_spec_checks")' "$CONTEXT_BUNDLE_PATH")"
+      printf 'has_strict_plan_checks=%s\n' "$(jq -r 'has("strict_plan_checks")' "$CONTEXT_BUNDLE_PATH")"
+      printf 'has_strict_plan_documents=%s\n' "$(jq -r 'has("strict_plan_documents")' "$CONTEXT_BUNDLE_PATH")"
     fi
   } >> "$MOCK_RECORD_FILE"
 fi
@@ -1252,6 +1254,188 @@ MOCK_REVIEWER
 done
 
 rm -rf "$_1654_doctrine_root" "$_1654_absent_root" "$_1654_unreadable_root" "$_1654_oversized_root" "$_1654_empty_root" "$_1654_grep_err_bin" "$_1654_grep_err_root" "$_1654_cp_fail_bin" "$_1654_cp_fail_root" "$_1654_no_digest_root" "$_1654_no_digest_path"
+
+# ---------------------------------------------------------------------------
+# Strict plan contract checks (#1655) — scenarios 1, 7, 13, 15
+# ---------------------------------------------------------------------------
+
+PLAN_CHECKLIST_FIXTURES="$FIXTURES/strict-plan-checks"
+SHIPPED_PLAN_CHECKLIST="$REPO_ROOT/docs/workflow/development-workflow/strict-plan-checks.md"
+PLAN_DEV_DIR="docs/specs/developments/20260831062000_1655-strict-plan-review-mode"
+PLAN_DOC="$PLAN_DEV_DIR/2_1655-strict-plan-review-mode_implementation-plan.md"
+PLAN_SPEC="$PLAN_DEV_DIR/1_1655-strict-plan-review-mode_specs.md"
+
+install_plan_checklist_into_repo() {
+  local src="$1"
+  mkdir -p "$VALID_REPO_ROOT/docs/workflow/development-workflow"
+  cp "$src" "$VALID_REPO_ROOT/docs/workflow/development-workflow/strict-plan-checks.md"
+  git -C "$VALID_REPO_ROOT" add docs/workflow/development-workflow/strict-plan-checks.md >/dev/null 2>&1 || true # workflow-shell-guard: allow SH001
+}
+
+install_plan_artifacts() {
+  local with_spec="${1:-1}"
+  mkdir -p "$VALID_REPO_ROOT/$PLAN_DEV_DIR"
+  cp "$REPO_ROOT/$PLAN_DOC" "$VALID_REPO_ROOT/$PLAN_DOC" 2>/dev/null || \
+    printf '# Plan\n\n**Spec**: [spec](./1_1655-strict-plan-review-mode_specs.md)\n' > "$VALID_REPO_ROOT/$PLAN_DOC"
+  if [ "$with_spec" = "1" ]; then
+    cp "$REPO_ROOT/$PLAN_SPEC" "$VALID_REPO_ROOT/$PLAN_SPEC" 2>/dev/null || \
+      printf '# Spec\n\n- [ ] AC-1. Example\n' > "$VALID_REPO_ROOT/$PLAN_SPEC"
+    git -C "$VALID_REPO_ROOT" add "$PLAN_DOC" "$PLAN_SPEC" >/dev/null 2>&1 || true # workflow-shell-guard: allow SH001
+  else
+    rm -f "$VALID_REPO_ROOT/$PLAN_SPEC"
+    git -C "$VALID_REPO_ROOT" rm -f "$PLAN_SPEC" >/dev/null 2>&1 || true # workflow-shell-guard: allow SH001
+    git -C "$VALID_REPO_ROOT" add "$PLAN_DOC" >/dev/null 2>&1 || true # workflow-shell-guard: allow SH001
+  fi
+  git -C "$VALID_REPO_ROOT" commit -m "test: plan artifacts" >/dev/null 2>&1 || true # workflow-shell-guard: allow SH001
+}
+
+install_plan_gh_mock() {
+  local changed_path="$1"
+  local head_branch="${MOCK_PR_HEAD_BRANCH:-implementation-plan/1655-test}"
+  cat > "$MOCK_BIN/gh" <<MOCK_GH
+#!/usr/bin/env bash
+case "\$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"$head_branch","headRefOid":"%s"}\n' "\${MOCK_PR_HEAD_SHA}"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf '%s\nREVIEW.md\n' "$changed_path"
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK_GH
+  chmod +x "$MOCK_BIN/gh"
+}
+
+run_plan_review() {
+  MOCK_PR_HEAD_BRANCH="${MOCK_PR_HEAD_BRANCH:-implementation-plan/1655-test}"
+  MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+  export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+  LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+  export LOCAL_AI_REVIEWER_COMMAND
+  run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT" "$@"
+}
+
+# Scenario 15: spec stage — spec applied, plan not_applicable stage_not_plan
+reset_mocks
+install_recording_two_pass_mock
+install_checklist_into_repo "$CHECKLIST_FIXTURES/well-formed.md"
+install_plan_checklist_into_repo "$PLAN_CHECKLIST_FIXTURES/well-formed.md"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_spec_checks","findings":[]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+run_spec_review
+run_test "1655_s15_spec_applied" "STRICT_SPEC_STATE=applied" "$(line_for STRICT_SPEC_STATE)"
+run_test "1655_s15_plan_na" "STRICT_PLAN_STATE=not_applicable" "$(line_for STRICT_PLAN_STATE)"
+run_test "1655_s15_plan_reason" "STRICT_PLAN_REASON=stage_not_plan" "$(line_for STRICT_PLAN_REASON)"
+
+# Scenario 7: partial applied set without source spec (fresh repo — no spec at HEAD)
+PLAN_REPO="$(mktemp -d)"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_DIR"
+printf '# Plan\n' > "$PLAN_REPO/$PLAN_DOC"
+git -C "$PLAN_REPO" add "$PLAN_DOC"
+git -C "$PLAN_REPO" commit -q -m "plan-only"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+reset_mocks
+install_recording_two_pass_mock
+install_plan_gh_mock "$PLAN_DOC"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_plan_checks","findings":[]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-no-spec"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+run_test "1655_s7_partial_applied" "STRICT_PLAN_APPLIED=source_declaration,phase_ordering,dependency_state,reversal_risk" "$(line_for STRICT_PLAN_APPLIED)"
+rm -rf "$PLAN_REPO"
+
+# Scenario 15 reverse: plan stage (fresh repo with spec sibling at HEAD)
+PLAN_REPO="$(mktemp -d)"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_DIR"
+cp "$REPO_ROOT/$PLAN_DOC" "$PLAN_REPO/$PLAN_DOC"
+cp "$REPO_ROOT/$PLAN_SPEC" "$PLAN_REPO/$PLAN_SPEC"
+git -C "$PLAN_REPO" add "$PLAN_DOC" "$PLAN_SPEC"
+git -C "$PLAN_REPO" commit -q -m "plan-with-spec"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+cp "$CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-spec-checks.md"
+reset_mocks
+install_recording_two_pass_mock
+install_plan_gh_mock "$PLAN_DOC"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_plan_checks","findings":[]}'
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-test"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+run_test "1655_s15_plan_applied" "STRICT_PLAN_STATE=applied" "$(line_for STRICT_PLAN_STATE)"
+run_test "1655_s15_spec_na" "STRICT_SPEC_STATE=not_applicable" "$(line_for STRICT_SPEC_STATE)"
+run_test "1655_s15_no_spec_reason" "no" "$(key_present STRICT_SPEC_REASON)"
+run_test "1655_s15_plan_applied_set7" "STRICT_PLAN_APPLIED=source_declaration,unspecified_step,spec_traceability,ac_test_coverage,phase_ordering,dependency_state,reversal_risk" "$(line_for STRICT_PLAN_APPLIED)"
+run_test "1655_s15_bundle_has_plan_docs" "true" "$(awk -F= '/^has_strict_plan_documents=/{print $2}' "$MOCK_RECORD_FILE" | tail -1)"
+rm -f "$MOCK_RECORD_FILE"
+rm -rf "$PLAN_REPO"
+
+# Scenario 13: runbook-only plan stage PR
+reset_mocks
+install_recording_two_pass_mock
+install_plan_checklist_into_repo "$PLAN_CHECKLIST_FIXTURES/well-formed.md"
+install_plan_gh_mock "docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md"
+MOCK_RECORD_FILE="$(mktemp)"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_RECORD_FILE MOCK_ORDINARY_STDOUT
+run_plan_review
+run_test "1655_s13_runbook_only" "STRICT_PLAN_STATE=not_applicable" "$(line_for STRICT_PLAN_STATE)"
+run_test "1655_s13_reason" "STRICT_PLAN_REASON=no_plan_document_changed" "$(line_for STRICT_PLAN_REASON)"
+run_test "1655_s13_one_invocation" "1" "$(grep -c '^mode=' "$MOCK_RECORD_FILE" || true)"
+rm -f "$MOCK_RECORD_FILE"
+
+# Scenario 14b: shipped plan identifiers
+EXPECTED_PLAN_IDS='["source_declaration","unspecified_step","spec_traceability","ac_test_coverage","phase_ordering","dependency_state","reversal_risk"]'
+EXTRACTED_PLAN_IDS="$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    extract_strict_checklist_known_checks "'"$SHIPPED_PLAN_CHECKLIST"'"
+  ' | jq -c 'sort'
+)"
+run_test "1655_s14b_shipped_ids" "$(printf '%s\n' "$EXPECTED_PLAN_IDS" | jq -c 'sort')" "$EXTRACTED_PLAN_IDS"
+
+# Scenario 16: evidence includes strict_plan on every local reviewer round
+reset_mocks
+install_recording_two_pass_mock
+install_plan_checklist_into_repo "$PLAN_CHECKLIST_FIXTURES/well-formed.md"
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$EVIDENCE_FILE"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_ORDINARY_STDOUT
+MOCK_PR_HEAD_BRANCH="feature/test"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "1655_s16_evidence_has_plan" "true" "$(jq -r 'has("strict_plan")' "$EVIDENCE_FILE")"
+run_test "1655_s16_evidence_plan_state" "not_applicable" "$(jq -r '.strict_plan.state' "$EVIDENCE_FILE")"
 
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1413,6 +1413,7 @@ run_test "1655_s17_applied_all7" "STRICT_PLAN_APPLIED=source_declaration,unspeci
 run_test "1655_s17_drop_source_on_nospec" "STRICT_PLAN_COUNT=1" "$(line_for STRICT_PLAN_COUNT)"
 run_test "1655_s17_kept_phase_ordering" "STRICT_PLAN_CHECKS=phase_ordering" "$(line_for STRICT_PLAN_CHECKS)"
 run_test "1655_s17_unknown_from_drop" "STRICT_PLAN_UNKNOWN_COUNT=1" "$(line_for STRICT_PLAN_UNKNOWN_COUNT)"
+run_test "1655_s17_unknown_detail" "STRICT_2_CHECK=unknown" "$(line_for STRICT_2_CHECK)"
 rm -rf "$PLAN_REPO"
 
 # Scenario 7a: coverage follows spec presence, not plan declaration

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1413,7 +1413,7 @@ run_test "1655_s17_applied_all7" "STRICT_PLAN_APPLIED=source_declaration,unspeci
 run_test "1655_s17_drop_source_on_nospec" "STRICT_PLAN_COUNT=1" "$(line_for STRICT_PLAN_COUNT)"
 run_test "1655_s17_kept_phase_ordering" "STRICT_PLAN_CHECKS=phase_ordering" "$(line_for STRICT_PLAN_CHECKS)"
 run_test "1655_s17_unknown_from_drop" "STRICT_PLAN_UNKNOWN_COUNT=1" "$(line_for STRICT_PLAN_UNKNOWN_COUNT)"
-run_test "1655_s17_unknown_detail" "STRICT_2_CHECK=unknown" "$(line_for STRICT_2_CHECK)"
+run_test "1655_s17_unknown_detail" "STRICT_1_CHECK=unknown" "$(line_for STRICT_1_CHECK)"
 rm -rf "$PLAN_REPO"
 
 # Scenario 7a: coverage follows spec presence, not plan declaration

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1315,7 +1315,7 @@ run_plan_review() {
   export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
   LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
   export LOCAL_AI_REVIEWER_COMMAND
-  run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT" "$@"
+  run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
 }
 
 # Scenario 15: spec stage — spec applied, plan not_applicable stage_not_plan

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1541,6 +1541,74 @@ run_test "1655_s9_whole_document" "$_full_text" "$_s9_text"
 rm -f "$BUNDLE_DUMP"
 rm -rf "$PLAN_REPO"
 
+# Scenario 10: two changed plan documents supplied with per-document sources (AC-13)
+PLAN_REPO="$(mktemp -d)"
+PLAN_DEV_A="docs/specs/developments/20260831062000_1655-strict-plan-review-mode"
+PLAN_DEV_B="docs/specs/developments/20260831062001_1655-other"
+PLAN_DOC_A="$PLAN_DEV_A/2_1655-strict-plan-review-mode_implementation-plan.md"
+PLAN_SPEC_A="$PLAN_DEV_A/1_1655-strict-plan-review-mode_specs.md"
+PLAN_DOC_B="$PLAN_DEV_B/2_1655-other_implementation-plan.md"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_A" "$PLAN_REPO/$PLAN_DEV_B"
+printf '# Plan A\n\nSibling spec present.\n' > "$PLAN_REPO/$PLAN_DOC_A"
+printf '# Spec A\n\n- [ ] AC-1.\n' > "$PLAN_REPO/$PLAN_SPEC_A"
+printf '# Plan B\n\nNo sibling spec.\n' > "$PLAN_REPO/$PLAN_DOC_B"
+git -C "$PLAN_REPO" add "$PLAN_DOC_A" "$PLAN_SPEC_A" "$PLAN_DOC_B"
+git -C "$PLAN_REPO" commit -q -m "two plans"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+reset_mocks
+BUNDLE_DUMP="$(mktemp)"
+cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+if [ -n "${MOCK_BUNDLE_DUMP:-}" ] && [ "${LOCAL_AI_REVIEWER_MODE:-ordinary}" = "strict" ]; then
+  cp "$CONTEXT_BUNDLE_PATH" "$MOCK_BUNDLE_DUMP"
+fi
+if [ "${LOCAL_AI_REVIEWER_MODE:-ordinary}" = "strict" ]; then
+  printf '%s\n' '{"mode":"strict_plan_checks","findings":[]}'
+else
+  printf '%s\n' '{"result":"clean","findings":[]}'
+fi
+MOCK_REVIEWER
+chmod +x "$MOCK_BIN/local-reviewer-mock"
+cat > "$MOCK_BIN/gh" <<MOCK_GH
+#!/usr/bin/env bash
+case "\$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"implementation-plan/1655-s10","headRefOid":"%s"}\n' "\${MOCK_PR_HEAD_SHA}"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf '%s\n%s\nREVIEW.md\n' "$PLAN_DOC_A" "$PLAN_DOC_B"
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+MOCK_BUNDLE_DUMP="$BUNDLE_DUMP"
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-s10"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_BUNDLE_DUMP MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+run_test "1655_s10_two_documents" "2" "$(jq -r '.strict_plan_documents | length' "$BUNDLE_DUMP")"
+run_test "1655_s10_doc_a_path" "$PLAN_DOC_A" "$(jq -r '.strict_plan_documents[0].path' "$BUNDLE_DUMP")"
+run_test "1655_s10_doc_b_path" "$PLAN_DOC_B" "$(jq -r '.strict_plan_documents[1].path' "$BUNDLE_DUMP")"
+run_test "1655_s10_doc_a_has_source" "true" "$(jq -r '.strict_plan_documents[0].has_source' "$BUNDLE_DUMP")"
+run_test "1655_s10_doc_b_has_source" "false" "$(jq -r '.strict_plan_documents[1].has_source' "$BUNDLE_DUMP")"
+run_test "1655_s10_one_source" "1" "$(jq -r '.strict_plan_sources | length' "$BUNDLE_DUMP")"
+run_test "1655_s10_source_plan_a" "$PLAN_DOC_A" "$(jq -r '.strict_plan_sources[0].plan_path' "$BUNDLE_DUMP")"
+rm -f "$BUNDLE_DUMP"
+rm -rf "$PLAN_REPO"
+
 # Scenario 11: git show failure → unavailable, one invocation
 PLAN_REPO="$(mktemp -d)"
 git -C "$PLAN_REPO" init -q
@@ -1654,6 +1722,26 @@ run_test "1655_s14d_extract_refused" "1" "$(
     extract_strict_plan_sections "'"$PLAN_CHECKLIST_FIXTURES/missing-source-last.md"'" >/dev/null && echo 0 || echo 1
   '
 )"
+run_test "1655_s14e_extract_refused" "1" "$(
+  HARNESS_MODE=1 bash -c '
+    source "'"$REVIEWER"'"
+    extract_strict_plan_sections "'"$PLAN_CHECKLIST_FIXTURES/invalid-source-value.md"'" >/dev/null && echo 0 || echo 1
+  '
+)"
+reset_mocks
+install_recording_two_pass_mock
+install_plan_checklist_into_repo "$PLAN_CHECKLIST_FIXTURES/invalid-source-value.md"
+install_plan_gh_mock "$PLAN_DOC"
+install_plan_artifacts 1
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+export MOCK_ORDINARY_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-14e"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+run_plan_review
+run_test "1655_s14e_unavailable" "STRICT_PLAN_STATE=unavailable" "$(line_for STRICT_PLAN_STATE)"
+run_test "1655_s14e_reason" "STRICT_PLAN_REASON=checklist_unreadable" "$(line_for STRICT_PLAN_REASON)"
+run_test "1655_s14e_no_count" "no" "$(key_present STRICT_PLAN_COUNT)"
 reset_mocks
 install_recording_two_pass_mock
 install_plan_checklist_into_repo "$PLAN_CHECKLIST_FIXTURES/compensating-duplicate-source.md"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1361,6 +1361,60 @@ run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
 run_test "1655_s7_partial_applied" "STRICT_PLAN_APPLIED=source_declaration,phase_ordering,dependency_state,reversal_risk" "$(line_for STRICT_PLAN_APPLIED)"
 rm -rf "$PLAN_REPO"
 
+# Scenario 17: mixed plans — source-dependent finding on no-spec plan is dropped
+PLAN_REPO="$(mktemp -d)"
+PLAN_DEV_A="docs/specs/developments/20260831062000_1655-strict-plan-review-mode"
+PLAN_DEV_B="docs/specs/developments/20260831062001_1655-other"
+PLAN_DOC_A="$PLAN_DEV_A/2_1655-strict-plan-review-mode_implementation-plan.md"
+PLAN_SPEC_A="$PLAN_DEV_A/1_1655-strict-plan-review-mode_specs.md"
+PLAN_DOC_B="$PLAN_DEV_B/2_1655-other_implementation-plan.md"
+git -C "$PLAN_REPO" init -q
+git -C "$PLAN_REPO" config user.email "test@example.com"
+git -C "$PLAN_REPO" config user.name "Test User"
+printf '# Review\n' > "$PLAN_REPO/REVIEW.md"
+git -C "$PLAN_REPO" add REVIEW.md
+git -C "$PLAN_REPO" commit -q -m "fixture"
+git -C "$PLAN_REPO" remote add origin "git@github.com:owner/repo.git"
+mkdir -p "$PLAN_REPO/$PLAN_DEV_A" "$PLAN_REPO/$PLAN_DEV_B"
+printf '# Plan A\n' > "$PLAN_REPO/$PLAN_DOC_A"
+printf '# Spec A\n' > "$PLAN_REPO/$PLAN_SPEC_A"
+printf '# Plan B\n' > "$PLAN_REPO/$PLAN_DOC_B"
+git -C "$PLAN_REPO" add "$PLAN_DOC_A" "$PLAN_SPEC_A" "$PLAN_DOC_B"
+git -C "$PLAN_REPO" commit -q -m "mixed plans"
+mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
+cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
+reset_mocks
+install_recording_two_pass_mock
+cat > "$MOCK_BIN/gh" <<MOCK_GH
+#!/usr/bin/env bash
+case "\$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    printf '{"baseRefName":"develop","headRefName":"implementation-plan/1655-mixed","headRefOid":"%s"}\n' "\${MOCK_PR_HEAD_SHA}"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf '%s\n%s\nREVIEW.md\n' "$PLAN_DOC_A" "$PLAN_DOC_B"
+    exit 0
+    ;;
+  *) exit 1 ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+MOCK_ORDINARY_STDOUT='{"result":"clean","findings":[]}'
+MOCK_STRICT_STDOUT='{"mode":"strict_plan_checks","findings":[{"check":"unspecified_step","path":"'"$PLAN_DOC_B"'","line":1,"body":"should drop"},{"check":"phase_ordering","path":"'"$PLAN_DOC_B"'","line":2,"body":"should keep"}]}'
+export MOCK_ORDINARY_STDOUT MOCK_STRICT_STDOUT
+MOCK_PR_HEAD_BRANCH="implementation-plan/1655-mixed"
+MOCK_PR_HEAD_SHA="$(git -C "$PLAN_REPO" rev-parse HEAD)"
+export MOCK_PR_HEAD_BRANCH MOCK_PR_HEAD_SHA
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+export LOCAL_AI_REVIEWER_COMMAND
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$PLAN_REPO"
+run_test "1655_s17_applied_all7" "STRICT_PLAN_APPLIED=source_declaration,unspecified_step,spec_traceability,ac_test_coverage,phase_ordering,dependency_state,reversal_risk" "$(line_for STRICT_PLAN_APPLIED)"
+run_test "1655_s17_drop_source_on_nospec" "STRICT_PLAN_COUNT=1" "$(line_for STRICT_PLAN_COUNT)"
+run_test "1655_s17_kept_phase_ordering" "STRICT_PLAN_CHECKS=phase_ordering" "$(line_for STRICT_PLAN_CHECKS)"
+run_test "1655_s17_unknown_from_drop" "STRICT_PLAN_UNKNOWN_COUNT=1" "$(line_for STRICT_PLAN_UNKNOWN_COUNT)"
+rm -rf "$PLAN_REPO"
+
 # Scenario 15 reverse: plan stage (fresh repo with spec sibling at HEAD)
 PLAN_REPO="$(mktemp -d)"
 git -C "$PLAN_REPO" init -q

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1495,7 +1495,7 @@ git -C "$PLAN_REPO" add "$PLAN_DOC" "$PLAN_SPEC"
 git -C "$PLAN_REPO" commit -q -m "long plan"
 mkdir -p "$PLAN_REPO/docs/workflow/development-workflow"
 cp "$PLAN_CHECKLIST_FIXTURES/well-formed.md" "$PLAN_REPO/docs/workflow/development-workflow/strict-plan-checks.md"
-_full_len="$(git -C "$PLAN_REPO" show "HEAD:$PLAN_DOC" | wc -c | tr -d ' ')"
+_full_len="$(git -C "$PLAN_REPO" show "HEAD:$PLAN_DOC" | jq -Rs 'length')"
 reset_mocks
 BUNDLE_DUMP="$(mktemp)"
 cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -17093,6 +17093,76 @@ unset unresolved_thread_count late_thread_count pr_number
 echo "=== Area 1650 complete ==="
 
 # ---------------------------------------------------------------------------
+# Area 1655: strict_plan ledger object (#1655 scenario 16)
+# ---------------------------------------------------------------------------
+echo "=== Area 1655: strict_plan ledger object ==="
+
+pr_number=""
+current_run_id="1655-ledger"
+unresolved_thread_count=0
+late_thread_count=0
+expensive_gate_last_result=""
+
+strict_plan_recorded=1
+strict_plan_state="applied"
+strict_plan_count="2"
+strict_plan_checks="phase_ordering,dependency_state"
+strict_plan_applied="source_declaration,phase_ordering,dependency_state,reversal_risk"
+strict_plan_unknown_count=""
+strict_plan_reason=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+run_test "1655_ledger_applied_state" "applied" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan.state')"
+run_test "1655_ledger_applied_count" "2" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan.count')"
+run_test "1655_ledger_applied_checks" "true" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan | has("checks")')"
+run_test "1655_ledger_applied_applied" "true" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan | has("applied")')"
+run_test "1655_ledger_applied_no_reason" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan | has("reason")')"
+
+strict_plan_state="not_applicable"
+strict_plan_count=""
+strict_plan_checks=""
+strict_plan_applied=""
+strict_plan_unknown_count=""
+strict_plan_reason="stage_not_plan"
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+run_test "1655_ledger_na_state" "not_applicable" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan.state')"
+run_test "1655_ledger_na_reason" "stage_not_plan" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan.reason')"
+run_test "1655_ledger_na_no_count" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan | has("count")')"
+run_test "1655_ledger_na_no_applied" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan | has("applied")')"
+
+strict_plan_recorded=0
+strict_plan_state=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "bugbot" 0 0 0 "" 0 0 "")"
+run_test "1655_ledger_absent_object" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r 'has("strict_plan")')"
+
+strict_plan_recorded=1
+strict_plan_state="unavailable"
+strict_plan_reason="checklist_unreadable"
+strict_plan_count=""
+strict_plan_checks=""
+strict_plan_applied=""
+_entry="$(reviewer_loop_history_build_entry 1 clean "" "local-ai-reviewer" 0 0 0 "" 0 0 "")"
+run_test "1655_ledger_unavail_reason" "checklist_unreadable" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan.reason')"
+run_test "1655_ledger_unavail_no_count" "false" \
+  "$(printf '%s\n' "$_entry" | jq -r '.strict_plan | has("count")')"
+
+unset strict_plan_recorded strict_plan_state strict_plan_count strict_plan_checks
+unset strict_plan_applied strict_plan_unknown_count strict_plan_reason _entry
+unset current_run_id unresolved_thread_count late_thread_count pr_number
+
+echo "=== Area 1655 complete ==="
+
+# ---------------------------------------------------------------------------
 # Area 1651: missed-finding telemetry
 # Scenarios 1–3, 6–16 (ancestry 4/5 live in test-reviewer-loop-commit-ancestry.sh)
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -3390,3 +3390,12 @@ _workflow_lowti_candidate_keys_json() {
   fi
   printf '%s\n' "${keys[@]}" | jq -R . | jq -sc .
 }
+
+# workflow_is_plan_document_path <path>
+#
+# True when path is an implementation-plan document under docs/specs/developments/.
+# Shared by check-documentation-stage-alignment.sh and local-ai-reviewer.sh (#1655).
+workflow_is_plan_document_path() {
+  local path="$1"
+  [[ "$path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]
+}


### PR DESCRIPTION
## Summary

- Refactors #1650 strict pass into a two-entry registry (spec + plan).
- Adds strict plan checks with git-show supply, applied-set reporting, and unknown relabelling.
- Forwards strict_plan through evidence JSON and reviewer-loop history.

## Pre-Submission Self-Review (Cross-Cutting Assumptions)

| Assumption | Status |
| --- | --- |
| #1650 strict pass merged (registry refactor baseline) | **Still valid** |
| #1653 review_stage=plan merged | **Still valid** |
| #1681 applied-set follows spec presence not plan declaration | **Still valid** |
| Dependencies #1650/#1653 merged on integration branch | **Still valid** |

## Test plan

- [x] test-local-ai-reviewer.sh — 321 passed
- [x] test-pr-review-loop.sh — Area 1655 strict_plan ledger
- [x] Smoke 20–21 + recorded proofs in docs/testing/workflow/1655-strict-plan-review-mode.smoke-test.md
- [ ] CI / reviewer loop

## Planted-violation proofs

See smoke runbook § Recorded proof results and PR comment https://github.com/lhpaul/ai-dev-framework-template/pull/1691#issuecomment-5491156335

P7–P13 pass-after-removal: negative controls (`declared_addition`, `irreversible_declared`, `all_falsifying_tests`) demonstrate the pass side for checks 2/7/4; positive fixtures include paired removal runs (e.g. `unspecified_step` without line 8 → no `unspecified_step` finding on re-run).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automated reviewer-loop and local AI reviewer orchestration (second-pass dispatch, parsing, and telemetry), but strict findings remain non-blocking and spec behavior is refactored rather than removed.
> 
> **Overview**
> Adds a **strict plan** pass alongside the existing strict spec pass, unified through a **spec/plan registry** in `local-ai-reviewer.sh`. Both entries always emit their own `STRICT_SPEC_*` / `STRICT_PLAN_*` state on every review; **at most one** runs a second non-blocking AI invocation for the resolved stage.
> 
> On `implementation-plan/*` PRs that change an implementation-plan document, the plan entry loads `strict-plan-checks.md` (seven checks with `Source: required|not required`), supplies **full plan text at reviewed HEAD** via `git show` (plus sibling specs when present), computes an **applied** check set (`STRICT_PLAN_APPLIED`), and filters source-dependent findings on plans without a sibling spec into `unknown`. Findings still never affect `RESULT` or blocking counts.
> 
> **Plumbing:** new `strict-plan-checks.md` and integration docs; Codex strict prompt branches on plan vs spec bundle; `pr-review-loop.sh` forwards keys, `strict_plan` evidence/history, and summary text; shared `workflow_is_plan_document_path` in `workflow-lib.sh`. **CI** markdown lint now covers `docs/workflow/**`. Large harness/smoke fixtures and recorded proofs document P1–P13 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d857f720908bc7c6238922fbfd0fbcb58cef390c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->