### PR TITLE
feat(1657): reviewer effectiveness report

### DIFF
--- a/changelog.d/1657.added.reviewer-effectiveness-report.md
+++ b/changelog.d/1657.added.reviewer-effectiveness-report.md
@@ -1,0 +1,3 @@
+### Added
+
+- `reviewer-effectiveness-report.sh` — read-only report summarizing reviewer-loop effectiveness per pull request and across a recent window, using persisted reviewer-loop history comments.

--- a/changelog.d/1657.added.reviewer-effectiveness-report.md
+++ b/changelog.d/1657.added.reviewer-effectiveness-report.md
@@ -1,3 +1,1 @@
-### Added
-
-- `reviewer-effectiveness-report.sh` — read-only report summarizing reviewer-loop effectiveness per pull request and across a recent window, using persisted reviewer-loop history comments.
+- Add `reviewer-effectiveness-report.sh`, a read-only report summarizing reviewer-loop effectiveness per pull request and across a recent window from persisted history comments.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -224,10 +224,11 @@ requests (default **20**; pass `--window` to change it — no config or env over
 
 Usage:
 
+<!-- workflow-shell-contract: bash -->
 ```bash
-./scripts/development-workflow/reviewer-effectiveness-report.sh --pr 1234
-./scripts/development-workflow/reviewer-effectiveness-report.sh --window 20 --repo owner/repo
-./scripts/development-workflow/reviewer-effectiveness-report.sh --pr 1234 --json
+bash ./scripts/development-workflow/reviewer-effectiveness-report.sh --pr 1234
+bash ./scripts/development-workflow/reviewer-effectiveness-report.sh --window 20 --repo owner/repo
+bash ./scripts/development-workflow/reviewer-effectiveness-report.sh --pr 1234 --json
 ```
 
 The seven measures, three exclusion reasons (`no_history`, `unparseable_history`,

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -216,6 +216,30 @@ Use this when:
 - A downstream private repository may inherit template workflows that are
   zero-billable in the public template but expensive after sync
 
+### `reviewer-effectiveness-report.sh`
+
+Read-only report of reviewer-loop effectiveness from persisted history comments.
+Supports a single pull request (`--pr`) or a window of the most recent *n* pull
+requests (default **20**; pass `--window` to change it — no config or env override).
+
+Usage:
+
+```bash
+./scripts/development-workflow/reviewer-effectiveness-report.sh --pr 1234
+./scripts/development-workflow/reviewer-effectiveness-report.sh --window 20 --repo owner/repo
+./scripts/development-workflow/reviewer-effectiveness-report.sh --pr 1234 --json
+```
+
+The seven measures, three exclusion reasons (`no_history`, `unparseable_history`,
+`history_unavailable`), and per-measure `not_recorded` states are documented in
+the `--help` output and in issue #1657's spec.
+
+Use this when:
+
+- You need evidence on whether the local reviewer is reducing external review
+  cycles, not just whether it ran
+- You are deciding whether a strict check earns the right to block
+
 ### `add-backlog-item.sh`
 
 Resolves the configured issue tracker destination for backlog creation and can create a GitHub issue when `issue_tracker.provider` maps to GitHub Issues / GitHub Projects.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7817,37 +7817,6 @@ codex_github_defaults_should_apply() {
   array_contains_value "codex-github" "${platforms[@]:-}"
 }
 
-REVIEWER_LOOP_HISTORY_SCHEMA="reviewer_loop_history.v1"
-REVIEWER_LOOP_HISTORY_MARKER="<!-- reviewer-loop-history:v1 -->"
-
-reviewer_loop_history_extract_latest_json() {
-  awk -v marker="$REVIEWER_LOOP_HISTORY_MARKER" '
-    index($0, marker) > 0 {
-      seen_marker = 1
-      in_json = 0
-      block = ""
-      next
-    }
-    seen_marker && $0 ~ /^```json[[:space:]]*$/ {
-      in_json = 1
-      block = ""
-      next
-    }
-    in_json && $0 ~ /^```[[:space:]]*$/ {
-      latest = block
-      in_json = 0
-      seen_marker = 0
-      next
-    }
-    in_json {
-      block = block $0 "\n"
-    }
-    END {
-      printf "%s", latest
-    }
-  '
-}
-
 reviewer_loop_history_platforms_json() {
   local platform_list="${1:-}"
 
@@ -10226,27 +10195,6 @@ reviewer_loop_history_select_summary_record() {
 # logic while masking the fact that the newest ledger state is actually
 # unreadable — defeating the fail-closed guarantee in reviewer_loop_
 # cycle_count_unavailable_should_escalate (found in review of PR #1507).
-# Counting must always see the newest ledger's true status, even when that
-# status is "unavailable".
-reviewer_loop_history_select_latest_summary_record() {
-  jq -rs '
-    (add // []) as $all
-    | [
-        $all[]
-        | select(
-            (.body // "" | contains("### Automated Reviewer Loop Summary")) and
-            (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
-          )
-      ]
-    | sort_by(.created_at)
-    | last
-    | {
-        id: (.id // ""),
-        body: (.body // "")
-      }
-  '
-}
-
 reviewer_loop_history_extract_preserved_section() {
   local existing_body="$1"
   local prior=""

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -66,6 +66,10 @@ rer_classify_payload() {
     printf 'unparseable_history\n'
     return 0
   fi
+  if ! printf '%s\n' "$json" | jq -e . >/dev/null 2>&1; then
+    printf 'unparseable_history\n'
+    return 0
+  fi
   if ! printf '%s\n' "$json" | jq -e --arg s "$REVIEWER_LOOP_HISTORY_SCHEMA" '
         .schema == $s and (.entries | type) == "array"
         and ((.history_status // "available") == "available")' >/dev/null 2>&1; then

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -112,7 +112,7 @@ rer_compute_measures_json() {
 
   if rer_measure_available "$payload" "missed_findings"; then
     m2="$(printf '%s\n' "$payload" | jq -c '
-      {availability:"computed", value:([.entries[]? | select((.missed_findings | length) > 0)] | length)}
+      {availability:"computed", value:([.entries[]?.missed_findings[]?] | length)}
     ')"
     m4="$(printf '%s\n' "$payload" | jq -c '
       {availability:"computed", value:([.entries[]?.missed_findings[]?

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -35,6 +35,18 @@ Options:
 
 The default window size is ${RER_DEFAULT_WINDOW}. No configuration file or
 environment variable changes it; pass --window to use a different size.
+
+Measures (per included pull request):
+  1. Rounds
+  2. External blocking rounds
+  3. Blocking findings
+  4. Confirmed miss records
+  5. Possible miss records
+  6. codex-github invocations
+  7. Final current-head evidence (state)
+
+Exclusion reasons: no_history, unparseable_history, history_unavailable.
+Per-measure absence is reported as not_recorded, never as zero.
 USAGE
 }
 

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -223,11 +223,11 @@ rer_aggregate_measure() {
   printf '%s\n' "$rows_json" | jq -c --arg f "$field" '
     [.[] | select(.state == "included") | .measures[$f]
       | select(.availability == "computed")] as $vals
-    | {
+    | if ($vals | length) == 0 then empty else {
         measure: $f,
         included: ($vals | length),
         total: ([$vals[] | .value | if type == "number" then . else 0 end] | add // 0)
-      }
+      } end
   '
 }
 
@@ -237,11 +237,11 @@ rer_aggregate_state_measure() {
   printf '%s\n' "$rows_json" | jq -c --arg f "$field" '
     [.[] | select(.state == "included") | .measures[$f]
       | select(.availability == "computed")] as $vals
-    | {
+    | if ($vals | length) == 0 then empty else {
         measure: $f,
         included: ($vals | length),
         values: [$vals[] | .value]
-      }
+      } end
   '
 }
 
@@ -418,9 +418,11 @@ rer_build_report() {
 
   if [ "$included" -gt 0 ]; then
     for measure in rounds external_blocking_rounds blocking_findings confirmed_miss_records possible_miss_records codex_github_invocations; do
-      aggregates+=("$(rer_aggregate_measure "$rows_json" "$measure")")
+      agg="$(rer_aggregate_measure "$rows_json" "$measure")"
+      [ -n "$agg" ] && aggregates+=("$agg")
     done
-    aggregates+=("$(rer_aggregate_state_measure "$rows_json" "final_current_head_evidence")")
+    agg="$(rer_aggregate_state_measure "$rows_json" "final_current_head_evidence")"
+    [ -n "$agg" ] && aggregates+=("$agg")
   fi
 
   strict_checks="$(rer_strict_checks_json "$rows_json")"

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -444,7 +444,7 @@ rer_build_report() {
     '{
       repo: $repo,
       accounting: {requested:$requested, included:$included, excluded:$excluded},
-      rows: $rows,
+      rows: [$rows[] | del(._payload)],
       exclusions: [$rows[] | select(.state != "included") | {pr, reason: .exclusion_reason}],
       aggregates: $aggregates
     }

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+_HARNESS_MODE_EFFECTIVE=0
+if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  _HARNESS_MODE_EFFECTIVE=1
+fi
+
+RER_DEFAULT_WINDOW=20
+
+rer_fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+rer_usage() {
+  cat <<USAGE
+Usage:
+  reviewer-effectiveness-report.sh --pr <number> [--repo <owner/repo>] [--json]
+  reviewer-effectiveness-report.sh [--window <n>] [--repo <owner/repo>] [--json]
+
+Read-only report of reviewer-loop effectiveness from persisted history comments.
+
+Options:
+  --pr <number>       Report for one pull request.
+  --window <n>        Report over the most recent n pull requests (default: ${RER_DEFAULT_WINDOW}).
+  --repo <owner/repo> Repository (defaults to gh's current repository).
+  --json              Machine-readable JSON output.
+  -h, --help          Show this help.
+
+The default window size is ${RER_DEFAULT_WINDOW}. No configuration file or
+environment variable changes it; pass --window to use a different size.
+USAGE
+}
+
+rer_measure_available() {
+  local payload="$1"
+  local field="$2"
+  printf '%s\n' "$payload" | jq -e --arg f "$field" '
+    [ .entries[]? | select(has($f)) ] | length > 0
+  ' >/dev/null 2>&1
+}
+
+rer_measure7_available() {
+  local payload="$1"
+  printf '%s\n' "$payload" | jq -e '
+    (.entries | last) as $e | ($e != null) and ($e | has("reviewed_heads"))
+  ' >/dev/null 2>&1
+}
+
+rer_classify_payload() {
+  local body="$1"
+  local json=""
+
+  if ! printf '%s\n' "$body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+    printf 'no_history\n'
+    return 0
+  fi
+  if ! json="$(printf '%s\n' "$body" | reviewer_loop_history_extract_latest_json)" \
+      || [ -z "$json" ]; then
+    printf 'unparseable_history\n'
+    return 0
+  fi
+  if ! printf '%s\n' "$json" | jq -e --arg s "$REVIEWER_LOOP_HISTORY_SCHEMA" '
+        .schema == $s and (.entries | type) == "array"
+        and ((.history_status // "available") == "available")' >/dev/null 2>&1; then
+    printf 'history_unavailable\n'
+    return 0
+  fi
+  printf 'included\n'
+}
+
+rer_fetch_summary_body() {
+  local repo_slug="$1"
+  local pr_number="$2"
+  local comments_json record body
+
+  if ! comments_json="$(gh api "repos/${repo_slug}/issues/${pr_number}/comments" --paginate 2>/dev/null)"; then
+    return 1
+  fi
+  record="$(printf '%s\n' "$comments_json" | reviewer_loop_history_select_latest_summary_record 2>/dev/null)" || record=""
+  body="$(printf '%s\n' "$record" | jq -r '.body // ""' 2>/dev/null)" || body=""
+  printf '%s' "$body"
+}
+
+rer_compute_measures_json() {
+  local payload="$1"
+  local m1 m2 m3 m4 m5 m6 m7
+  local avail2 avail3 avail6 avail7
+
+  m1="$(printf '%s\n' "$payload" | jq -c '{availability:"computed", value:(.entries | length)}')"
+
+  if rer_measure_available "$payload" "missed_findings"; then
+    avail2=computed
+    m2="$(printf '%s\n' "$payload" | jq -c '
+      {availability:"computed", value:([.entries[]? | select((.missed_findings | length) > 0)] | length)}
+    ')"
+    m4="$(printf '%s\n' "$payload" | jq -c '
+      {availability:"computed", value:([.entries[]?.missed_findings[]?
+        | select(.local_evidence_state == "clean_same_commit")] | length)}
+    ')"
+    m5="$(printf '%s\n' "$payload" | jq -c '
+      {availability:"computed", value:([.entries[]?.missed_findings[]?
+        | select(.local_evidence_state == "clean_earlier_commit")] | length)}
+    ')"
+  else
+    avail2=not_recorded
+    m2='{"availability":"not_recorded"}'
+    m4='{"availability":"not_recorded"}'
+    m5='{"availability":"not_recorded"}'
+  fi
+
+  if rer_measure_available "$payload" "blocking_count"; then
+    m3="$(printf '%s\n' "$payload" | jq -c '
+      {availability:"computed", value:([.entries[]? | select(has("blocking_count")) | .blocking_count] | add // 0)}
+    ')"
+  else
+    m3='{"availability":"not_recorded"}'
+  fi
+
+  if rer_measure_available "$payload" "platforms"; then
+    m6="$(printf '%s\n' "$payload" | jq -c '
+      {availability:"computed", value:([.entries[]? | select(has("platforms")) | select(.platforms | index("codex-github"))] | length)}
+    ')"
+  else
+    m6='{"availability":"not_recorded"}'
+  fi
+
+  if rer_measure7_available "$payload"; then
+    m7="$(printf '%s\n' "$payload" | jq -c '
+      (.entries | last) as $e
+      | ($e.reviewed_heads // []) as $heads
+      | if ($heads | length) == 0 then
+          {availability:"computed", value:"not-reported"}
+        elif ([$heads[] | .state] | all(. == "current")) then
+          {availability:"computed", value:"current"}
+        elif ([$heads[] | .state] | any(. == "not-current")) then
+          {availability:"computed", value:"not-current"}
+        elif ([$heads[] | .state] | all(. == "not-reported")) then
+          {availability:"computed", value:"not-reported"}
+        else
+          {availability:"computed", value:"not-current"}
+        end
+    ')"
+  else
+    m7='{"availability":"not_recorded"}'
+  fi
+
+  jq -nc \
+    --argjson rounds "$m1" \
+    --argjson external_blocking_rounds "$m2" \
+    --argjson blocking_findings "$m3" \
+    --argjson confirmed_miss_records "$m4" \
+    --argjson possible_miss_records "$m5" \
+    --argjson codex_github_invocations "$m6" \
+    --argjson final_current_head_evidence "$m7" \
+    '{
+      rounds: $rounds,
+      external_blocking_rounds: $external_blocking_rounds,
+      blocking_findings: $blocking_findings,
+      confirmed_miss_records: $confirmed_miss_records,
+      possible_miss_records: $possible_miss_records,
+      codex_github_invocations: $codex_github_invocations,
+      final_current_head_evidence: $final_current_head_evidence
+    }'
+}
+
+rer_process_pr() {
+  local repo_slug="$1"
+  local pr_number="$2"
+  local body state json measures
+
+  if ! body="$(rer_fetch_summary_body "$repo_slug" "$pr_number")"; then
+    return 1
+  fi
+
+  state="$(rer_classify_payload "$body")"
+  case "$state" in
+    included)
+      json="$(printf '%s\n' "$body" | reviewer_loop_history_extract_latest_json)"
+      measures="$(rer_compute_measures_json "$json")"
+      jq -nc --argjson pr "$pr_number" --arg state "$state" --argjson measures "$measures" \
+        '{pr:$pr, state:$state, measures:$measures}'
+      ;;
+    *)
+      jq -nc --argjson pr "$pr_number" --arg state "$state" --arg reason "$state" \
+        '{pr:$pr, state:$state, exclusion_reason:$reason}'
+      ;;
+  esac
+}
+
+rer_validate_window() {
+  local window="$1"
+  case "$window" in
+    ''|*[!0-9]*)
+      printf 'invalid\n'
+      ;;
+    0)
+      printf 'zero\n'
+      ;;
+    *)
+      printf 'ok\n'
+      ;;
+  esac
+}
+
+rer_list_recent_prs() {
+  local repo_slug="$1"
+  local limit="$2"
+  gh pr list --repo "$repo_slug" --state all --limit "$limit" \
+    --json number | jq -r 'sort_by(.number) | reverse | .[].number' 2>/dev/null
+}
+
+rer_aggregate_measure() {
+  local rows_json="$1"
+  local field="$2"
+  printf '%s\n' "$rows_json" | jq -c --arg f "$field" '
+    [.[] | select(.state == "included") | .measures[$f]
+      | select(.availability == "computed")] as $vals
+    | {
+        measure: $f,
+        included: ($vals | length),
+        total: ([$vals[] | .value | if type == "number" then . else 0 end] | add // 0)
+      }
+  '
+}
+
+rer_aggregate_state_measure() {
+  local rows_json="$1"
+  local field="$2"
+  printf '%s\n' "$rows_json" | jq -c --arg f "$field" '
+    [.[] | select(.state == "included") | .measures[$f]
+      | select(.availability == "computed")] as $vals
+    | {
+        measure: $f,
+        included: ($vals | length),
+        values: [$vals[] | .value]
+      }
+  '
+}
+
+rer_strict_checks_json() {
+  local rows_json="$1"
+  printf '%s\n' "$rows_json" | jq -c '
+    def pr_entries:
+      [.[] | select(.state == "included") | . as $row
+        | ($row._payload.entries // [])[] | . + {_pr: $row.pr}];
+
+    def spec_applied_prs:
+      [.[] | select(.state == "included") | select(
+        any(._payload.entries[]?; (.strict_spec.state // "") == "applied")
+      ) | .pr] | unique;
+
+    def plan_applied_prs($check):
+      [.[] | select(.state == "included") | select(
+        any(._payload.entries[]?;
+          (.strict_plan.state // "") == "applied"
+          and ((.strict_plan.applied // []) | index($check)))
+      ) | .pr] | unique;
+
+    def spec_fired_prs($check):
+      [.[] | select(.state == "included") | select(
+        any(._payload.entries[]?;
+          (.strict_spec.state // "") == "applied"
+          and ((.strict_spec.checks // []) | index($check)))
+      ) | .pr] | unique;
+
+    def plan_fired_prs($check):
+      [.[] | select(.state == "included") | select(
+        any(._payload.entries[]?;
+          (.strict_plan.state // "") == "applied"
+          and ((.strict_plan.checks // []) | index($check)))
+      ) | .pr] | unique;
+
+    [pr_entries[] | .strict_spec.checks[]? // empty] as $spec_checks
+    | [pr_entries[] | .strict_plan.checks[]? // empty] as $plan_checks
+    | ($spec_checks + $plan_checks | unique) as $all_checks
+    | if ($all_checks | length) == 0 then
+        null
+      else
+        {
+          checks: (
+            [($spec_checks | unique[]) as $c
+              | {
+                  check: $c,
+                  kind: "spec",
+                  fired: (spec_fired_prs($c) | length),
+                  applied: (spec_applied_prs | length)
+                }]
+            + [($plan_checks | unique[]) as $c
+              | select(($spec_checks | index($c)) | not)
+              | {
+                  check: $c,
+                  kind: "plan",
+                  fired: (plan_fired_prs($c) | length),
+                  applied: (plan_applied_prs($c) | length)
+                }]
+          )
+        }
+      end
+  '
+}
+
+rer_render_text() {
+  local report_json="$1"
+  local window_used requested included excluded
+
+  window_used="$(printf '%s\n' "$report_json" | jq -r '.window_used // empty')"
+  requested="$(printf '%s\n' "$report_json" | jq -r '.accounting.requested')"
+  included="$(printf '%s\n' "$report_json" | jq -r '.accounting.included')"
+  excluded="$(printf '%s\n' "$report_json" | jq -r '.accounting.excluded')"
+
+  printf 'Reviewer effectiveness report\n'
+  if [ -n "$window_used" ]; then
+    printf 'Window: %s pull requests (requested: %s)\n\n' "$window_used" "$requested"
+  fi
+
+  printf '%s\n' "$report_json" | jq -r '
+    .rows[] | select(.state == "included") |
+    "PR #\(.pr)",
+    "  Rounds: \(.measures.rounds.value)",
+    (if .measures.external_blocking_rounds.availability == "computed"
+      then "  External blocking rounds: \(.measures.external_blocking_rounds.value)"
+      else "  External blocking rounds: Not recorded" end),
+    (if .measures.blocking_findings.availability == "computed"
+      then "  Blocking findings: \(.measures.blocking_findings.value)"
+      else "  Blocking findings: Not recorded" end),
+    (if .measures.confirmed_miss_records.availability == "computed"
+      then "  Confirmed miss records: \(.measures.confirmed_miss_records.value)"
+      else "  Confirmed miss records: Not recorded" end),
+    (if .measures.possible_miss_records.availability == "computed"
+      then "  Possible miss records: \(.measures.possible_miss_records.value)"
+      else "  Possible miss records: Not recorded" end),
+    (if .measures.codex_github_invocations.availability == "computed"
+      then "  codex-github invocations: \(.measures.codex_github_invocations.value)"
+      else "  codex-github invocations: Not recorded" end),
+    (if .measures.final_current_head_evidence.availability == "computed"
+      then "  Final current-head evidence: \(.measures.final_current_head_evidence.value)"
+      else "  Final current-head evidence: Not recorded" end),
+    ""
+  '
+
+  if [ "$included" -gt 0 ] 2>/dev/null; then
+    printf 'Aggregates\n'
+    for measure in rounds external_blocking_rounds blocking_findings confirmed_miss_records possible_miss_records codex_github_invocations; do
+      agg="$(printf '%s\n' "$report_json" | jq -r --arg m "$measure" '
+        .aggregates[]? | select(.measure == $m) |
+        if .included > 0 then
+          "\(.measure): \(.total) (included: \(.included))"
+        else empty end
+      ')"
+      [ -n "$agg" ] && printf '  %s\n' "$agg"
+    done
+    fche_agg="$(printf '%s\n' "$report_json" | jq -r '
+      .aggregates[]? | select(.measure == "final_current_head_evidence") |
+      if .included > 0 then
+        "final_current_head_evidence: \(.values | join(", ")) (included: \(.included))"
+      else empty end
+    ')"
+    [ -n "$fche_agg" ] && printf '  %s\n' "$fche_agg"
+    printf '\n'
+  fi
+
+  strict="$(printf '%s\n' "$report_json" | jq -r '
+    .strict_checks.checks[]? | "  \(.check) (\(.kind)): \(.fired) / \(.applied)"
+  ')"
+  if [ -n "$strict" ]; then
+    printf 'Strict-check incidence\n%s\n\n' "$strict"
+  fi
+
+  printf 'Exclusion accounting\n'
+  printf '  Requested: %s\n  Included: %s\n  Excluded: %s\n' "$requested" "$included" "$excluded"
+  printf '%s\n' "$report_json" | jq -r '
+    .exclusions[]? | "  PR #\(.pr): \(.reason)"
+  '
+}
+
+rer_build_report() {
+  local repo_slug="$1"
+  shift
+  local -a pr_numbers=("$@")
+  local -a rows=()
+  local pr body state json row measures
+  local rows_json accounting included excluded requested
+  local -a aggregates=()
+  local strict_checks report agg_json
+
+  requested="${#pr_numbers[@]}"
+  for pr in "${pr_numbers[@]}"; do
+    if ! body="$(rer_fetch_summary_body "$repo_slug" "$pr")"; then
+      rer_fail "failed to fetch reviewer-loop history for PR #${pr}"
+    fi
+    state="$(rer_classify_payload "$body")"
+    case "$state" in
+      included)
+        json="$(printf '%s\n' "$body" | reviewer_loop_history_extract_latest_json)"
+        measures="$(rer_compute_measures_json "$json")"
+        row="$(jq -nc --argjson pr "$pr" --arg state "$state" --argjson measures "$measures" --argjson payload "$json" \
+          '{pr:$pr, state:$state, measures:$measures, _payload:$payload}')"
+        ;;
+      *)
+        row="$(jq -nc --argjson pr "$pr" --arg state "$state" --arg reason "$state" \
+          '{pr:$pr, state:$state, exclusion_reason:$reason}')"
+        ;;
+    esac
+    rows+=("$row")
+  done
+
+  rows_json="$(printf '%s\n' "${rows[@]}" | jq -s '.')"
+  included="$(printf '%s\n' "$rows_json" | jq '[.[] | select(.state == "included")] | length')"
+  excluded="$(printf '%s\n' "$rows_json" | jq '[.[] | select(.state != "included")] | length')"
+
+  if [ "$included" -gt 0 ]; then
+    for measure in rounds external_blocking_rounds blocking_findings confirmed_miss_records possible_miss_records codex_github_invocations; do
+      aggregates+=("$(rer_aggregate_measure "$rows_json" "$measure")")
+    done
+    aggregates+=("$(rer_aggregate_state_measure "$rows_json" "final_current_head_evidence")")
+  fi
+
+  strict_checks="$(rer_strict_checks_json "$rows_json")"
+
+  if [ "${#aggregates[@]}" -gt 0 ]; then
+    agg_json="$(printf '%s\n' "${aggregates[@]}" | jq -s '.')"
+  else
+    agg_json='[]'
+  fi
+
+  report="$(jq -nc \
+    --arg repo "$repo_slug" \
+    --argjson rows "$rows_json" \
+    --argjson requested "$requested" \
+    --argjson included "$included" \
+    --argjson excluded "$excluded" \
+    --argjson aggregates "$agg_json" \
+    --argjson strict_checks "${strict_checks:-null}" \
+    '{
+      repo: $repo,
+      accounting: {requested:$requested, included:$included, excluded:$excluded},
+      rows: $rows,
+      exclusions: [$rows[] | select(.state != "included") | {pr, reason: .exclusion_reason}],
+      aggregates: $aggregates
+    }
+    | if $strict_checks != null then . + {strict_checks: $strict_checks} else . end
+    ')"
+  printf '%s\n' "$report"
+}
+
+rer_main() {
+  local pr_number="" window="" repo_slug="" json_output=0
+  local window_arg_present=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ "$#" -ge 2 ] || rer_fail "--pr requires a value"
+        pr_number="$2"
+        shift 2
+        ;;
+      --window)
+        [ "$#" -ge 2 ] || rer_fail "--window requires a value"
+        window="$2"
+        window_arg_present=1
+        shift 2
+        ;;
+      --repo)
+        [ "$#" -ge 2 ] || rer_fail "--repo requires a value"
+        repo_slug="$2"
+        shift 2
+        ;;
+      --json) json_output=1; shift ;;
+      -h|--help) rer_usage; exit 0 ;;
+      *) rer_fail "unknown argument: $1" ;;
+    esac
+  done
+
+  command -v gh >/dev/null 2>&1 || rer_fail "gh CLI is required"
+  command -v jq >/dev/null 2>&1 || rer_fail "jq is required"
+
+  if [ -z "$repo_slug" ]; then
+    repo_slug="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" || repo_slug=""
+    [ -n "$repo_slug" ] || rer_fail "could not resolve repository; pass --repo owner/repo"
+  fi
+
+  if [ -n "$pr_number" ] && { [ "$window_arg_present" -eq 1 ] || [ -n "$window" ]; }; then
+    rer_fail "use either --pr or --window, not both"
+  fi
+
+  local -a prs=()
+  local report window_used="" final_report
+
+  if [ -n "$pr_number" ]; then
+    case "$pr_number" in
+      ''|*[!0-9]*) rer_fail "--pr must be a positive integer" ;;
+    esac
+    prs=("$pr_number")
+    report="$(rer_build_report "$repo_slug" "${prs[@]}")"
+    final_report="$report"
+  else
+    if [ "$window_arg_present" -eq 0 ]; then
+      window="$RER_DEFAULT_WINDOW"
+    fi
+    case "$(rer_validate_window "$window")" in
+      invalid) rer_fail "window size must be a positive whole number; got: ${window}" ;;
+      zero) rer_fail "window size must be a positive whole number; got: ${window}" ;;
+    esac
+    window_used="$window"
+    while IFS= read -r n; do
+      [ -n "$n" ] && prs+=("$n")
+    done < <(rer_list_recent_prs "$repo_slug" "$window")
+    if [ "${#prs[@]}" -eq 0 ]; then
+      rer_fail "no pull requests found in ${repo_slug}"
+    fi
+    report="$(rer_build_report "$repo_slug" "${prs[@]}")"
+    final_report="$(printf '%s\n' "$report" | jq -c --argjson w "$window_used" '. + {window_used: $w}')"
+  fi
+
+  if [ "$json_output" -eq 1 ]; then
+    printf '%s\n' "$final_report"
+  else
+    rer_render_text "$final_report"
+  fi
+}
+
+if [ "$_HARNESS_MODE_EFFECTIVE" -eq 0 ]; then
+  rer_main "$@"
+fi

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -282,8 +282,9 @@ rer_strict_checks_json() {
       ) | .pr] | unique;
 
     [pr_entries[] | .strict_spec.checks[]? // empty] as $spec_checks
-    | [pr_entries[] | .strict_plan.checks[]? // empty] as $plan_checks
-    | ($spec_checks + $plan_checks | unique) as $all_checks
+    | [pr_entries[] | .strict_plan.applied[]? // empty] as $plan_applied_checks
+    | [pr_entries[] | .strict_plan.checks[]? // empty] as $plan_fired_checks
+    | ($spec_checks + $plan_applied_checks + $plan_fired_checks | unique) as $all_checks
     | if ($all_checks | length) == 0 then
         null
       else
@@ -296,8 +297,7 @@ rer_strict_checks_json() {
                   fired: (spec_fired_prs($c) | length),
                   applied: (spec_applied_prs | length)
                 }]
-            + [($plan_checks | unique[]) as $c
-              | select(($spec_checks | index($c)) | not)
+            + [($plan_applied_checks | unique[]) as $c
               | {
                   check: $c,
                   kind: "plan",

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -95,12 +95,10 @@ rer_fetch_summary_body() {
 rer_compute_measures_json() {
   local payload="$1"
   local m1 m2 m3 m4 m5 m6 m7
-  local avail2 avail3 avail6 avail7
 
   m1="$(printf '%s\n' "$payload" | jq -c '{availability:"computed", value:(.entries | length)}')"
 
   if rer_measure_available "$payload" "missed_findings"; then
-    avail2=computed
     m2="$(printf '%s\n' "$payload" | jq -c '
       {availability:"computed", value:([.entries[]? | select((.missed_findings | length) > 0)] | length)}
     ')"
@@ -113,7 +111,6 @@ rer_compute_measures_json() {
         | select(.local_evidence_state == "clean_earlier_commit")] | length)}
     ')"
   else
-    avail2=not_recorded
     m2='{"availability":"not_recorded"}'
     m4='{"availability":"not_recorded"}'
     m5='{"availability":"not_recorded"}'
@@ -390,7 +387,7 @@ rer_build_report() {
   local -a pr_numbers=("$@")
   local -a rows=()
   local pr body state json row measures
-  local rows_json accounting included excluded requested
+  local rows_json requested included excluded
   local -a aggregates=()
   local strict_checks report agg_json
 

--- a/scripts/development-workflow/reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/reviewer-effectiveness-report.sh
@@ -225,8 +225,15 @@ rer_validate_window() {
 rer_list_recent_prs() {
   local repo_slug="$1"
   local limit="$2"
-  gh pr list --repo "$repo_slug" --state all --limit "$limit" \
-    --json number | jq -r 'sort_by(.number) | reverse | .[].number' 2>/dev/null
+  local pr_json=""
+
+  if ! pr_json="$(gh pr list --repo "$repo_slug" --state all --limit "$limit" --json number 2>/dev/null)"; then
+    return 1
+  fi
+  if ! printf '%s\n' "$pr_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    return 1
+  fi
+  printf '%s\n' "$pr_json" | jq -r 'sort_by(.number) | reverse | .[].number'
 }
 
 rer_aggregate_measure() {
@@ -526,7 +533,7 @@ rer_main() {
     window_used="$window"
     while IFS= read -r n; do
       [ -n "$n" ] && prs+=("$n")
-    done < <(rer_list_recent_prs "$repo_slug" "$window")
+    done < <(rer_list_recent_prs "$repo_slug" "$window") || rer_fail "failed to list recent pull requests for ${repo_slug}"
     if [ "${#prs[@]}" -eq 0 ]; then
       rer_fail "no pull requests found in ${repo_slug}"
     fi

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/full-telemetry.body
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/full-telemetry.body
@@ -1,0 +1,89 @@
+### Automated Reviewer Loop Summary
+
+Some summary text.
+
+<!-- reviewer-loop-history:v1 -->
+```json
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 200,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "available",
+  "entries": [
+    {
+      "iteration": 1,
+      "platforms": ["local-ai-reviewer", "codex-github"],
+      "blocking_count": 1,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_same_commit",
+          "classification": "confirmed_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "local-ai-reviewer", "reviewed_head": "abc", "state": "current", "reason": ""}
+      ],
+      "strict_spec": {"state": "applied", "count": 1, "checks": ["spec-ac-1"]},
+      "strict_plan": {"state": "applied", "count": 1, "checks": ["plan-ac-1"], "applied": ["plan-ac-1"]}
+    },
+    {
+      "iteration": 2,
+      "platforms": ["coderabbit"],
+      "blocking_count": 2,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_earlier_commit",
+          "classification": "possible_miss"
+        },
+        {
+          "reviewer": "codex-github",
+          "local_evidence_state": "not_clean",
+          "classification": "not_a_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "coderabbit", "reviewed_head": "def", "state": "not-current", "reason": "head_mismatch"}
+      ],
+      "strict_spec": {"state": "applied", "count": 1, "checks": ["spec-ac-1"]},
+      "strict_plan": {"state": "applied", "count": 0, "checks": [], "applied": ["plan-ac-1"]}
+    },
+    {
+      "iteration": 3,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_same_commit",
+          "classification": "confirmed_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "local-ai-reviewer", "reviewed_head": "fff", "state": "current", "reason": ""}
+      ]
+    },
+    {
+      "iteration": 4,
+      "platforms": ["codex-github"],
+      "blocking_count": 3,
+      "missed_findings": [
+        {
+          "reviewer": "codex-github",
+          "local_evidence_state": "clean_same_commit",
+          "blocking_count": 3,
+          "classification": "confirmed_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "codex-github", "reviewed_head": "fff", "state": "current", "reason": ""}
+      ],
+      "strict_spec": {"state": "applied", "count": 1, "checks": ["spec-ac-1"]},
+      "strict_plan": {"state": "applied", "count": 1, "checks": ["plan-ac-1"], "applied": ["plan-ac-1"]}
+    }
+  ]
+}
+```
+
+*Posted automatically by `pr-review-loop.sh`.*

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/full-telemetry.json
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/full-telemetry.json
@@ -1,0 +1,80 @@
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 200,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "available",
+  "entries": [
+    {
+      "iteration": 1,
+      "platforms": ["local-ai-reviewer", "codex-github"],
+      "blocking_count": 1,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_same_commit",
+          "classification": "confirmed_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "local-ai-reviewer", "reviewed_head": "abc", "state": "current", "reason": ""}
+      ],
+      "strict_spec": {"state": "applied", "count": 1, "checks": ["spec-ac-1"]},
+      "strict_plan": {"state": "applied", "count": 1, "checks": ["plan-ac-1"], "applied": ["plan-ac-1"]}
+    },
+    {
+      "iteration": 2,
+      "platforms": ["coderabbit"],
+      "blocking_count": 2,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_earlier_commit",
+          "classification": "possible_miss"
+        },
+        {
+          "reviewer": "codex-github",
+          "local_evidence_state": "not_clean",
+          "classification": "not_a_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "coderabbit", "reviewed_head": "def", "state": "not-current", "reason": "head_mismatch"}
+      ],
+      "strict_spec": {"state": "applied", "count": 1, "checks": ["spec-ac-1"]},
+      "strict_plan": {"state": "applied", "count": 0, "checks": [], "applied": ["plan-ac-1"]}
+    },
+    {
+      "iteration": 3,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_same_commit",
+          "classification": "confirmed_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "local-ai-reviewer", "reviewed_head": "fff", "state": "current", "reason": ""}
+      ]
+    },
+    {
+      "iteration": 4,
+      "platforms": ["codex-github"],
+      "blocking_count": 3,
+      "missed_findings": [
+        {
+          "reviewer": "codex-github",
+          "local_evidence_state": "clean_same_commit",
+          "blocking_count": 3,
+          "classification": "confirmed_miss"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "codex-github", "reviewed_head": "fff", "state": "current", "reason": ""}
+      ],
+      "strict_spec": {"state": "applied", "count": 1, "checks": ["spec-ac-1"]},
+      "strict_plan": {"state": "applied", "count": 1, "checks": ["plan-ac-1"], "applied": ["plan-ac-1"]}
+    }
+  ]
+}

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/malformed-json.body
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/malformed-json.body
@@ -1,0 +1,10 @@
+### Automated Reviewer Loop Summary
+
+Marker present but JSON block is malformed.
+
+<!-- reviewer-loop-history:v1 -->
+```json
+{ this is not valid json
+```
+
+*Posted automatically by `pr-review-loop.sh`.*

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/no-marker.body
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/no-marker.body
@@ -1,0 +1,4 @@
+### Automated Reviewer Loop Summary
+
+No marker here.
+*Posted automatically by `pr-review-loop.sh`.*

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/partial-telemetry.json
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/partial-telemetry.json
@@ -1,0 +1,50 @@
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 300,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "available",
+  "entries": [
+    {
+      "iteration": 1,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 1
+    },
+    {
+      "iteration": 2,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0
+    },
+    {
+      "iteration": 3,
+      "platforms": ["local-ai-reviewer", "codex-github"],
+      "blocking_count": 2,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_same_commit"
+        }
+      ]
+    },
+    {
+      "iteration": 4,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0,
+      "missed_findings": [
+        {
+          "reviewer": "coderabbit",
+          "local_evidence_state": "clean_earlier_commit"
+        }
+      ],
+      "reviewed_heads": [
+        {"platform": "local-ai-reviewer", "reviewed_head": "aaa", "state": "current", "reason": ""}
+      ]
+    },
+    {
+      "iteration": 5,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0,
+      "missed_findings": [],
+      "reviewed_heads": []
+    }
+  ]
+}

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/today-schema.body
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/today-schema.body
@@ -1,0 +1,35 @@
+### Automated Reviewer Loop Summary
+
+Some summary text.
+
+<!-- reviewer-loop-history:v1 -->
+```json
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 100,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "available",
+  "entries": [
+    {
+      "iteration": 1,
+      "platforms": ["local-ai-reviewer", "codex-github"],
+      "blocking_count": 2,
+      "suggestion_count": 0
+    },
+    {
+      "iteration": 2,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0,
+      "suggestion_count": 1
+    },
+    {
+      "iteration": 3,
+      "platforms": ["codex-github"],
+      "blocking_count": 1,
+      "suggestion_count": 0
+    }
+  ]
+}
+```
+
+*Posted automatically by `pr-review-loop.sh`.*

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/today-schema.json
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/today-schema.json
@@ -1,0 +1,26 @@
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 100,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "available",
+  "entries": [
+    {
+      "iteration": 1,
+      "platforms": ["local-ai-reviewer", "codex-github"],
+      "blocking_count": 2,
+      "suggestion_count": 0
+    },
+    {
+      "iteration": 2,
+      "platforms": ["local-ai-reviewer"],
+      "blocking_count": 0,
+      "suggestion_count": 1
+    },
+    {
+      "iteration": 3,
+      "platforms": ["codex-github"],
+      "blocking_count": 1,
+      "suggestion_count": 0
+    }
+  ]
+}

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/unavailable.body
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/unavailable.body
@@ -1,0 +1,17 @@
+### Automated Reviewer Loop Summary
+
+Some summary text.
+
+<!-- reviewer-loop-history:v1 -->
+```json
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 102,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "unavailable",
+  "history_unavailable_reason": "history_render_failed",
+  "entries": []
+}
+```
+
+*Posted automatically by `pr-review-loop.sh`.*

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/unavailable.json
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/unavailable.json
@@ -1,0 +1,8 @@
+{
+  "schema": "reviewer_loop_history.v1",
+  "pr_number": 102,
+  "updated_at": "2026-08-01T00:00:00Z",
+  "history_status": "unavailable",
+  "history_unavailable_reason": "history_render_failed",
+  "entries": []
+}

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/unparseable.body
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/unparseable.body
@@ -1,0 +1,8 @@
+### Automated Reviewer Loop Summary
+
+Summary without parseable history block.
+
+<!-- reviewer-loop-history:v1 -->
+This comment has the marker but no fenced JSON block.
+
+*Posted automatically by `pr-review-loop.sh`.*

--- a/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/wrap-history.sh
+++ b/scripts/development-workflow/tests/fixtures/reviewer-effectiveness/wrap-history.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Helper: wrap a history JSON payload in a summary comment body.
+payload="$1"
+cat <<EOF
+### Automated Reviewer Loop Summary
+
+Some summary text.
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+${payload}
+\`\`\`
+
+*Posted automatically by \`pr-review-loop.sh\`.*
+EOF

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3520,7 +3520,6 @@ unset _post_summary_call_line _print_result_line
 # max_total_cycles enforcement functions must stay callable from the
 # harness after future refactors move code around.
 for _mc_fn in reviewer_loop_resolve_run_id reviewer_loop_history_entries_count \
-    reviewer_loop_history_select_latest_summary_record \
     reviewer_loop_resolve_max_cycles reviewer_loop_resolve_max_total_cycles \
     reviewer_loop_cap_exceeded reviewer_loop_cycle_count_unavailable_should_escalate \
     reviewer_loop_persist_failure_should_escalate \
@@ -3537,6 +3536,18 @@ for _mc_fn in reviewer_loop_resolve_run_id reviewer_loop_history_entries_count \
     run_test "cycles_fn_defined_before_harness_return_${_mc_fn}" "yes" "yes"
   else
     run_test "cycles_fn_defined_before_harness_return_${_mc_fn}" "yes" "no"
+  fi
+done
+# #1657 moved the history selector to workflow-lib.sh; keep a source-order check here.
+for _mc_fn in reviewer_loop_history_select_latest_summary_record \
+    reviewer_loop_history_extract_latest_json; do
+  _mc_fn_line="$(grep -n "^${_mc_fn}()" \
+    "$REPO_ROOT/scripts/development-workflow/workflow-lib.sh" 2>/dev/null \
+    | head -1 | cut -d: -f1)"
+  if [ -n "$_mc_fn_line" ]; then
+    run_test "history_fn_defined_in_workflow_lib_${_mc_fn}" "yes" "yes"
+  else
+    run_test "history_fn_defined_in_workflow_lib_${_mc_fn}" "yes" "no"
   fi
 done
 unset _mc_fn _mc_fn_line _mc_harness_return_line

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -142,6 +142,7 @@ assert_contains "$today_text" 'External blocking rounds: Not recorded' 'not_reco
 today_json_out="$(PATH="$TMP_DIR:$PATH" HARNESS_MODE=0 "$SCRIPT" --pr 201 --repo example/repo --json 2>/dev/null)"
 assert_jq "$today_json_out" '[.aggregates[] | select(.measure == "external_blocking_rounds")] | length' '0' 'omit aggregate for not_recorded measure'
 assert_jq "$today_json_out" '[.aggregates[] | select(.measure == "rounds")] | length' '1' 'include aggregate for computed measure'
+assert_jq "$today_json_out" '.rows[0] | has("_payload")' 'false' 'JSON output omits internal payload'
 
 # --- end-to-end with recording gh stub ---
 cat > "$TMP_DIR/gh" <<'MOCK_GH'

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -45,6 +45,7 @@ assert_not_contains() {
   fi
 }
 
+# shellcheck source=scripts/development-workflow/reviewer-effectiveness-report.sh
 HARNESS_MODE=1 source "$SCRIPT"
 
 wrap_body() {

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -220,10 +220,10 @@ fi
 pass 'read-only gh invocations'
 
 # AC-2d: no alternate default window configuration in script/help
-extra_window_defaults="$(rg -n 'DEFAULT_WINDOW|default window|RER_.*WINDOW' "$SCRIPT" "$ROOT_DIR/scripts/development-workflow/README.md" 2>/dev/null \
-  | rg -v 'RER_DEFAULT_WINDOW=20|default window size is 20|default: \$\{RER_DEFAULT_WINDOW\}|Window: .*pull requests|default \*\*20\*\*|default window and that nothing' || true)"
-if [ -n "$extra_window_defaults" ]; then
-  fail "found alternate default-window sources:${extra_window_defaults}"
+forbidden_window_sources="$(rg -n '\b(WINDOW_SIZE|REPORT_WINDOW|DEFAULT_PR_WINDOW|RER_.*WINDOW)\b' "$SCRIPT" 2>/dev/null \
+  | rg -v 'RER_DEFAULT_WINDOW' || true)"
+if [ -n "$forbidden_window_sources" ]; then
+  fail "found alternate default-window sources:${forbidden_window_sources}"
 fi
 pass 'default window source'
 

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -85,6 +85,22 @@ assert_jq "$strict" '.checks[] | select(.check=="spec-ac-1") | .fired' '1' 'spec
 assert_jq "$strict" '.checks[] | select(.check=="plan-ac-1") | .fired' '1' 'plan check fired once per PR'
 assert_jq "$strict" '.checks[] | select(.check=="plan-ac-1") | .applied' '1' 'plan check applied denominator'
 
+# --- partial telemetry: mixed field availability and measure 7 last entry ---
+partial_json="$(wrap_body "$FIXTURE_DIR/partial-telemetry.json" | reviewer_loop_history_extract_latest_json)"
+partial_measures="$(rer_compute_measures_json "$partial_json")"
+assert_jq "$partial_measures" '.rounds.value' '5' 'partial rounds counts all entries'
+assert_jq "$partial_measures" '.external_blocking_rounds.value' '2' 'partial external rounds from rounds with records'
+assert_jq "$partial_measures" '.confirmed_miss_records.value' '1' 'partial confirmed from later rounds'
+assert_jq "$partial_measures" '.possible_miss_records.value' '1' 'partial possible from later rounds'
+assert_jq "$partial_measures" '.final_current_head_evidence.availability' 'computed' 'measure7 available from last entry field'
+assert_jq "$partial_measures" '.final_current_head_evidence.value' 'not-reported' 'measure7 reads last entry only'
+
+partial_row="$(jq -nc --argjson pr 300 --arg state included --argjson measures "$partial_measures" --argjson payload "$partial_json" \
+  '{pr:$pr, state:$state, measures:$measures, _payload:$payload}')"
+partial_rows_json="$(printf '%s\n' "$partial_row" | jq -s '.')"
+assert_jq "$(rer_aggregate_measure "$partial_rows_json" "external_blocking_rounds")" '.included' '1' 'partial aggregate denominator for telemetry measure'
+assert_jq "$(rer_aggregate_measure "$partial_rows_json" "rounds")" '.included' '1' 'partial aggregate denominator for rounds'
+
 # --- AC-2: --pr and window row equivalence (mock gh for PR 200) ---
 cat > "$TMP_DIR/gh" <<'MOCK_EQUIV'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -139,6 +139,10 @@ today_text="$(PATH="$TMP_DIR:$PATH" HARNESS_MODE=0 "$SCRIPT" --pr 201 --repo exa
 assert_not_contains "$today_text" 'External blocking rounds: 0' 'not_recorded not rendered as zero'
 assert_contains "$today_text" 'External blocking rounds: Not recorded' 'not_recorded rendered as word'
 
+today_json_out="$(PATH="$TMP_DIR:$PATH" HARNESS_MODE=0 "$SCRIPT" --pr 201 --repo example/repo --json 2>/dev/null)"
+assert_jq "$today_json_out" '[.aggregates[] | select(.measure == "external_blocking_rounds")] | length' '0' 'omit aggregate for not_recorded measure'
+assert_jq "$today_json_out" '[.aggregates[] | select(.measure == "rounds")] | length' '1' 'include aggregate for computed measure'
+
 # --- end-to-end with recording gh stub ---
 cat > "$TMP_DIR/gh" <<'MOCK_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -42,6 +42,7 @@ wrap_body() {
 # --- classifier scenarios ---
 assert_eq "$(rer_classify_payload "$(cat "$FIXTURE_DIR/no-marker.body")")" "no_history" "scenario 1 no marker"
 assert_eq "$(rer_classify_payload "$(cat "$FIXTURE_DIR/unparseable.body")")" "unparseable_history" "scenario 2 unparseable"
+assert_eq "$(rer_classify_payload "$(cat "$FIXTURE_DIR/malformed-json.body")")" "unparseable_history" "malformed json is unparseable not unavailable"
 assert_eq "$(rer_classify_payload "$(wrap_body "$FIXTURE_DIR/unavailable.json")")" "history_unavailable" "scenario 3 unavailable"
 assert_eq "$(rer_classify_payload "$(wrap_body "$FIXTURE_DIR/today-schema.json")")" "included" "today schema included"
 

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -71,7 +71,7 @@ assert_jq "$today_measures" '.final_current_head_evidence.availability' 'not_rec
 # --- full telemetry ---
 full_json="$(wrap_body "$FIXTURE_DIR/full-telemetry.json" | reviewer_loop_history_extract_latest_json)"
 full_measures="$(rer_compute_measures_json "$full_json")"
-assert_jq "$full_measures" '.external_blocking_rounds.value' '4' 'external blocking rounds total'
+assert_jq "$full_measures" '.external_blocking_rounds.value' '5' 'external blocking rounds total records'
 assert_jq "$full_measures" '.confirmed_miss_records.value' '3' 'confirmed misses'
 assert_jq "$full_measures" '.possible_miss_records.value' '1' 'possible misses'
 assert_jq "$full_measures" '.final_current_head_evidence.value' 'current' 'final head evidence'
@@ -89,7 +89,7 @@ assert_jq "$strict" '.checks[] | select(.check=="plan-ac-1") | .applied' '1' 'pl
 partial_json="$(wrap_body "$FIXTURE_DIR/partial-telemetry.json" | reviewer_loop_history_extract_latest_json)"
 partial_measures="$(rer_compute_measures_json "$partial_json")"
 assert_jq "$partial_measures" '.rounds.value' '5' 'partial rounds counts all entries'
-assert_jq "$partial_measures" '.external_blocking_rounds.value' '2' 'partial external rounds from rounds with records'
+assert_jq "$partial_measures" '.external_blocking_rounds.value' '2' 'partial external rounds count records'
 assert_jq "$partial_measures" '.confirmed_miss_records.value' '1' 'partial confirmed from later rounds'
 assert_jq "$partial_measures" '.possible_miss_records.value' '1' 'partial possible from later rounds'
 assert_jq "$partial_measures" '.final_current_head_evidence.availability' 'computed' 'measure7 available from last entry field'

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -33,6 +33,18 @@ assert_jq() {
   assert_eq "$got" "$want" "$msg"
 }
 
+assert_contains() {
+  local text="$1" pattern="$2" msg="$3"
+  printf '%s\n' "$text" | grep -Fq "$pattern" || fail "$msg"
+}
+
+assert_not_contains() {
+  local text="$1" pattern="$2" msg="$3"
+  if printf '%s\n' "$text" | grep -Fq "$pattern"; then
+    fail "$msg"
+  fi
+}
+
 HARNESS_MODE=1 source "$SCRIPT"
 
 wrap_body() {
@@ -62,6 +74,69 @@ assert_jq "$full_measures" '.external_blocking_rounds.value' '4' 'external block
 assert_jq "$full_measures" '.confirmed_miss_records.value' '3' 'confirmed misses'
 assert_jq "$full_measures" '.possible_miss_records.value' '1' 'possible misses'
 assert_jq "$full_measures" '.final_current_head_evidence.value' 'current' 'final head evidence'
+
+# --- strict checks incidence ---
+full_row="$(jq -nc --argjson pr 200 --arg state included --argjson measures "$full_measures" --argjson payload "$full_json" \
+  '{pr:$pr, state:$state, measures:$measures, _payload:$payload}')"
+full_rows_json="$(printf '%s\n' "$full_row" | jq -s '.')"
+strict="$(rer_strict_checks_json "$full_rows_json")"
+assert_jq "$strict" '.checks[] | select(.check=="spec-ac-1") | .fired' '1' 'spec check fired once per PR'
+assert_jq "$strict" '.checks[] | select(.check=="plan-ac-1") | .fired' '1' 'plan check fired once per PR'
+assert_jq "$strict" '.checks[] | select(.check=="plan-ac-1") | .applied' '1' 'plan check applied denominator'
+
+# --- AC-2: --pr and window row equivalence (mock gh for PR 200) ---
+cat > "$TMP_DIR/gh" <<'MOCK_EQUIV'
+#!/usr/bin/env bash
+set -euo pipefail
+json_comment() {
+  jq -nc --arg body "$(cat "$1")" --arg created_at "2026-08-01T00:00:00Z" \
+    '[{id: 1, body: $body, created_at: $created_at}]'
+}
+case "$*" in
+  *issues/200/comments*)
+    json_comment <(bash "$GH_FIXTURE_DIR/wrap-history.sh" "$(cat "$GH_FIXTURE_DIR/full-telemetry.json")")
+    ;;
+  *pr\ list*)
+    printf '[{"number":200}]\n'
+    ;;
+  *) echo "unexpected gh equiv: $*" >&2; exit 99 ;;
+esac
+MOCK_EQUIV
+chmod +x "$TMP_DIR/gh"
+export GH_FIXTURE_DIR="$FIXTURE_DIR"
+single_out="$(PATH="$TMP_DIR:$PATH" HARNESS_MODE=0 "$SCRIPT" --pr 200 --repo example/repo --json 2>/dev/null)"
+window_out="$(PATH="$TMP_DIR:$PATH" HARNESS_MODE=0 "$SCRIPT" --window 1 --repo example/repo --json 2>/dev/null)"
+single_measures="$(printf '%s\n' "$single_out" | jq -c '.rows[0].measures')"
+window_measures="$(printf '%s\n' "$window_out" | jq -c '.rows[0].measures')"
+assert_eq "$single_measures" "$window_measures" 'single PR and window measures match'
+
+# --- selector agreement with loop (scenario 22) ---
+body_file="$FIXTURE_DIR/full-telemetry.body"
+[ -f "$body_file" ] || bash "$FIXTURE_DIR/wrap-history.sh" "$(cat "$FIXTURE_DIR/full-telemetry.json")" > "$body_file"
+comments_json="$(jq -nc --arg body "$(cat "$body_file")" --arg created_at "2026-08-01T12:00:00Z" \
+  '[{id:1, body:$body, created_at:$created_at}]')"
+loop_record="$(printf '%s\n' "$comments_json" | reviewer_loop_history_select_latest_summary_record)"
+report_record="$(printf '%s\n' "$comments_json" | reviewer_loop_history_select_latest_summary_record)"
+assert_eq "$(printf '%s\n' "$loop_record" | jq -c .)" "$(printf '%s\n' "$report_record" | jq -c .)" 'selector agrees between callers'
+
+# --- not_recorded never renders as 0 in text ---
+cat > "$TMP_DIR/gh" <<'MOCK_TEXT'
+#!/usr/bin/env bash
+set -euo pipefail
+json_comment() {
+  jq -nc --arg body "$(bash "$GH_FIXTURE_DIR/wrap-history.sh" "$(cat "$GH_FIXTURE_DIR/today-schema.json")")" \
+    --arg created_at "2026-08-01T00:00:00Z" '[{id:1, body:$body, created_at:$created_at}]'
+}
+case "$*" in
+  *issues/201/comments*) json_comment ;;
+  *pr\ list*) printf '[{"number":201}]\n' ;;
+  *) exit 99 ;;
+esac
+MOCK_TEXT
+chmod +x "$TMP_DIR/gh"
+today_text="$(PATH="$TMP_DIR:$PATH" HARNESS_MODE=0 "$SCRIPT" --pr 201 --repo example/repo 2>/dev/null)"
+assert_not_contains "$today_text" 'External blocking rounds: 0' 'not_recorded not rendered as zero'
+assert_contains "$today_text" 'External blocking rounds: Not recorded' 'not_recorded rendered as word'
 
 # --- end-to-end with recording gh stub ---
 cat > "$TMP_DIR/gh" <<'MOCK_GH'

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -219,10 +219,11 @@ if grep -E ' (post|create|edit|delete|patch) ' "$TMP_DIR/gh.log" >/dev/null 2>&1
 fi
 pass 'read-only gh invocations'
 
-# AC-2d: no alternate default window config in script/help
-if rg -n 'RER_DEFAULT_WINDOW|default window' "$SCRIPT" >/dev/null \
-  && rg -n 'WINDOW|DEFAULT.*20' "$SCRIPT" | rg -v 'RER_DEFAULT_WINDOW=20' >/dev/null 2>&1; then
-  : # only RER_DEFAULT_WINDOW constant allowed
+# AC-2d: no alternate default window configuration in script/help
+extra_window_defaults="$(rg -n 'DEFAULT_WINDOW|default window|RER_.*WINDOW' "$SCRIPT" "$ROOT_DIR/scripts/development-workflow/README.md" 2>/dev/null \
+  | rg -v 'RER_DEFAULT_WINDOW=20|default window size is 20|default: \$\{RER_DEFAULT_WINDOW\}|Window: .*pull requests|default \*\*20\*\*|default window and that nothing' || true)"
+if [ -n "$extra_window_defaults" ]; then
+  fail "found alternate default-window sources:${extra_window_defaults}"
 fi
 pass 'default window source'
 

--- a/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
+++ b/scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/development-workflow/reviewer-effectiveness-report.sh"
+FIXTURE_DIR="$ROOT_DIR/scripts/development-workflow/tests/fixtures/reviewer-effectiveness"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  [ "$got" = "$want" ] || fail "$msg (got='$got' want='$want')"
+}
+
+assert_jq() {
+  local json="$1" filter="$2" want="$3" msg="$4"
+  local got
+  got="$(printf '%s\n' "$json" | jq -r "$filter")"
+  assert_eq "$got" "$want" "$msg"
+}
+
+HARNESS_MODE=1 source "$SCRIPT"
+
+wrap_body() {
+  bash "$FIXTURE_DIR/wrap-history.sh" "$(cat "$1")"
+}
+
+# --- classifier scenarios ---
+assert_eq "$(rer_classify_payload "$(cat "$FIXTURE_DIR/no-marker.body")")" "no_history" "scenario 1 no marker"
+assert_eq "$(rer_classify_payload "$(cat "$FIXTURE_DIR/unparseable.body")")" "unparseable_history" "scenario 2 unparseable"
+assert_eq "$(rer_classify_payload "$(wrap_body "$FIXTURE_DIR/unavailable.json")")" "history_unavailable" "scenario 3 unavailable"
+assert_eq "$(rer_classify_payload "$(wrap_body "$FIXTURE_DIR/today-schema.json")")" "included" "today schema included"
+
+# --- measure 6 today schema ---
+today_json="$(wrap_body "$FIXTURE_DIR/today-schema.json" | reviewer_loop_history_extract_latest_json)"
+today_measures="$(rer_compute_measures_json "$today_json")"
+assert_jq "$today_measures" '.rounds.value' '3' 'rounds count'
+assert_jq "$today_measures" '.external_blocking_rounds.availability' 'not_recorded' 'external blocking not recorded'
+assert_jq "$today_measures" '.blocking_findings.value' '3' 'blocking findings sum'
+assert_jq "$today_measures" '.codex_github_invocations.value' '2' 'codex invocations'
+assert_jq "$today_measures" '.final_current_head_evidence.availability' 'not_recorded' 'measure 7 not recorded'
+
+# --- full telemetry ---
+full_json="$(wrap_body "$FIXTURE_DIR/full-telemetry.json" | reviewer_loop_history_extract_latest_json)"
+full_measures="$(rer_compute_measures_json "$full_json")"
+assert_jq "$full_measures" '.external_blocking_rounds.value' '4' 'external blocking rounds total'
+assert_jq "$full_measures" '.confirmed_miss_records.value' '3' 'confirmed misses'
+assert_jq "$full_measures" '.possible_miss_records.value' '1' 'possible misses'
+assert_jq "$full_measures" '.final_current_head_evidence.value' 'current' 'final head evidence'
+
+# --- end-to-end with recording gh stub ---
+cat > "$TMP_DIR/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG="${GH_RECORD_LOG:-/dev/null}"
+printf '%s\n' "$*" >> "$LOG"
+json_comment() {
+  local body_file="$1"
+  jq -nc --arg body "$(cat "$body_file")" --arg created_at "2026-08-01T00:00:00Z" \
+    '[{id: 1, body: $body, created_at: $created_at}]'
+}
+case "$*" in
+  *issues/101/comments*)
+    json_comment "$GH_FIXTURE_DIR/no-marker.body"
+    ;;
+  *issues/102/comments*)
+    json_comment "$GH_FIXTURE_DIR/unparseable.body"
+    ;;
+  *issues/103/comments*)
+    json_comment "$GH_FIXTURE_DIR/unavailable.body"
+    ;;
+  *issues/200/comments*)
+    json_comment <(bash "$GH_FIXTURE_DIR/wrap-history.sh" "$(cat "$GH_FIXTURE_DIR/today-schema.json")")
+    ;;
+  *pr\ list*)
+    printf '[{"number":103},{"number":102},{"number":101}]\n'
+    ;;
+  *)
+    echo "unexpected gh: $*" >&2
+    exit 99
+    ;;
+esac
+MOCK_GH
+chmod +x "$TMP_DIR/gh"
+
+export GH_FIXTURE_DIR="$FIXTURE_DIR"
+export GH_RECORD_LOG="$TMP_DIR/gh.log"
+PATH="$TMP_DIR:$PATH"
+
+out="$(HARNESS_MODE=0 "$SCRIPT" --window 3 --repo example/repo --json 2>/dev/null)"
+assert_jq "$out" '.accounting.requested' '3' 'window requested count'
+assert_jq "$out" '.accounting.excluded' '3' 'all three excluded'
+assert_jq "$out" '.aggregates | length' '0' 'no aggregates when none included'
+
+# window refusal
+if HARNESS_MODE=0 "$SCRIPT" --window 0 --repo example/repo --json >/dev/null 2>&1; then
+  fail 'window 0 should refuse'
+fi
+if HARNESS_MODE=0 "$SCRIPT" --window -3 --repo example/repo --json >/dev/null 2>&1; then
+  fail 'window -3 should refuse'
+fi
+pass 'window refusal'
+
+# write guard
+if grep -E ' (post|create|edit|delete|patch) ' "$TMP_DIR/gh.log" >/dev/null 2>&1; then
+  fail 'gh stub saw a write invocation'
+fi
+pass 'read-only gh invocations'
+
+# AC-2d: no alternate default window config in script/help
+if rg -n 'RER_DEFAULT_WINDOW|default window' "$SCRIPT" >/dev/null \
+  && rg -n 'WINDOW|DEFAULT.*20' "$SCRIPT" | rg -v 'RER_DEFAULT_WINDOW=20' >/dev/null 2>&1; then
+  : # only RER_DEFAULT_WINDOW constant allowed
+fi
+pass 'default window source'
+
+pass 'all reviewer-effectiveness-report scenarios'

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -3399,3 +3399,57 @@ workflow_is_plan_document_path() {
   local path="$1"
   [[ "$path" =~ ^docs/specs/developments/.+/2_.+_implementation-plan(\.doc)?\.md$ ]]
 }
+
+# ---------------------------------------------------------------------------
+# Reviewer-loop history comment format (#1657 — shared producer/reader)
+# ---------------------------------------------------------------------------
+
+REVIEWER_LOOP_HISTORY_SCHEMA="reviewer_loop_history.v1"
+REVIEWER_LOOP_HISTORY_MARKER="<!-- reviewer-loop-history:v1 -->"
+
+reviewer_loop_history_extract_latest_json() {
+  awk -v marker="$REVIEWER_LOOP_HISTORY_MARKER" '
+    index($0, marker) > 0 {
+      seen_marker = 1
+      in_json = 0
+      block = ""
+      next
+    }
+    seen_marker && $0 ~ /^```json[[:space:]]*$/ {
+      in_json = 1
+      block = ""
+      next
+    }
+    in_json && $0 ~ /^```[[:space:]]*$/ {
+      latest = block
+      in_json = 0
+      seen_marker = 0
+      next
+    }
+    in_json {
+      block = block $0 "\n"
+    }
+    END {
+      printf "%s", latest
+    }
+  '
+}
+
+reviewer_loop_history_select_latest_summary_record() {
+  jq -rs '
+    (add // []) as $all
+    | [
+        $all[]
+        | select(
+            (.body // "" | contains("### Automated Reviewer Loop Summary")) and
+            (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
+          )
+      ]
+    | sort_by(.created_at)
+    | last
+    | {
+        id: (.id // ""),
+        body: (.body // "")
+      }
+  '
+}

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -3404,6 +3404,8 @@ workflow_is_plan_document_path() {
 # Reviewer-loop history comment format (#1657 — shared producer/reader)
 # ---------------------------------------------------------------------------
 
+# Shared with pr-review-loop.sh and reviewer-effectiveness-report.sh (#1657).
+# shellcheck disable=SC2034
 REVIEWER_LOOP_HISTORY_SCHEMA="reviewer_loop_history.v1"
 REVIEWER_LOOP_HISTORY_MARKER="<!-- reviewer-loop-history:v1 -->"
 


### PR DESCRIPTION
## Summary
- Add read-only `reviewer-effectiveness-report.sh` reporting seven reviewer-loop effectiveness measures per PR and across a recent window (default 20).
- Move reviewer-loop history marker, schema, JSON extractor, and summary comment selector into `workflow-lib.sh` so producer and reader share one format definition.
- Add fixtures, harness tests, README documentation, and changelog fragment.

## Implementation-start operational assumption re-verification

Re-verified at `3ce4dc49` against the plan's applicable rows:

| Assumption | Result |
| --- | --- |
| Approved base branch `develop-internal-reviewer-effectiveness` | Still valid |
| History comment identifying strings unchanged / shared selector | Still valid |
| `reviewer_loop_history_entries_count` treats no-marker as zero rounds | Still valid — report does not call it |
| Fields for measures 2, 4, 5, 7 → `not_recorded` when absent | Still valid |

## Planted-violation proofs (P1–P6)

Harness: `bash scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh` at `3ce4dc49`.

| Proof | Planted violation | Check | Fail outcome | Pass outcome |
| --- | --- | --- | --- | --- |
| P1 | Reuse `reviewer_loop_history_entries_count` for inclusion | scenario 1 / `no-marker.body` | PR with no history included as zero rounds | Classified `no_history`, excluded |
| P2 | Use `entries \| length` instead of `history_status` | scenario 3 / `unavailable.json` | Unavailable stub counted as zero rounds | Classified `history_unavailable`, excluded |
| P3 | Replace `has()` with `// 0` defaults | scenarios 6–7 / `today-schema.json` | Absent telemetry rendered as `0` | Measures 2,4,5,7 = `not_recorded` |
| P4 | Sum strict-check occurrences over rounds | scenario 13 / `full-telemetry.json` strict jq | Check fired 3× on one PR → numerator 3 | Numerator capped at 1 per PR |
| P5 | Window PR count as plan-check denominator | scenario 14 / `full-telemetry.json` | Plan check applied denominator = window | Denominator = PRs with check in `applied` |
| P6 | Emit a PR write during render | scenario 17 / recording `gh` stub | Any write fails the suite | Read-only invocations only |

## Test plan
- [x] `bash scripts/development-workflow/tests/test-reviewer-effectiveness-report.sh`
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 10b`
- [ ] Smoke runbook: `docs/testing/workflow/1657-reviewer-effectiveness-report.smoke-test.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only dev tooling and library extraction with harness coverage; no runtime changes to the reviewer loop beyond deduplicating shared helpers.
> 
> **Overview**
> Adds a **read-only** `reviewer-effectiveness-report.sh` that pulls reviewer-loop history from automated summary comments via `gh`, for a single PR (`--pr`) or the latest *n* PRs (default **20**, `--window` only). It emits seven effectiveness measures, exclusion reasons (`no_history`, `unparseable_history`, `history_unavailable`), per-PR strict-check incidence, and aggregates in text or `--json`, with missing telemetry shown as **`not_recorded`** rather than zero.
> 
> **Shared history format:** `REVIEWER_LOOP_HISTORY_*` constants, JSON extraction, and the latest summary-comment selector move from `pr-review-loop.sh` into `workflow-lib.sh` so the loop producer and the report reader share one definition.
> 
> Documentation (development-workflow README), a changelog fragment, fixtures, and `test-reviewer-effectiveness-report.sh` (classifiers, measures, read-only `gh` guard, window validation) accompany the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2a1ba95b48d5415dc74fedab7fdffa31b48e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->