### PR TITLE
chore(env): add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "AI Dev Framework Template",
+  "user": "ubuntu",
+  "install": "bash ./scripts/cloud-agent-install.sh"
+}

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for the AI dev framework template.
+#
+# Idempotent, non-interactive repository bootstrap. Prepares everything the
+# repository's lint tooling and workflow test harnesses need:
+#   - Node dependencies for markdownlint (npm ci from the committed lockfile)
+#   - shellcheck  (ShellCheck static analysis of scripts/development-workflow)
+#   - zsh         (cross-shell snippet-lint test suite)
+#   - PyYAML      (workflow test suites that parse workflow YAML with Python)
+#
+# Safe to run repeatedly: apt install is a no-op when packages are present and
+# npm ci reconciles node_modules to the lockfile.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+log() { printf '[cloud-agent-install] %s\n' "$*"; }
+
+install_system_packages() {
+  local missing=()
+  command -v shellcheck >/dev/null 2>&1 || missing+=(shellcheck)
+  command -v zsh >/dev/null 2>&1 || missing+=(zsh)
+  # python3-yaml backs `import yaml` for the workflow test harnesses.
+  python3 -c 'import yaml' >/dev/null 2>&1 || missing+=(python3-yaml)
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    log "system packages already present: shellcheck, zsh, python3-yaml"
+    return 0
+  fi
+
+  local sudo=""
+  if [ "$(id -u)" -ne 0 ]; then
+    command -v sudo >/dev/null 2>&1 && sudo="sudo"
+  fi
+
+  log "installing system packages: ${missing[*]}"
+  DEBIAN_FRONTEND=noninteractive $sudo apt-get update -o Acquire::Retries=3
+  DEBIAN_FRONTEND=noninteractive $sudo apt-get install --yes --no-install-recommends "${missing[@]}"
+}
+
+install_node_dependencies() {
+  if [ ! -f package-lock.json ]; then
+    log "no package-lock.json found; skipping npm ci"
+    return 0
+  fi
+  log "installing Node dependencies (npm ci)"
+  npm ci
+}
+
+install_system_packages
+install_node_dependencies
+
+log "verifying toolchain"
+node --version
+npm --version
+python3 --version
+python3 -c 'import yaml; print("PyYAML", yaml.__version__)'
+shellcheck --version | sed -n '2p'
+zsh --version
+./node_modules/.bin/markdownlint-cli2 --version
+
+log "install complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent development environment so future agents boot with the toolchain this repo's lint and workflow-test suites require.

The repo is an AI development workflow framework template; its runnable "applications" are the lint tooling and workflow test harnesses exercised by CI. This change makes that development experience reproducible out of the box.

## What's included

- `.cursor/environment.json` — default-image environment that runs the install script on setup.
- `scripts/cloud-agent-install.sh` — idempotent, non-interactive bootstrap that installs:
  - Node dependencies via `npm ci` (markdownlint tooling)
  - `shellcheck` (ShellCheck static analysis of `scripts/development-workflow`)
  - `zsh` (cross-shell snippet-lint suite)
  - `python3-yaml` / PyYAML (workflow test harnesses that parse workflow YAML)

## Validation

All commands mirror the repository's CI workflows and were run in the agent VM:

| Check | Result |
| --- | --- |
| `markdownlint-cli2` (spec/plan/workflow/CHANGELOG) | 483 files, 0 errors |
| Heuristic lint (GLOB001, COUNT001) | Passed |
| `changelog-fragments.sh validate` | clean (4 fragments) |
| CHANGELOG duplicate-header + link-reference check | Passed |
| `review-doctrine-lint.sh` | Passed (5 entries) |
| ShellCheck (`--severity=warning`, 153 scripts) | 0 findings |
| Workflow shell guard lint tests | 34 passed, 0 failed |
| Workflow shell snippet lint tests | 105 passed, 0 failed |
| Representative workflow suites (select-test-suites, changelog-fragments, branch-name, scope-resolver, post-merge-cleanup, branch-filters) | All passed |
| Install idempotence | Passed twice |
| Install script self-lint (ShellCheck) | Clean |

## Notes

- `node_modules/` remains gitignored; the install script reconciles it from the committed lockfile.
- The committed `.cursor/environment.json` is the highest-precedence environment source and follows branches/PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0925965d-193f-4140-b92b-db3a5186ce3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0925965d-193f-4140-b92b-db3a5186ce3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

