### PR TITLE
fix(ci): shard workflow test matrix

### DIFF
--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -72,6 +72,7 @@ env:
   # 600s gives headroom for a genuinely slow suite and a tight bound on a stuck
   # one.
   SUITE_TIMEOUT_SECONDS: '600'
+  SUITE_TIMEOUT_KILL_AFTER_SECONDS: '30'
 
 jobs:
   select:
@@ -214,7 +215,7 @@ jobs:
 
       - name: Run shard ${{ matrix.shard.id }}
         # Computed by select-test-suites.sh as:
-        # suite count * ceil((SUITE_TIMEOUT_SECONDS + kill-after grace) / 60)
+        # suite count * ceil((SUITE_TIMEOUT_SECONDS + SUITE_TIMEOUT_KILL_AFTER_SECONDS) / 60)
         # + setup/reporting overhead. A fixed shard deadline can still suppress
         # later suites when several earlier suites time out.
         timeout-minutes: ${{ matrix.shard.timeout_minutes }}
@@ -234,9 +235,10 @@ jobs:
           # ever runs.
           #
           # Hang isolation: the job-level timeout-minutes bounds the shard, not
-          # the suite, so without the per-suite 'timeout' below one stuck
-          # harness would suppress every suite after it in this shard while the
-          # workflow still claimed all selected suites ran.
+          # the suite, so a stuck harness must be killed before the loop moves
+          # on. The Python supervisor starts every suite in a new session and
+          # cleans up its whole process group; a plain 'timeout bash "$suite"'
+          # can leave TERM-ignoring grandchildren alive after bash exits.
           set -uo pipefail
 
           failed=0
@@ -251,8 +253,54 @@ jobs:
             started=$SECONDS
             printf '::group::%s\n' "$suite"
             status=0
-            timeout --signal=TERM --kill-after=30s \
-              "$SUITE_TIMEOUT_SECONDS" bash "$suite" || status=$?
+          python3 - "$SUITE_TIMEOUT_SECONDS" "$suite" <<'PY' || status=$?
+          import os
+          import signal
+          import subprocess
+          import sys
+          import time
+
+          timeout_seconds = int(sys.argv[1])
+          suite = sys.argv[2]
+          kill_after_seconds = int(os.environ.get("SUITE_TIMEOUT_KILL_AFTER_SECONDS", "30"))
+
+          process = subprocess.Popen(["bash", suite], start_new_session=True)
+          timed_out = False
+
+          try:
+              returncode = process.wait(timeout=timeout_seconds)
+          except subprocess.TimeoutExpired:
+              timed_out = True
+              returncode = 124
+              try:
+                  os.killpg(process.pid, signal.SIGTERM)
+              except ProcessLookupError:
+                  pass
+              try:
+                  process.wait(timeout=kill_after_seconds)
+              except subprocess.TimeoutExpired:
+                  try:
+                      os.killpg(process.pid, signal.SIGKILL)
+                  except ProcessLookupError:
+                      pass
+                  process.wait()
+          finally:
+              # A suite shell can exit while background descendants keep running. Clean
+              # the process group even on non-timeout exits so later suites start clean.
+              for sig in (signal.SIGTERM, signal.SIGKILL):
+                  try:
+                      os.killpg(process.pid, sig)
+                  except ProcessLookupError:
+                      break
+                  if sig == signal.SIGTERM:
+                      time.sleep(0.2)
+
+          if timed_out:
+              sys.exit(124)
+          if returncode < 0:
+              sys.exit(128 - returncode)
+          sys.exit(returncode)
+          PY
             duration_seconds=$((SECONDS - started))
             case "$status" in
               0) result='pass' ;;

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -15,13 +15,26 @@ name: workflow test harnesses
 # drift this issue exists to end, and test-select-test-suites.sh asserts
 # against it.
 #
-# Tradeoff (AC-4): the full set is 65 suites / ~27 min sequentially, and
-# test-pr-review-loop.sh alone is ~13 min of that — 48% of the total, with a
-# median suite in the low seconds. Running everything on every PR would put 27
-# minutes in front of every change. Running the change-scoped subset keeps the
-# typical PR at well under a minute while making "green" mean the changed
-# script's own tests passed. The scheduled nightly full run is the backstop
-# that catches cross-suite and mapping regressions the subset cannot see.
+# Tradeoff (AC-4): the full set changes as the workflow framework grows, and
+# most suites still finish in seconds while the slowest suite dominates the
+# critical path. Running everything on every PR would put the full harness in
+# front of every change. Running the change-scoped subset keeps the typical PR
+# fast while making "green" mean the changed script's own tests passed. The
+# scheduled nightly full run is the backstop for cross-suite and mapping
+# regressions the subset cannot see.
+#
+# Sharding (#1722) narrows this tradeoff but does not remove it. The matrix
+# runs one job per SHARD, not one per suite. GitHub bills every job rounded up
+# to a whole minute, so a job per suite pays the checkout/interpreter overhead
+# and the one-minute floor once for every suite. Packed into SHARD_COUNT shards,
+# that overhead is paid once per shard while per-suite pass/fail still appears
+# in the step summary.
+#
+# The packing itself lives in select-test-suites.sh --shards, not here, for the
+# same reason the selection does: a list in this file is a list that drifts.
+# What is lost is one check name per suite in the PR rollup; per-suite
+# pass/fail moves to the step summary, which is where the detail belongs
+# anyway. The required check name is unchanged.
 
 on:
   pull_request:
@@ -43,6 +56,23 @@ concurrency:
   group: workflow-tests-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # How many parallel jobs a full selection is packed into. The bill is roughly
+  # (total work + one rounding penalty per shard), so raising this buys wall
+  # clock and costs minutes; lowering it does the reverse. 8 sits at the point
+  # where the slowest real suite is typically its own shard; past that, more
+  # shards cost minutes without shortening the critical path.
+  SHARD_COUNT: '8'
+  # Per-suite wall-clock cap inside a shard. A hang must cost only its own
+  # suite: the job-level timeout-minutes is a backstop for the shard as a
+  # whole, sized from the number of suites in that shard. On its own it would
+  # let a hung harness suppress later suites — coverage the per-suite matrix
+  # never lost — but it still needs to be large enough for several suites in one
+  # shard to hit their own per-suite caps without starving the rest.
+  # 600s gives headroom for a genuinely slow suite and a tight bound on a stuck
+  # one.
+  SUITE_TIMEOUT_SECONDS: '600'
+
 jobs:
   select:
     name: select suites
@@ -50,15 +80,21 @@ jobs:
     permissions:
       contents: read
     outputs:
-      suites: ${{ steps.select.outputs.suites }}
+      shards: ${{ steps.select.outputs.shards }}
       count: ${{ steps.select.outputs.count }}
       mode: ${{ steps.select.outputs.mode }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          # Full history so the merge-base diff below is computable.
+          # Full history so the merge-base diff below is computable. A partial
+          # clone keeps every commit and tree — which is all merge-base and
+          # 'diff --name-only' need — while skipping file contents, so this
+          # stays cheap as the repository grows. Do NOT swap it for a shallow
+          # 'fetch-depth: N': that drops commits, and a merge-base that falls
+          # outside the fetched depth silently produces the wrong change set.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Resolve suites to run
         id: select
@@ -72,7 +108,7 @@ jobs:
           if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "mode=full" >> "$GITHUB_OUTPUT"
             echo "Full run (event: $EVENT_NAME)."
-            suites="$(bash "$selector" --all --format json)"
+            shards="$(bash "$selector" --all --shards "$SHARD_COUNT" --format json)"
             lines="$(bash "$selector" --all)"
           else
             echo "mode=selected" >> "$GITHUB_OUTPUT"
@@ -86,12 +122,13 @@ jobs:
             git diff --name-only "$base_sha" HEAD > changed-files.txt
             echo "Changed files:"
             sed 's/^/  /' changed-files.txt
-            suites="$(bash "$selector" --changed-files changed-files.txt --format json)"
+            shards="$(bash "$selector" --changed-files changed-files.txt \
+              --shards "$SHARD_COUNT" --format json)"
             lines="$(bash "$selector" --changed-files changed-files.txt)"
           fi
 
           count="$(printf '%s\n' "$lines" | grep -c . || true)"
-          echo "suites=$suites" >> "$GITHUB_OUTPUT"
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
           {
@@ -100,15 +137,7 @@ jobs:
             if [ "$count" -eq 0 ]; then
               echo "_No workflow test suite covers this change set._"
             else
-              # Formatted with printf rather than sed, and with the
-              # backticks escaped inside double quotes: a literal backtick in
-              # a single-quoted string trips shellcheck SC2016, which
-              # actionlint surfaces in consumer repositories that lint this
-              # workflow (#1631).
-              while IFS= read -r suite; do
-                [ -n "$suite" ] || continue
-                printf -- "- \`%s\`\n" "$suite"
-              done <<< "$lines"
+              printf '%s\n' "$lines" | awk '{ printf "- `%s`\n", $0 }'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -131,19 +160,21 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   test:
-    name: ${{ matrix.suite }}
+    name: shard ${{ matrix.shard.id }}
     needs: select
     if: needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
-      # Run every selected suite even when one fails, so a PR gets the whole
-      # picture in one pass instead of one failure per push.
+      # Run every shard even when one fails, so a PR gets the whole picture in
+      # one pass instead of one failure per push. The suites WITHIN a shard get
+      # the same treatment by the run step below, which deliberately does not
+      # 'set -e'.
       fail-fast: false
       max-parallel: 8
       matrix:
-        suite: ${{ fromJSON(needs.select.outputs.suites) }}
+        shard: ${{ fromJSON(needs.select.outputs.shards) }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -160,7 +191,7 @@ jobs:
       #
       # A dedicated venv with a pinned version, rather than "install if
       # missing": an unpinned install takes whatever PyPI serves that day, and
-      # an "already present" branch takes whatever the image happens to ship —
+      # an "already present" branch takes whatever the image happens to ship -
       # both leave the same commit free to change YAML-parsing behavior between
       # runs, which is the nondeterminism this step exists to remove. The venv
       # also keeps the install off the runner's system interpreter, which is
@@ -181,11 +212,84 @@ jobs:
           # Subsequent steps resolve python3 from the venv.
           echo "$venv/bin" >> "$GITHUB_PATH"
 
-      - name: Run ${{ matrix.suite }}
-        # Longest suite is test-pr-review-loop.sh at ~13 min; this bounds a hang
-        # well above that rather than inheriting the 6-hour Actions default.
-        timeout-minutes: 30
-        run: bash "${{ matrix.suite }}"
+      - name: Run shard ${{ matrix.shard.id }}
+        # Computed by select-test-suites.sh as:
+        # suite count * ceil((SUITE_TIMEOUT_SECONDS + kill-after grace) / 60)
+        # + setup/reporting overhead. A fixed shard deadline can still suppress
+        # later suites when several earlier suites time out.
+        timeout-minutes: ${{ matrix.shard.timeout_minutes }}
+        env:
+          SHARD_ID: ${{ matrix.shard.id }}
+          SHARD_SUITES: ${{ matrix.shard.suites }}
+        run: |
+          # Before sharding, every suite was its own job: neither a failure
+          # nor a hang could take a sibling with it. Both properties have to be
+          # rebuilt here, and they need different mechanisms.
+          #
+          # Failure isolation: GitHub runs this with 'bash -eo pipefail', so a
+          # non-zero suite would abort the loop. The '|| status=$?' form below
+          # puts each suite in a '||' list, which '-e' exempts by definition;
+          # do not rewrite it as a bare 'bash "$suite"' on its own line
+          # followed by a '$?' check, which '-e' would abort before the check
+          # ever runs.
+          #
+          # Hang isolation: the job-level timeout-minutes bounds the shard, not
+          # the suite, so without the per-suite 'timeout' below one stuck
+          # harness would suppress every suite after it in this shard while the
+          # workflow still claimed all selected suites ran.
+          set -uo pipefail
+
+          failed=0
+          failed_suites=""
+          {
+            printf '### Shard %s\n\n' "$SHARD_ID"
+            printf '| suite | result | seconds |\n|---|---|---|\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # shellcheck disable=SC2086  # deliberate: the shard is a space-joined suite list
+          for suite in $SHARD_SUITES; do
+            started=$SECONDS
+            printf '::group::%s\n' "$suite"
+            status=0
+            timeout --signal=TERM --kill-after=30s \
+              "$SUITE_TIMEOUT_SECONDS" bash "$suite" || status=$?
+            duration_seconds=$((SECONDS - started))
+            case "$status" in
+              0) result='pass' ;;
+              # 124 is ambiguous: it can be timeout's own deadline, or a nested
+              # command that exited 124 before the outer deadline fired. Only
+              # call it a timeout when the measured runtime reaches the outer
+              # suite deadline; otherwise report the command status as FAIL.
+              124)
+                failed=1
+                if [ "$duration_seconds" -ge "$SUITE_TIMEOUT_SECONDS" ]; then
+                  result='**TIMEOUT**'
+                else
+                  result='**FAIL**'
+                fi
+                ;;
+              # A later 137 is ambiguous too: it can be timeout's SIGKILL after
+              # grace expires, but it can also be an unrelated OOM/kill -9 crash.
+              # Report 137 as a failure rather than claiming a definite timeout.
+              *) result='**FAIL**'; failed=1 ;;
+            esac
+            if [ "$status" -ne 0 ]; then
+              printf -v failed_suites '%s  %s: %s\n' "$failed_suites" "$suite" "$result"
+            fi
+            printf '::endgroup::\n'
+            printf "| \`%s\` | %s | %s |\n" \
+              "$suite" "$result" "$duration_seconds" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          # Per-suite pass/fail lives in the step summary now that the check
+          # rollup names shards rather than suites, so a failure has to name
+          # the suite here too — a bare non-zero exit would make the reader
+          # open the log to find out which of a dozen suites broke.
+          if [ "$failed" -ne 0 ]; then
+            echo "Shard $SHARD_ID: one or more suites failed (see the table above)." >&2
+            printf 'Failed suites:\n%s' "$failed_suites" >&2
+          fi
+          exit "$failed"
 
   # A single stable check name to require in branch protection. The matrix job
   # names change with the selection, so they cannot be required directly.

--- a/changelog.d/1722-shard-workflow-tests.md
+++ b/changelog.d/1722-shard-workflow-tests.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Shard the workflow test harness matrix so full selections run one job per
+  balanced shard instead of one job per suite, preserving per-suite failure and
+  timeout isolation while reducing GitHub Actions minute-rounding waste.

--- a/changelog.d/1722.fixed.shard-workflow-tests.md
+++ b/changelog.d/1722.fixed.shard-workflow-tests.md
@@ -1,5 +1,3 @@
-### Fixed
-
 - Shard the workflow test harness matrix so full selections run one job per
   balanced shard instead of one job per suite, preserving per-suite failure and
   timeout isolation while reducing GitHub Actions minute-rounding waste.

--- a/scripts/development-workflow/select-test-suites.sh
+++ b/scripts/development-workflow/select-test-suites.sh
@@ -45,6 +45,7 @@
 #
 #   select-test-suites.sh --changed-files <path>   # '-' reads stdin
 #   select-test-suites.sh --all
+#   select-test-suites.sh --all --shards 8
 #   select-test-suites.sh --report-gaps
 #   select-test-suites.sh --print-map
 #
@@ -52,6 +53,11 @@
 #   --changed-files <path>  File with one changed repo-relative path per line.
 #                           Emits the suites that change set requires.
 #   --all                   Emit every suite (the scheduled full run).
+#   --shards <n>            Group the selected suites into at most <n> shards
+#                           instead of emitting them individually, so CI can
+#                           run one job per shard rather than one job per
+#                           suite. See "Sharding" below. Requires --all or
+#                           --changed-files.
 #   --report-gaps           Emit the coverage-gap report (AC-3): workflow
 #                           scripts with no suite, and suites that no PR change
 #                           set can select. Always exits 0 — the report is
@@ -59,7 +65,45 @@
 #   --print-map             Emit 'suite<TAB>pattern' for each resolved mapping.
 #   --format <lines|json>   Output format for suite lists. Default 'lines'.
 #
-# Output (lines format): repo-relative suite paths, one per line, sorted.
+# ── Sharding ────────────────────────────────────────────────────────────────
+#
+# GitHub bills every job rounded UP to a whole minute, and most suites here
+# finish in seconds, so one job per suite bills several times the compute it
+# uses. --shards packs the selection into at most <n> groups that each run
+# sequentially in one job.
+#
+# Packing is longest-processing-time-first: suites are sorted longest-first and
+# each is placed in the shard with the least work so far. That keeps the
+# slowest shard — and therefore the wall-clock time of the whole run — close to
+# the theoretical minimum, which is what stops the cheaper billing from costing
+# latency. The BILL is roughly independent of how well the packing balances
+# (it is the total work plus one rounding penalty per shard); the WALL TIME is
+# not, which is why the packing is worth doing properly.
+#
+# A suite's expected duration comes from a '# duration: <seconds>' header line,
+# read from the same bounded header window as '# covers:'. A suite that does
+# not declare one is assumed to take DEFAULT_SUITE_SECONDS. Only suites that
+# run materially longer than that need a header — the default is deliberately
+# close to the median so an undeclared suite cannot distort the packing much,
+# and a stale hint costs balance, never correctness.
+#
+# ── Output ──────────────────────────────────────────────────────────────────
+#
+# Without --shards
+#   lines: repo-relative suite paths, one per line, sorted.
+#   json:  ["suite", ...]
+#
+# With --shards <n>
+#   lines: one shard per line, '<id><TAB><space-joined suites>'.
+#   json:  [{"id":"1/8","suites":"a b c","timeout_minutes":38}, ...] —
+#          shaped for a GitHub Actions matrix, where each element becomes one
+#          job, 'id' names it, and 'timeout_minutes' gives that shard enough
+#          budget for every suite to reach its own per-suite cap plus the
+#          timeout command's kill-after grace.
+#
+# Fewer suites than shards yields fewer shards; an empty selection yields no
+# shards at all ('[]' in json), so the caller can skip the test job entirely.
+#
 # Exit codes: 0 success, 2 usage error.
 #
 # Portability: written for bash 3.2 (the macOS system bash) — no mapfile,
@@ -89,6 +133,29 @@ SCRIPTS_DIR="scripts/development-workflow"
 # widening a suite's declared surface.
 COVERS_HEADER_LINES=60
 
+# Assumed duration of a suite that declares no '# duration:' header, in
+# seconds. Measured over production runs by subtracting the per-job overhead
+# floor from observed suite durations. Most suites in downstream rollouts run
+# in the low seconds, so this slightly over-states a typical undeclared suite.
+# That direction is the safe one — an unknown suite gets spread out rather than
+# piled onto a shard that is already the critical path.
+DEFAULT_SUITE_SECONDS=5
+
+# Mirrors workflow-tests.yml's SUITE_TIMEOUT_SECONDS default. The workflow
+# exports that env var before calling this selector, so matrix timeouts stay in
+# step with the per-suite guard without asking GitHub expressions to do
+# arithmetic.
+SHARD_SUITE_TIMEOUT_SECONDS="${SUITE_TIMEOUT_SECONDS:-600}"
+case "$SHARD_SUITE_TIMEOUT_SECONDS" in
+  '' | *[!0-9]*) die "SUITE_TIMEOUT_SECONDS must be a positive integer, got '$SHARD_SUITE_TIMEOUT_SECONDS'" ;;
+esac
+SHARD_SUITE_TIMEOUT_SECONDS=$((10#$SHARD_SUITE_TIMEOUT_SECONDS))
+[ "$SHARD_SUITE_TIMEOUT_SECONDS" -gt 0 ] \
+  || die "SUITE_TIMEOUT_SECONDS must be a positive integer, got '$SHARD_SUITE_TIMEOUT_SECONDS'"
+SHARD_TIMEOUT_KILL_AFTER_SECONDS=30
+SHARD_TIMEOUT_OVERHEAD_MINUTES=5
+GITHUB_JOB_TIMEOUT_LIMIT_MINUTES=360
+
 # Changing any of these invalidates the per-suite mapping itself, or is a shared
 # dependency of most suites, so a change to one runs the full set rather than a
 # selected subset. Deliberately conservative: the cost of over-running is wall
@@ -99,7 +166,11 @@ $TESTS_DIR/fixtures/**
 .github/workflows/workflow-tests.yml"
 
 usage() {
-  sed -n '3,66p' "$0" | sed 's/^# \{0,1\}//'
+  # Print the whole leading comment header rather than a hard-coded line range:
+  # a fixed range silently truncates the help text the moment the header grows,
+  # and the truncation is invisible unless someone reads --help expecting the
+  # part that vanished.
+  awk 'NR <= 2 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
 }
 
 # ── Pattern matching ────────────────────────────────────────────────────────
@@ -227,6 +298,56 @@ suite_patterns() {
   return 0
 }
 
+# suite_duration <suite-path> — the suite's expected runtime in seconds.
+#
+# Read from a '# duration: <seconds>' header line in the same bounded window as
+# '# covers:', defaulting to DEFAULT_SUITE_SECONDS. Only used to balance shards,
+# so a missing or stale value costs wall-clock balance and never correctness —
+# which is why a malformed value falls back to the default rather than dying.
+suite_duration() {
+  local suite="$1" line rest token value=""
+
+  while IFS= read -r line; do
+    case "$line" in
+      '#'*duration:*)
+        rest="${line#*duration:}"
+        # Word-split without pathname expansion, matching suite_patterns. Only
+        # the first token is the duration; anything after it is prose.
+        set -f
+        # shellcheck disable=SC2086  # deliberate word-splitting; globbing disabled above
+        for token in $rest; do
+          value="$token"
+          break
+        done
+        set +f
+        ;;
+    esac
+    # Read the whole header rather than breaking out on the first hit: breaking
+    # closes the process substitution while read_suite_header is still writing,
+    # which surfaces as EPIPE noise on stderr.
+  done < <(read_suite_header "$suite")
+
+  case "$value" in
+    '' | *[!0-9]*) printf '%s\n' "$DEFAULT_SUITE_SECONDS"; return 0 ;;
+  esac
+
+  # Normalise to base 10 HERE, at the boundary, before the value reaches any
+  # arithmetic. A digits-only check is not enough: bash reads a leading-zero
+  # literal as octal, so '# duration: 08' passes validation and then dies in
+  # emit_shards with 'value too great for base', taking the whole selection —
+  # and therefore the CI gate — down over a duration hint that is only ever
+  # meant to affect shard balance. '10#' forces base 10 regardless of padding.
+  value=$((10#$value))
+
+  # Checked after normalisation so '0', '00' and '000' are all caught; a
+  # zero-length suite would let one shard absorb unlimited work.
+  if [ "$value" -le 0 ]; then
+    printf '%s\n' "$DEFAULT_SUITE_SECONDS"
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
 # suite_has_mapping <suite> — true when the suite covers something beyond
 # itself, i.e. some PR change set other than editing the test can select it.
 suite_has_mapping() {
@@ -267,14 +388,131 @@ emit_suites() {
   printf ']\n'
 }
 
+# json_escape <string> — escape for a JSON string body.
+json_escape() {
+  local escaped="$1"
+  # Backslash first, then the quote, so a value containing either still yields
+  # valid JSON. The workflow feeds this straight into fromJSON(), where a
+  # malformed string fails the whole run rather than one job.
+  escaped="${escaped//\\/\\\\}"
+  escaped="${escaped//\"/\\\"}"
+  printf '%s' "$escaped"
+}
+
+# emit_shards <format> <shard-count> — reads a newline-delimited suite list on
+# stdin and packs it into at most <shard-count> shards.
+#
+# Longest-processing-time-first: sort the suites longest-first, then place each
+# into whichever shard has the least work so far. Deterministic — ties in
+# duration break on the suite path — so the same selection always produces the
+# same shards, which is what makes the packing testable.
+emit_shards() {
+  local format="$1" shard_count="$2"
+  local suite secs i idx total=0 n=0 timeout_minutes per_suite_timeout_minutes
+  local -a bin_load bin_suites bin_count
+  local first=1
+
+  # Pair each suite with its duration and sort longest-first. Sorting here, in
+  # one pass, rather than calling suite_duration inside the packing loop keeps
+  # the header of each suite read exactly once.
+  local paired=""
+  while IFS= read -r suite; do
+    [ -n "$suite" ] || continue
+    secs="$(suite_duration "$suite")"
+    paired="$paired$secs	$suite
+"
+    total=$((total + 1))
+  done
+
+  if [ "$total" -eq 0 ]; then
+    [ "$format" = json ] && printf '[]\n'
+    return 0
+  fi
+
+  # More shards than suites would emit empty shards, i.e. jobs that bill a
+  # minute to run nothing.
+  [ "$shard_count" -gt "$total" ] && shard_count="$total"
+
+  i=0
+  while [ "$i" -lt "$shard_count" ]; do
+    bin_load[i]=0
+    bin_suites[i]=""
+    bin_count[i]=0
+    i=$((i + 1))
+  done
+
+  while IFS='	' read -r secs suite; do
+    [ -n "$suite" ] || continue
+    # Least-loaded shard wins; the lowest index wins a tie, keeping the
+    # assignment deterministic.
+    idx=0
+    i=1
+    while [ "$i" -lt "$shard_count" ]; do
+      if [ "${bin_load[$i]}" -lt "${bin_load[$idx]}" ]; then
+        idx=$i
+      fi
+      i=$((i + 1))
+    done
+    bin_load[idx]=$(( bin_load[idx] + secs ))
+    bin_count[idx]=$(( bin_count[idx] + 1 ))
+    if [ -z "${bin_suites[$idx]}" ]; then
+      bin_suites[idx]="$suite"
+    else
+      bin_suites[idx]="${bin_suites[idx]} $suite"
+    fi
+  done <<EOF
+$(printf '%s' "$paired" | LC_ALL=C sort -t'	' -k1,1nr -k2,2)
+EOF
+
+  per_suite_timeout_minutes=$(((SHARD_SUITE_TIMEOUT_SECONDS + SHARD_TIMEOUT_KILL_AFTER_SECONDS + 59) / 60))
+  i=0
+  while [ "$i" -lt "$shard_count" ]; do
+    timeout_minutes=$((bin_count[i] * per_suite_timeout_minutes + SHARD_TIMEOUT_OVERHEAD_MINUTES))
+    if [ "$timeout_minutes" -gt "$GITHUB_JOB_TIMEOUT_LIMIT_MINUTES" ]; then
+      die "shard $((i + 1))/$shard_count requires ${timeout_minutes}m, exceeding GitHub Actions ${GITHUB_JOB_TIMEOUT_LIMIT_MINUTES}m job timeout cap; increase --shards"
+    fi
+    i=$((i + 1))
+  done
+
+  [ "$format" = json ] && printf '['
+  i=0
+  while [ "$i" -lt "$shard_count" ]; do
+    n=$((i + 1))
+    if [ "$format" = json ]; then
+      timeout_minutes=$((bin_count[i] * per_suite_timeout_minutes + SHARD_TIMEOUT_OVERHEAD_MINUTES))
+      [ "$first" -eq 1 ] || printf ','
+      first=0
+      printf '{"id":"%s/%s","suites":"%s","timeout_minutes":%s}' \
+        "$n" "$shard_count" "$(json_escape "${bin_suites[$i]}")" "$timeout_minutes"
+    else
+      printf '%s/%s\t%s\n' "$n" "$shard_count" "${bin_suites[$i]}"
+    fi
+    i=$((i + 1))
+  done
+  [ "$format" = json ] && printf ']\n'
+  return 0
+}
+
 # ── Modes ───────────────────────────────────────────────────────────────────
 
+# emit_selection <format> <shard-count> — the single exit point for a suite
+# list, so --all and --changed-files cannot drift on how sharding is applied.
+# A shard count of 0 means "not sharding".
+emit_selection() {
+  local format="$1" shard_count="$2"
+  if [ "$shard_count" -gt 0 ]; then
+    emit_shards "$format" "$shard_count"
+  else
+    emit_suites "$format"
+  fi
+}
+
 mode_all() {
-  list_suites | emit_suites "$1"
+  list_suites | emit_selection "$1" "$2"
 }
 
 mode_changed() {
-  local format="$1" source="$2"
+  local format="$1" source="$2" shard_count="$3"
   local changed_raw changed="" line pattern suite matched file
 
   if [ "$source" = '-' ]; then
@@ -301,7 +539,7 @@ EOF
       [ -n "$pattern" ] || continue
       if path_matches "$file" "$pattern"; then
         printf 'INFO: full run triggered by %s (matches %s)\n' "$file" "$pattern" >&2
-        mode_all "$format"
+        mode_all "$format" "$shard_count"
         return 0
       fi
     done <<EOF
@@ -335,7 +573,7 @@ EOF
     # Guard the brace group's own exit status: 'set -o pipefail' would
     # otherwise surface a falsy last command here as a selector failure.
     true
-  } | emit_suites "$format"
+  } | emit_selection "$format" "$shard_count"
 }
 
 mode_report_gaps() {
@@ -416,7 +654,7 @@ mode_print_map() {
 # ── Entry point ─────────────────────────────────────────────────────────────
 
 main() {
-  local mode="" changed_source="" format="lines"
+  local mode="" changed_source="" format="lines" shard_count=0
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -438,16 +676,44 @@ main() {
         esac
         shift 2
         ;;
+      --shards)
+        [ $# -ge 2 ] || die "--shards requires a value"
+        shard_count="$2"
+        case "$shard_count" in
+          '' | *[!0-9]*) die "--shards must be a positive integer, got '$2'" ;;
+        esac
+        # Normalise before the range check, for the same reason suite_duration
+        # does: a digits-only test accepts '00', which is not the literal '0'
+        # and so slipped past a '| 0)' arm, then compared equal to zero
+        # downstream and silently emitted the UNSHARDED shape — a JSON array of
+        # strings where the matrix expects {id, suites} objects, so the caller
+        # got blank shard fields instead of a usage error. '10#' additionally
+        # stops a padded value like '08' being read as octal.
+        shard_count=$((10#$shard_count))
+        [ "$shard_count" -gt 0 ] \
+          || die "--shards must be a positive integer, got '$2'"
+        shift 2
+        ;;
       -h | --help) usage; exit 0 ;;
       *) die "unknown argument '$1'" ;;
     esac
   done
 
+  # --shards changes the SHAPE of a suite list, so it is meaningless for the
+  # two report modes. Rejecting it is better than ignoring it: a caller that
+  # passes it there has misunderstood the output it is about to parse.
+  if [ "$shard_count" -gt 0 ]; then
+    case "$mode" in
+      all | changed) ;;
+      *) die "--shards requires --all or --changed-files" ;;
+    esac
+  fi
+
   assert_suites_readable
 
   case "$mode" in
-    all) mode_all "$format" ;;
-    changed) mode_changed "$format" "$changed_source" ;;
+    all) mode_all "$format" "$shard_count" ;;
+    changed) mode_changed "$format" "$changed_source" "$shard_count" ;;
     gaps) mode_report_gaps ;;
     map) mode_print_map ;;
     *) die "no mode selected (expected --changed-files, --all, --report-gaps, or --print-map)" ;;

--- a/scripts/development-workflow/select-test-suites.sh
+++ b/scripts/development-workflow/select-test-suites.sh
@@ -141,10 +141,9 @@ COVERS_HEADER_LINES=60
 # piled onto a shard that is already the critical path.
 DEFAULT_SUITE_SECONDS=5
 
-# Mirrors workflow-tests.yml's SUITE_TIMEOUT_SECONDS default. The workflow
-# exports that env var before calling this selector, so matrix timeouts stay in
-# step with the per-suite guard without asking GitHub expressions to do
-# arithmetic.
+# Mirrors workflow-tests.yml's per-suite timeout defaults. The workflow exports
+# these env vars before calling this selector, so matrix timeouts stay in step
+# with the per-suite guard without asking GitHub expressions to do arithmetic.
 SHARD_SUITE_TIMEOUT_SECONDS="${SUITE_TIMEOUT_SECONDS:-600}"
 case "$SHARD_SUITE_TIMEOUT_SECONDS" in
   '' | *[!0-9]*) die "SUITE_TIMEOUT_SECONDS must be a positive integer, got '$SHARD_SUITE_TIMEOUT_SECONDS'" ;;
@@ -152,7 +151,13 @@ esac
 SHARD_SUITE_TIMEOUT_SECONDS=$((10#$SHARD_SUITE_TIMEOUT_SECONDS))
 [ "$SHARD_SUITE_TIMEOUT_SECONDS" -gt 0 ] \
   || die "SUITE_TIMEOUT_SECONDS must be a positive integer, got '$SHARD_SUITE_TIMEOUT_SECONDS'"
-SHARD_TIMEOUT_KILL_AFTER_SECONDS=30
+SHARD_TIMEOUT_KILL_AFTER_SECONDS="${SUITE_TIMEOUT_KILL_AFTER_SECONDS:-30}"
+case "$SHARD_TIMEOUT_KILL_AFTER_SECONDS" in
+  '' | *[!0-9]*) die "SUITE_TIMEOUT_KILL_AFTER_SECONDS must be a positive integer, got '$SHARD_TIMEOUT_KILL_AFTER_SECONDS'" ;;
+esac
+SHARD_TIMEOUT_KILL_AFTER_SECONDS=$((10#$SHARD_TIMEOUT_KILL_AFTER_SECONDS))
+[ "$SHARD_TIMEOUT_KILL_AFTER_SECONDS" -gt 0 ] \
+  || die "SUITE_TIMEOUT_KILL_AFTER_SECONDS must be a positive integer, got '$SHARD_TIMEOUT_KILL_AFTER_SECONDS'"
 SHARD_TIMEOUT_OVERHEAD_MINUTES=5
 GITHUB_JOB_TIMEOUT_LIMIT_MINUTES=360
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # test-pr-review-loop.sh — Self-contained test harness for pr-review-loop.sh.
+# duration: 210
 # covers: scripts/development-workflow/pr-review-loop.sh
 # covers: docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
 #

--- a/scripts/development-workflow/tests/test-select-test-suites.sh
+++ b/scripts/development-workflow/tests/test-select-test-suites.sh
@@ -369,12 +369,13 @@ if [ -f "$WORKFLOW_FILE" ]; then
   # the check passing on the prose that describes it. A structural assertion
   # that cannot fail is worse than none, because it reads as coverage.
   workflow_code="$(grep -vE '^[[:space:]]*#' "$WORKFLOW_FILE")"
-  if printf '%s\n' "$workflow_code" | grep -qE 'timeout --signal=TERM --kill-after' \
-    && printf '%s\n' "$workflow_code" | grep -qF "\"\$SUITE_TIMEOUT_SECONDS\" bash \"\$suite\""; then
+  if printf '%s\n' "$workflow_code" | grep -qF 'start_new_session=True' \
+    && printf '%s\n' "$workflow_code" | grep -qF 'os.killpg(process.pid, signal.SIGKILL)' \
+    && printf '%s\n' "$workflow_code" | grep -qF 'process.wait(timeout=timeout_seconds)'; then
     PASS_COUNT=$((PASS_COUNT + 1)); echo "PASS: workflow_has_per_suite_timeout"
   else
     FAIL_COUNT=$((FAIL_COUNT + 1))
-    echo "FAIL: workflow_has_per_suite_timeout — a hang would suppress the rest of its shard"
+    echo "FAIL: workflow_has_per_suite_timeout — a hang or leaked child would corrupt the rest of its shard"
   fi
   if printf '%s\n' "$workflow_code" | grep -qF '|| status=$?'; then
     PASS_COUNT=$((PASS_COUNT + 1)); echo "PASS: workflow_keeps_failure_isolation"
@@ -510,7 +511,10 @@ with open(os.environ["SELECTOR"], encoding="utf-8") as selector:
     selector_source = selector.read()
 default_timeout = int(re.search(r"^SHARD_SUITE_TIMEOUT_SECONDS=\"\$\{SUITE_TIMEOUT_SECONDS:-([0-9]+)\}\"$", selector_source, re.M).group(1))
 suite_timeout = int(os.environ.get("SUITE_TIMEOUT_SECONDS", default_timeout))
-kill_after = int(re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
+if (match := re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=\"\$\{SUITE_TIMEOUT_KILL_AFTER_SECONDS:-([0-9]+)\}\"$", selector_source, re.M)):
+    kill_after = int(os.environ.get("SUITE_TIMEOUT_KILL_AFTER_SECONDS", match.group(1)))
+else:
+    kill_after = int(re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
 overhead = int(re.search(r"^SHARD_TIMEOUT_OVERHEAD_MINUTES=([0-9]+)$", selector_source, re.M).group(1))
 per_suite_timeout = (suite_timeout + kill_after + 59) // 60
 ok = True
@@ -529,7 +533,10 @@ with open(os.environ["SELECTOR"], encoding="utf-8") as selector:
     selector_source = selector.read()
 default_timeout = int(re.search(r"^SHARD_SUITE_TIMEOUT_SECONDS=\"\$\{SUITE_TIMEOUT_SECONDS:-([0-9]+)\}\"$", selector_source, re.M).group(1))
 suite_timeout = int(os.environ.get("SUITE_TIMEOUT_SECONDS", default_timeout))
-kill_after = int(re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
+if (match := re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=\"\$\{SUITE_TIMEOUT_KILL_AFTER_SECONDS:-([0-9]+)\}\"$", selector_source, re.M)):
+    kill_after = int(os.environ.get("SUITE_TIMEOUT_KILL_AFTER_SECONDS", match.group(1)))
+else:
+    kill_after = int(re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
 overhead = int(re.search(r"^SHARD_TIMEOUT_OVERHEAD_MINUTES=([0-9]+)$", selector_source, re.M).group(1))
 limit = int(re.search(r"^GITHUB_JOB_TIMEOUT_LIMIT_MINUTES=([0-9]+)$", selector_source, re.M).group(1))
 per_suite_timeout = (suite_timeout + kill_after + 59) // 60
@@ -698,19 +705,17 @@ if len(run) != 1:
 open(sys.argv[2], "w").write(run[0])
 EXTRACT
 then
-  # The extracted step calls 'timeout' by name. When only 'gtimeout' is
-  # present, shim it in on PATH rather than rewriting the step — the whole
-  # point of extracting it is that it runs unmodified.
-  mkdir -p "$SHARD_PROBE_DIR/bin"
-  printf '#!/usr/bin/env bash\nexec %s "$@"\n' \
-    "$(command -v "$SHARD_PROBE_TIMEOUT")" > "$SHARD_PROBE_DIR/bin/timeout"
-  chmod +x "$SHARD_PROBE_DIR/bin/timeout"
-
-	  printf '#!/usr/bin/env bash\necho hanging; sleep 120\n' > "$SHARD_PROBE_DIR/s_hang.sh"
-	  printf '#!/usr/bin/env bash\necho failing; exit 1\n'    > "$SHARD_PROBE_DIR/s_fail.sh"
-	  printf '#!/usr/bin/env bash\nexit 124\n'                > "$SHARD_PROBE_DIR/s_124.sh"
-	  printf '#!/usr/bin/env bash\nkill -9 "$$"\n'            > "$SHARD_PROBE_DIR/s_kill.sh"
-	  printf '#!/usr/bin/env bash\necho passing\n'            > "$SHARD_PROBE_DIR/s_pass.sh"
+  printf '#!/usr/bin/env bash\necho hanging; sleep 120\n' > "$SHARD_PROBE_DIR/s_hang.sh"
+  printf '#!/usr/bin/env bash\necho failing; exit 1\n'    > "$SHARD_PROBE_DIR/s_fail.sh"
+  printf '#!/usr/bin/env bash\nexit 124\n'                > "$SHARD_PROBE_DIR/s_124.sh"
+  printf '#!/usr/bin/env bash\nkill -9 "$$"\n'            > "$SHARD_PROBE_DIR/s_kill.sh"
+  printf '#!/usr/bin/env bash\necho passing\n'            > "$SHARD_PROBE_DIR/s_pass.sh"
+  cat > "$SHARD_PROBE_DIR/s_leak.sh" <<'LEAK'
+#!/usr/bin/env bash
+(trap '' TERM; sleep 120) &
+echo "$!" > leak-child.pid
+wait
+LEAK
 
   # The hang is first on purpose: if the per-suite timeout is ever removed,
   # nothing after it would run. The outer 'timeout 90' keeps that regression a
@@ -720,8 +725,9 @@ then
     && PATH="$SHARD_PROBE_DIR/bin:$PATH" \
 	       GITHUB_STEP_SUMMARY="$SHARD_PROBE_DIR/summary.md" \
 	       SHARD_ID="probe" \
-	       SHARD_SUITES="s_hang.sh s_fail.sh s_124.sh s_kill.sh s_pass.sh" \
+	       SHARD_SUITES="s_hang.sh s_fail.sh s_124.sh s_kill.sh s_pass.sh s_leak.sh" \
 	       SUITE_TIMEOUT_SECONDS=3 \
+	       SUITE_TIMEOUT_KILL_AFTER_SECONDS=1 \
 	       "$SHARD_PROBE_TIMEOUT_ABS" 90 bash -eo pipefail "$SHARD_PROBE_DIR/step.sh" ) \
     > "$SHARD_PROBE_DIR/out.txt" 2>&1
   shard_ec=$?
@@ -744,12 +750,26 @@ then
   # loop, which is what GitHub's inherited 'bash -e' would otherwise do.
   run_test "shard_loop_reports_fail" "yes" \
     "$(printf '%s' "$shard_summary" | grep -q 's_fail.sh.*FAIL' && echo yes || echo no)"
-	  run_test "shard_loop_reports_sigkill_as_fail" "yes" \
-	    "$(printf '%s' "$shard_summary" | grep -q 's_kill.sh.*FAIL' && echo yes || echo no)"
-	  run_test "shard_loop_reports_command_124_as_fail" "yes" \
-	    "$(printf '%s' "$shard_summary" | grep -q 's_124.sh.*FAIL' && echo yes || echo no)"
-	  run_test "shard_loop_runs_all_five_suites" "5" \
-	    "$(printf '%s' "$shard_summary" | grep -c '^| `s_' || true)"
+  run_test "shard_loop_reports_sigkill_as_fail" "yes" \
+    "$(printf '%s' "$shard_summary" | grep -q 's_kill.sh.*FAIL' && echo yes || echo no)"
+  run_test "shard_loop_reports_command_124_as_fail" "yes" \
+    "$(printf '%s' "$shard_summary" | grep -q 's_124.sh.*FAIL' && echo yes || echo no)"
+  run_test "shard_loop_runs_all_six_suites" "6" \
+    "$(printf '%s' "$shard_summary" | grep -c '^| `s_' || true)"
+  if [ -s "$SHARD_PROBE_DIR/leak-child.pid" ]; then
+    leak_pid="$(cat "$SHARD_PROBE_DIR/leak-child.pid")"
+    if kill -0 "$leak_pid" 2>/dev/null; then
+      leak_alive=yes
+      kill "$leak_pid" 2>/dev/null || true
+      sleep 0.1
+      kill -9 "$leak_pid" 2>/dev/null || true
+    else
+      leak_alive=no
+    fi
+  else
+    leak_alive=missing
+  fi
+  run_test "shard_loop_kills_timeout_descendants" "no" "$leak_alive"
 
   shard_output="$(cat "$SHARD_PROBE_DIR/out.txt" 2>/dev/null || true)"
   run_test "shard_loop_stderr_names_timeout_suite" "yes" \

--- a/scripts/development-workflow/tests/test-select-test-suites.sh
+++ b/scripts/development-workflow/tests/test-select-test-suites.sh
@@ -163,8 +163,8 @@ if [ -e "$NEW_SUITE" ] || [ -L "$NEW_SUITE" ]; then
   printf 'ERROR: probe path already exists, refusing to overwrite: %s\n' "$NEW_SUITE" >&2
   exit 2
 fi
-cleanup_probe() { rm -f -- "$NEW_SUITE"; }
-trap cleanup_probe EXIT
+cleanup_ac2_probe() { rm -f -- "$NEW_SUITE"; }
+trap cleanup_ac2_probe EXIT
 cat > "$NEW_SUITE" <<'PROBE'
 #!/usr/bin/env bash
 # test-zzz-ac2-probe.sh - temporary probe suite.
@@ -174,7 +174,7 @@ PROBE
 assert_contains "ac2_new_suite_in_all" "$T/test-zzz-ac2-probe.sh" "$(bash "$SELECTOR" --all)"
 assert_contains "ac2_new_suite_selected_by_covers" "$T/test-zzz-ac2-probe.sh" \
   "$(select_for "$S/zzz-ac2-probe.sh")"
-cleanup_probe
+cleanup_ac2_probe
 trap - EXIT
 assert_not_contains "ac2_probe_removed" "$T/test-zzz-ac2-probe.sh" "$(bash "$SELECTOR" --all)"
 
@@ -555,15 +555,15 @@ if [ -e "$REPO_ROOT/$DEFAULT_DURATION_PROBE" ] || [ -L "$REPO_ROOT/$DEFAULT_DURA
     "$REPO_ROOT/$DEFAULT_DURATION_PROBE" >&2
   exit 2
 fi
-cleanup_probe() { rm -f -- "$REPO_ROOT/$DEFAULT_DURATION_PROBE"; }
-trap cleanup_probe EXIT
+cleanup_default_duration_probe() { rm -f -- "$REPO_ROOT/$DEFAULT_DURATION_PROBE"; }
+trap cleanup_default_duration_probe EXIT
 printf '#!/usr/bin/env bash\n# covers: scripts/development-workflow/zzz-default-duration-probe.sh\nexit 0\n' \
   > "$REPO_ROOT/$DEFAULT_DURATION_PROBE"
 default_duration_out="$(printf '%s\n' scripts/development-workflow/zzz-default-duration-probe.sh \
   | bash "$SELECTOR" --changed-files - --shards 1 2>/dev/null)"
 run_test "shards_default_duration_applies" "yes" \
   "$(printf '%s' "$default_duration_out" | grep -q 'test-zzz-default-duration-probe.sh' && echo yes || echo no)"
-cleanup_probe
+cleanup_default_duration_probe
 trap - EXIT
 
 # Duration hints must be normalised to base 10 at the boundary. A digits-only
@@ -582,8 +582,8 @@ if [ -e "$REPO_ROOT/$DURATION_PROBE" ] || [ -L "$REPO_ROOT/$DURATION_PROBE" ]; t
     "$REPO_ROOT/$DURATION_PROBE" >&2
   exit 2
 fi
-cleanup_probe() { rm -f -- "$REPO_ROOT/$DURATION_PROBE"; }
-trap cleanup_probe EXIT
+cleanup_duration_probe() { rm -f -- "$REPO_ROOT/$DURATION_PROBE"; }
+trap cleanup_duration_probe EXIT
 for pad in 08 09 007 00 0; do
   printf '#!/usr/bin/env bash\n# duration: %s\n# covers: scripts/development-workflow/zzz-duration-probe.sh\nexit 0\n' \
     "$pad" > "$REPO_ROOT/$DURATION_PROBE"
@@ -597,7 +597,7 @@ for pad in 08 09 007 00 0; do
   run_test "duration_zero_padded_${pad}_suite_present" "yes" \
     "$(printf '%s' "$probe_out" | grep -q 'test-zzz-duration-probe.sh' && echo yes || echo no)"
 done
-cleanup_probe
+cleanup_duration_probe
 trap - EXIT
 
 # Argument validation. '00'/'000' are in here because a digits-only check

--- a/scripts/development-workflow/tests/test-select-test-suites.sh
+++ b/scripts/development-workflow/tests/test-select-test-suites.sh
@@ -2,6 +2,7 @@
 # test-select-test-suites.sh - Tests for the CI test-suite selector (issue #1537).
 # covers: scripts/development-workflow/select-test-suites.sh
 # covers: .github/workflows/workflow-tests.yml
+# duration: 38
 
 set -euo pipefail
 
@@ -340,10 +341,428 @@ if [ -f "$WORKFLOW_FILE" ]; then
   # The hard-coded per-suite 'run:' steps this issue removed must not come back.
   hardcoded="$(grep -cE '^\s+run: bash scripts/development-workflow/tests/test-' "$WORKFLOW_FILE" || true)"
   run_test "workflow_has_no_hardcoded_suite_steps" "0" "$hardcoded"
+
+  # The matrix must fan out over SHARDS, not suites (#1722). A revert to
+  # 'matrix: suite:' restores one job per suite, which bills roughly four times
+  # the compute it uses — the whole point of the sharding change.
+  for needle in "--shards" "matrix.shard.suites" "matrix.shard.timeout_minutes" "fromJSON(needs.select.outputs.shards)"; do
+    if grep -qF -- "$needle" "$WORKFLOW_FILE"; then
+      PASS_COUNT=$((PASS_COUNT + 1)); echo "PASS: workflow_has_$needle"
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1)); echo "FAIL: workflow_has_$needle — not found"
+    fi
+  done
+  if grep -qE '^\s+suite: \$\{\{ fromJSON' "$WORKFLOW_FILE"; then
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "FAIL: workflow_matrix_is_sharded — per-suite matrix fan-out is back"
+  else
+    PASS_COUNT=$((PASS_COUNT + 1)); echo "PASS: workflow_matrix_is_sharded"
+  fi
+
+  # Sharding rebuilt two isolation properties the per-suite matrix gave for
+  # free, and each has its own mechanism. Losing either is silent: the run
+  # still goes green having tested less than it claims.
+  #
+  # These greps strip comment lines FIRST. Grepping the raw file made the
+  # assertion unfalsifiable: the explanatory comments in workflow-tests.yml
+  # quote '|| status=$?' verbatim, so deleting the executable invocation left
+  # the check passing on the prose that describes it. A structural assertion
+  # that cannot fail is worse than none, because it reads as coverage.
+  workflow_code="$(grep -vE '^[[:space:]]*#' "$WORKFLOW_FILE")"
+  if printf '%s\n' "$workflow_code" | grep -qE 'timeout --signal=TERM --kill-after' \
+    && printf '%s\n' "$workflow_code" | grep -qF "\"\$SUITE_TIMEOUT_SECONDS\" bash \"\$suite\""; then
+    PASS_COUNT=$((PASS_COUNT + 1)); echo "PASS: workflow_has_per_suite_timeout"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "FAIL: workflow_has_per_suite_timeout — a hang would suppress the rest of its shard"
+  fi
+  if printf '%s\n' "$workflow_code" | grep -qF '|| status=$?'; then
+    PASS_COUNT=$((PASS_COUNT + 1)); echo "PASS: workflow_keeps_failure_isolation"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "FAIL: workflow_keeps_failure_isolation — bash -e would abort the shard on the first failing suite"
+  fi
 else
   FAIL_COUNT=$((FAIL_COUNT + 1))
   echo "FAIL: workflow_exists — $WORKFLOW_FILE not found"
 fi
+
+# ---------------------------------------------------------------------------
+# Area 11: shard packing (#1722)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 11: shard packing ==="
+
+all_suites="$(bash "$SELECTOR" --all)"
+all_count="$(printf '%s\n' "$all_suites" | grep -c .)"
+
+shards="$(bash "$SELECTOR" --all --shards 8)"
+run_test "shards_emits_requested_count" "8" "$(printf '%s\n' "$shards" | grep -c .)"
+
+# Nothing may be dropped and nothing duplicated: the suites across all shards
+# must be exactly the unsharded selection. A packing bug that loses a suite is
+# otherwise invisible — the run still goes green, having tested less.
+packed="$(printf '%s\n' "$shards" | cut -f2- | tr ' ' '\n' | grep -c . || true)"
+run_test "shards_preserve_suite_count" "$all_count" "$packed"
+run_test "shards_preserve_exact_set" "same" \
+  "$(if [ "$(printf '%s\n' "$shards" | cut -f2- | tr ' ' '\n' | grep . | LC_ALL=C sort)" \
+        = "$(printf '%s\n' "$all_suites" | LC_ALL=C sort)" ]; then echo same; else echo differs; fi)"
+
+# No shard may be empty — an empty shard is a job that bills a minute to run
+# nothing.
+run_test "shards_are_all_non_empty" "0" \
+  "$(printf '%s\n' "$shards" | grep -c '	$' || true)"
+
+# Ids are 1-based and name the total, so a job name identifies the shard.
+run_test "shards_first_id" "1/8" "$(printf '%s\n' "$shards" | head -1 | cut -f1)"
+run_test "shards_last_id" "8/8" "$(printf '%s\n' "$shards" | tail -1 | cut -f1)"
+
+# Deterministic: the packing is an input to a matrix, so the same selection
+# must always produce the same shards or a re-run reshuffles the jobs.
+run_test "shards_are_deterministic" "same" \
+  "$(if [ "$shards" = "$(bash "$SELECTOR" --all --shards 8)" ]; then echo same; else echo differs; fi)"
+
+# Longest-processing-time-first: the slowest declared suite must be placed
+# first, and every later suite must go to the least-loaded shard available at
+# that moment. This tests the packing rule itself instead of depending on
+# today's full-suite inventory having uneven shard sizes.
+expected_shards="$(printf '%s\n' "$all_suites" | REPO_ROOT="$REPO_ROOT" SELECTOR="$SELECTOR" python3 -c 'import os, re, sys
+repo = os.environ["REPO_ROOT"]
+with open(os.environ["SELECTOR"], encoding="utf-8") as selector:
+    selector_source = selector.read()
+header_lines = int(re.search(r"^COVERS_HEADER_LINES=([0-9]+)$", selector_source, re.M).group(1))
+default = int(re.search(r"^DEFAULT_SUITE_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
+
+def suite_duration(suite):
+    duration = default
+    with open(os.path.join(repo, suite), encoding="utf-8") as handle:
+        for _ in range(header_lines):
+            line = handle.readline()
+            if not line:
+                break
+            if line.startswith("#") and "duration:" in line:
+                token = line.split("duration:", 1)[1].split()
+                value = token[0] if token else ""
+                if re.fullmatch(r"[0-9]+", value or "") and int(value, 10) > 0:
+                    duration = int(value, 10)
+                else:
+                    duration = default
+    return duration
+
+suites = [line.strip() for line in sys.stdin if line.strip()]
+ranked = [(-suite_duration(suite), suite) for suite in suites]
+bins = [{"load": 0, "suites": []} for _ in range(8)]
+for negative_duration, suite in sorted(ranked):
+    index = min(range(len(bins)), key=lambda i: (bins[i]["load"], i))
+    bins[index]["load"] += -negative_duration
+    bins[index]["suites"].append(suite)
+for index, shard in enumerate(bins, 1):
+    print("%s/8\t%s" % (index, " ".join(shard["suites"])))')"
+longest_suite="$(printf '%s\n' "$all_suites" | REPO_ROOT="$REPO_ROOT" SELECTOR="$SELECTOR" python3 -c 'import os, re, sys
+repo = os.environ["REPO_ROOT"]
+with open(os.environ["SELECTOR"], encoding="utf-8") as selector:
+    selector_source = selector.read()
+header_lines = int(re.search(r"^COVERS_HEADER_LINES=([0-9]+)$", selector_source, re.M).group(1))
+default = int(re.search(r"^DEFAULT_SUITE_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
+ranked = []
+for suite in [line.strip() for line in sys.stdin if line.strip()]:
+    duration = default
+    with open(os.path.join(repo, suite), encoding="utf-8") as handle:
+        for _ in range(header_lines):
+            line = handle.readline()
+            if not line:
+                break
+            if line.startswith("#") and "duration:" in line:
+                token = line.split("duration:", 1)[1].split()
+                value = token[0] if token else ""
+                if re.fullmatch(r"[0-9]+", value or "") and int(value, 10) > 0:
+                    duration = int(value, 10)
+                else:
+                    duration = default
+    ranked.append((-duration, suite))
+print(sorted(ranked)[0][1])')"
+first_actual_suite="$(printf '%s\n' "$shards" | head -1 | cut -f2- | tr ' ' '\n' | head -1)"
+run_test "shards_place_longest_suite_first" "$longest_suite" "$first_actual_suite"
+run_test "shards_match_lpt_expected" "$expected_shards" "$shards"
+
+# Fewer suites than shards must not emit empty shards.
+two="$(printf '%s\n' "$S/run-item-scope-resolver.sh" "$S/run-epic-risk-classifier.sh" \
+  | bash "$SELECTOR" --changed-files - --shards 8 2>/dev/null)"
+run_test "shards_clamp_to_suite_count" "2" "$(printf '%s\n' "$two" | grep -c .)"
+run_test "shards_clamp_renumbers_total" "1/2" "$(printf '%s\n' "$two" | head -1 | cut -f1)"
+
+# An empty selection yields no shards at all, so the caller can skip the job.
+run_test "shards_empty_selection_lines" "0" \
+  "$(printf '%s\n' "README.md" | bash "$SELECTOR" --changed-files - --shards 8 2>/dev/null | grep -c . || true)"
+run_test "shards_empty_selection_json" "[]" \
+  "$(printf '%s\n' "README.md" | bash "$SELECTOR" --changed-files - --shards 8 --format json 2>/dev/null)"
+
+# JSON is fed straight to fromJSON() in the workflow, where a malformed value
+# fails the whole run rather than one job.
+shards_json="$(bash "$SELECTOR" --all --shards 8 --format json)"
+run_test "shards_json_parses" "8" \
+  "$(printf '%s' "$shards_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
+run_test "shards_json_keys" "id suites timeout_minutes" \
+  "$(printf '%s' "$shards_json" | python3 -c 'import json,sys; print(" ".join(sorted(json.load(sys.stdin)[0])))')"
+run_test "shards_json_timeout_scales_by_suite_count" "yes" \
+  "$(printf '%s' "$shards_json" | SELECTOR="$SELECTOR" python3 -c 'import json, os, re, sys
+with open(os.environ["SELECTOR"], encoding="utf-8") as selector:
+    selector_source = selector.read()
+default_timeout = int(re.search(r"^SHARD_SUITE_TIMEOUT_SECONDS=\"\$\{SUITE_TIMEOUT_SECONDS:-([0-9]+)\}\"$", selector_source, re.M).group(1))
+suite_timeout = int(os.environ.get("SUITE_TIMEOUT_SECONDS", default_timeout))
+kill_after = int(re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
+overhead = int(re.search(r"^SHARD_TIMEOUT_OVERHEAD_MINUTES=([0-9]+)$", selector_source, re.M).group(1))
+per_suite_timeout = (suite_timeout + kill_after + 59) // 60
+ok = True
+for shard in json.load(sys.stdin):
+    expected = len(shard["suites"].split()) * per_suite_timeout + overhead
+    if shard["timeout_minutes"] != expected:
+        ok = False
+print("yes" if ok else "no")')"
+
+set +e
+shards_too_large_out="$(bash "$SELECTOR" --all --shards 1 --format json 2>&1)"
+shards_too_large_ec=$?
+set -e
+oversized_expectations="$(ALL_COUNT="$all_count" SELECTOR="$SELECTOR" python3 -c 'import os, re
+with open(os.environ["SELECTOR"], encoding="utf-8") as selector:
+    selector_source = selector.read()
+default_timeout = int(re.search(r"^SHARD_SUITE_TIMEOUT_SECONDS=\"\$\{SUITE_TIMEOUT_SECONDS:-([0-9]+)\}\"$", selector_source, re.M).group(1))
+suite_timeout = int(os.environ.get("SUITE_TIMEOUT_SECONDS", default_timeout))
+kill_after = int(re.search(r"^SHARD_TIMEOUT_KILL_AFTER_SECONDS=([0-9]+)$", selector_source, re.M).group(1))
+overhead = int(re.search(r"^SHARD_TIMEOUT_OVERHEAD_MINUTES=([0-9]+)$", selector_source, re.M).group(1))
+limit = int(re.search(r"^GITHUB_JOB_TIMEOUT_LIMIT_MINUTES=([0-9]+)$", selector_source, re.M).group(1))
+per_suite_timeout = (suite_timeout + kill_after + 59) // 60
+timeout_minutes = int(os.environ["ALL_COUNT"]) * per_suite_timeout + overhead
+print("2 yes" if timeout_minutes > limit else "0 no")')"
+run_test "shards_rejects_layout_over_timeout_cap" \
+  "$(printf '%s\n' "$oversized_expectations" | cut -d' ' -f1)" "$shards_too_large_ec"
+run_test "shards_rejects_layout_over_timeout_cap_message" \
+  "$(printf '%s\n' "$oversized_expectations" | cut -d' ' -f2)" \
+  "$(printf '%s' "$shards_too_large_out" | grep -q 'exceeding GitHub Actions 360m job timeout cap' && echo yes || echo no)"
+
+# A padded-but-positive shard count must still WORK, not just avoid the octal
+# error — the fix normalises rather than rejects, so '08' means 8.
+padded_shape="$(printf '%s\n' "$S/run-item-scope-resolver.sh" \
+  | bash "$SELECTOR" --changed-files - --shards 08 --format json 2>/dev/null)"
+run_test "shards_padded_count_is_sharded_shape" "id suites timeout_minutes" \
+  "$(printf '%s' "$padded_shape" | python3 -c 'import json,sys; print(" ".join(sorted(json.load(sys.stdin)[0])))')"
+
+# A suite with no '# duration:' header must still be packed, at the default.
+DEFAULT_DURATION_PROBE="$T/test-zzz-default-duration-probe.sh"
+if [ -e "$REPO_ROOT/$DEFAULT_DURATION_PROBE" ] || [ -L "$REPO_ROOT/$DEFAULT_DURATION_PROBE" ]; then
+  printf 'ERROR: probe path already exists, refusing to overwrite: %s\n' \
+    "$REPO_ROOT/$DEFAULT_DURATION_PROBE" >&2
+  exit 2
+fi
+cleanup_probe() { rm -f -- "$REPO_ROOT/$DEFAULT_DURATION_PROBE"; }
+trap cleanup_probe EXIT
+printf '#!/usr/bin/env bash\n# covers: scripts/development-workflow/zzz-default-duration-probe.sh\nexit 0\n' \
+  > "$REPO_ROOT/$DEFAULT_DURATION_PROBE"
+default_duration_out="$(printf '%s\n' scripts/development-workflow/zzz-default-duration-probe.sh \
+  | bash "$SELECTOR" --changed-files - --shards 1 2>/dev/null)"
+run_test "shards_default_duration_applies" "yes" \
+  "$(printf '%s' "$default_duration_out" | grep -q 'test-zzz-default-duration-probe.sh' && echo yes || echo no)"
+cleanup_probe
+trap - EXIT
+
+# Duration hints must be normalised to base 10 at the boundary. A digits-only
+# check accepts '08', which bash then reads as octal and dies on with 'value
+# too great for base' — taking the whole selection, and therefore the CI gate,
+# down over a hint that is only meant to affect shard balance.
+DURATION_PROBE="$T/test-zzz-duration-probe.sh"
+# Refuse to touch an occupied path, exactly as the unreadable probe above does.
+# The selector only discovers suites inside the real tests directory, so the
+# probe has to live there — which means this suite writes and then DELETES a
+# path in the developer's working tree. Without this guard, someone with
+# untracked work at that name loses it to a test run, silently and twice over
+# (overwritten in the loop, removed by cleanup).
+if [ -e "$REPO_ROOT/$DURATION_PROBE" ] || [ -L "$REPO_ROOT/$DURATION_PROBE" ]; then
+  printf 'ERROR: probe path already exists, refusing to overwrite: %s\n' \
+    "$REPO_ROOT/$DURATION_PROBE" >&2
+  exit 2
+fi
+cleanup_probe() { rm -f -- "$REPO_ROOT/$DURATION_PROBE"; }
+trap cleanup_probe EXIT
+for pad in 08 09 007 00 0; do
+  printf '#!/usr/bin/env bash\n# duration: %s\n# covers: scripts/development-workflow/zzz-duration-probe.sh\nexit 0\n' \
+    "$pad" > "$REPO_ROOT/$DURATION_PROBE"
+  set +e
+  probe_out="$(printf '%s\n' scripts/development-workflow/zzz-duration-probe.sh | bash "$SELECTOR" --changed-files - --shards 1 2>&1)"
+  probe_ec=$?
+  set -e
+  run_test "duration_zero_padded_${pad}_exit_0" "0" "$probe_ec"
+  run_test "duration_zero_padded_${pad}_no_base_error" "no" \
+    "$(printf '%s' "$probe_out" | grep -q 'value too great for base' && echo yes || echo no)"
+  run_test "duration_zero_padded_${pad}_suite_present" "yes" \
+    "$(printf '%s' "$probe_out" | grep -q 'test-zzz-duration-probe.sh' && echo yes || echo no)"
+done
+cleanup_probe
+trap - EXIT
+
+# Argument validation. '00'/'000' are in here because a digits-only check
+# accepts them while they are not the literal '0': before the fix they passed
+# validation, compared equal to zero downstream, and made the selector emit the
+# UNSHARDED shape (an array of strings) where the matrix expects {id, suites}
+# objects — a silent wrong answer instead of a usage error.
+for bad in 0 00 000 -1 abc ''; do
+  set +e
+  bash "$SELECTOR" --all --shards "$bad" >/dev/null 2>&1
+  ec=$?
+  set -e
+  run_test "shards_rejects_${bad:-empty}" "2" "$ec"
+done
+
+set +e
+bash "$SELECTOR" --all --shards >/dev/null 2>&1
+ec=$?
+set -e
+run_test "shards_missing_value_exit_2" "2" "$ec"
+
+# --shards changes the shape of a suite list, so it is meaningless for the
+# report modes. Silently ignoring it would hand the caller output it is not
+# expecting to parse.
+for mode in --report-gaps --print-map; do
+  set +e
+  bash "$SELECTOR" "$mode" --shards 8 >/dev/null 2>&1
+  ec=$?
+  set -e
+  run_test "shards_rejected_for_${mode#--}" "2" "$ec"
+done
+
+# ---------------------------------------------------------------------------
+# Area 12: the shard loop's isolation behaviour, executed (#1722)
+# ---------------------------------------------------------------------------
+#
+# Area 10's greps only prove the invocation LOOKS right. This extracts the real
+# 'Run shard' step out of the workflow and runs it against synthetic suites, so
+# the assertions are about what the loop DOES. It is the difference between a
+# check that survives a refactor and one that survives a rewrite.
+echo ""
+echo "=== Area 12: shard loop isolation (executed) ==="
+
+# Both the outer deadline below and the extracted step's own invocation need
+# GNU timeout, which stock macOS does not ship — this suite runs locally as
+# well as in CI, so an unguarded dependency would make the documented full
+# local harness fail at 127 before testing anything. Same handling as
+# resilient_timeout() in local-ai-reviewer.sh: probe for --kill-after support
+# rather than trusting the name, and accept Homebrew's 'gtimeout' too.
+# The extraction below parses the workflow YAML, which needs PyYAML. CI
+# provisions it explicitly in the shard job, but a local host is not required to
+# have it — and an unguarded import here fails as "could not read the step",
+# which points at the workflow rather than at the missing module.
+SHARD_PROBE_YAML=no
+if python3 -c 'import yaml' >/dev/null 2>&1; then
+  SHARD_PROBE_YAML=yes
+fi
+
+SHARD_PROBE_TIMEOUT=""
+SHARD_PROBE_TIMEOUT_ABS=""
+for candidate in timeout gtimeout; do
+  if command -v "$candidate" >/dev/null 2>&1 \
+    && "$candidate" --help 2>&1 | grep -q -- '--kill-after'; then
+    SHARD_PROBE_TIMEOUT="$candidate"
+    # Absolute path, so neither the shim below nor anything else on PATH can
+    # shadow it back onto itself.
+    SHARD_PROBE_TIMEOUT_ABS="$(command -v "$candidate")"
+    break
+  fi
+done
+
+SHARD_PROBE_DIR="$(mktemp -d)"
+cleanup_shard_probe() { rm -rf -- "$SHARD_PROBE_DIR"; }
+trap cleanup_shard_probe EXIT
+
+if [ -z "$SHARD_PROBE_TIMEOUT" ] || [ "$SHARD_PROBE_YAML" = no ]; then
+  # Skipped rather than failed, and loudly: the properties are still covered by
+  # the comment-stripped structural assertions above and by every CI run, which
+  # always has both GNU timeout and a provisioned PyYAML. Name the missing
+  # dependency — "skipped" without a reason is indistinguishable from "quietly
+  # not testing this any more".
+  probe_missing=""
+  [ -z "$SHARD_PROBE_TIMEOUT" ] && probe_missing="GNU timeout (install coreutils)"
+  if [ "$SHARD_PROBE_YAML" = no ]; then
+    [ -n "$probe_missing" ] && probe_missing="$probe_missing and "
+    probe_missing="${probe_missing}PyYAML (pip install PyYAML)"
+  fi
+  echo "SKIP: shard loop isolation — missing $probe_missing"
+# Pull the step's script out of the YAML rather than duplicating it here: a
+# copy would drift, and then this suite would be testing its own replica.
+elif python3 - "$WORKFLOW_FILE" "$SHARD_PROBE_DIR/step.sh" <<'EXTRACT'
+import sys, yaml
+wf = yaml.safe_load(open(sys.argv[1]))
+steps = wf["jobs"]["test"]["steps"]
+run = [s["run"] for s in steps if str(s.get("name", "")).startswith("Run shard")]
+if len(run) != 1:
+    raise SystemExit(f"expected exactly one 'Run shard' step, found {len(run)}")
+open(sys.argv[2], "w").write(run[0])
+EXTRACT
+then
+  # The extracted step calls 'timeout' by name. When only 'gtimeout' is
+  # present, shim it in on PATH rather than rewriting the step — the whole
+  # point of extracting it is that it runs unmodified.
+  mkdir -p "$SHARD_PROBE_DIR/bin"
+  printf '#!/usr/bin/env bash\nexec %s "$@"\n' \
+    "$(command -v "$SHARD_PROBE_TIMEOUT")" > "$SHARD_PROBE_DIR/bin/timeout"
+  chmod +x "$SHARD_PROBE_DIR/bin/timeout"
+
+	  printf '#!/usr/bin/env bash\necho hanging; sleep 120\n' > "$SHARD_PROBE_DIR/s_hang.sh"
+	  printf '#!/usr/bin/env bash\necho failing; exit 1\n'    > "$SHARD_PROBE_DIR/s_fail.sh"
+	  printf '#!/usr/bin/env bash\nexit 124\n'                > "$SHARD_PROBE_DIR/s_124.sh"
+	  printf '#!/usr/bin/env bash\nkill -9 "$$"\n'            > "$SHARD_PROBE_DIR/s_kill.sh"
+	  printf '#!/usr/bin/env bash\necho passing\n'            > "$SHARD_PROBE_DIR/s_pass.sh"
+
+  # The hang is first on purpose: if the per-suite timeout is ever removed,
+  # nothing after it would run. The outer 'timeout 90' keeps that regression a
+  # test failure rather than a hung CI job.
+  set +e
+  ( cd "$SHARD_PROBE_DIR" \
+    && PATH="$SHARD_PROBE_DIR/bin:$PATH" \
+	       GITHUB_STEP_SUMMARY="$SHARD_PROBE_DIR/summary.md" \
+	       SHARD_ID="probe" \
+	       SHARD_SUITES="s_hang.sh s_fail.sh s_124.sh s_kill.sh s_pass.sh" \
+	       SUITE_TIMEOUT_SECONDS=3 \
+	       "$SHARD_PROBE_TIMEOUT_ABS" 90 bash -eo pipefail "$SHARD_PROBE_DIR/step.sh" ) \
+    > "$SHARD_PROBE_DIR/out.txt" 2>&1
+  shard_ec=$?
+  set -e
+  shard_summary="$(cat "$SHARD_PROBE_DIR/summary.md" 2>/dev/null || true)"
+
+  run_test "shard_loop_exits_nonzero" "1" "$shard_ec"
+
+  # Hang isolation: the hung suite is bounded and labelled as a TIMEOUT, not
+  # folded into a generic failure.
+  run_test "shard_loop_reports_timeout" "yes" \
+    "$(printf '%s' "$shard_summary" | grep -q 's_hang.sh.*TIMEOUT' && echo yes || echo no)"
+
+  # ...and the suites AFTER the hang still ran. This is the property a
+  # shard-level timeout-minutes cannot provide.
+  run_test "shard_loop_runs_suites_after_hang" "yes" \
+    "$(printf '%s' "$shard_summary" | grep -q 's_pass.sh.*pass' && echo yes || echo no)"
+
+  # Failure isolation: a failing suite is labelled FAIL and does not abort the
+  # loop, which is what GitHub's inherited 'bash -e' would otherwise do.
+  run_test "shard_loop_reports_fail" "yes" \
+    "$(printf '%s' "$shard_summary" | grep -q 's_fail.sh.*FAIL' && echo yes || echo no)"
+	  run_test "shard_loop_reports_sigkill_as_fail" "yes" \
+	    "$(printf '%s' "$shard_summary" | grep -q 's_kill.sh.*FAIL' && echo yes || echo no)"
+	  run_test "shard_loop_reports_command_124_as_fail" "yes" \
+	    "$(printf '%s' "$shard_summary" | grep -q 's_124.sh.*FAIL' && echo yes || echo no)"
+	  run_test "shard_loop_runs_all_five_suites" "5" \
+	    "$(printf '%s' "$shard_summary" | grep -c '^| `s_' || true)"
+
+  shard_output="$(cat "$SHARD_PROBE_DIR/out.txt" 2>/dev/null || true)"
+  run_test "shard_loop_stderr_names_timeout_suite" "yes" \
+    "$(printf '%s' "$shard_output" | grep -q 's_hang.sh: \*\*TIMEOUT\*\*' && echo yes || echo no)"
+  run_test "shard_loop_stderr_names_failed_suite" "yes" \
+    "$(printf '%s' "$shard_output" | grep -q 's_fail.sh: \*\*FAIL\*\*' && echo yes || echo no)"
+else
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  echo "FAIL: shard_loop_step_extractable — could not read the 'Run shard' step from $WORKFLOW_FILE"
+fi
+
+cleanup_shard_probe
+trap - EXIT
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Backports the proven workflow-test sharding fix from `mome-cl/mome-platform#2979` into the template.

The workflow test harness now fans out over balanced shards instead of one GitHub Actions job per suite. `select-test-suites.sh --shards` emits a GitHub Actions matrix shape with `id`, space-joined `suites`, and `timeout_minutes`; the workflow executes every suite in a shard sequentially with per-suite timeout and failure isolation.

Closes #1722.

## Scope

Implemented from #1722 items 1-3:

- Shard `workflow-tests.yml` instead of fanning out one matrix job per suite.
- Stop paying checkout/interpreter setup and the one-minute job floor once per suite; pay it once per shard instead.
- Keep selection cheap enough for the existing full-history merge-base behavior by using a partial clone (`filter: blob:none`) while preserving correctness.

Explicitly not included:

- The original #1722 item 4 recommendation to fold `ci.yml` `Detect changed paths` into consumers. The issue owner corrected that recommendation in https://github.com/lhpaul/ai-dev-framework-template/issues/1722#issuecomment-5605575809: that change would increase bill by forcing expensive jobs to start more often, so it is out of scope here.

## Rollout Evidence From MOME

Measured on a full 85-suite selection after the MOME rollout:

| | before | after |
|---|---:|---:|
| jobs | 85 | 8 (+2 orchestration) |
| billed minutes | ~95 | ~22 |
| wall clock | ~8 min | ~6.0 min |

The important behavior carried upstream is not the exact suite count; it is replacing per-suite billed jobs with a bounded shard matrix while preserving the stable required check name.

## Same-PR Planted-Violation Proofs

These proofs were run locally against this PR branch at head `933a3d9bdb22bbd6f719d5e09fc8a34870df96e0`, then the planted violations were removed. Later heads only added review-gate hardening around the same sharding behavior: `11816f09` renamed the changelog fragment and test cleanup helpers, `f5a2f00f` switched the ready-phase reviewer from Bugbot to codex-github after Bugbot quota exhaustion, `6ed6ad90` replaced plain `timeout bash "$suite"` with a Python process-group supervisor so timed-out suites cannot leave TERM-ignoring descendants alive, and `221116ca` added the missing `# duration: 210` metadata for the known slow `test-pr-review-loop.sh` harness so LPT packing no longer treats it as a 5-second suite.

### Proof A: per-suite matrix fan-out is caught

Planted violation:

- File/line: `.github/workflows/workflow-tests.yml:177`
- Change: replaced the sharded matrix entry `shard: ${{ fromJSON(needs.select.outputs.shards) }}` with `suite: ${{ fromJSON(needs.select.outputs.shards) }}`.

Failure run:

- Command: `bash scripts/development-workflow/tests/test-select-test-suites.sh > /tmp/proof-a-matrix-fail.log 2>&1`
- Exit: `1`
- Failing assertion: `FAIL: workflow_matrix_is_sharded — per-suite matrix fan-out is back`
- Summary: `Results: 107 passed, 1 failed`

Pass run after removing the planted violation:

- Command: `bash scripts/development-workflow/tests/test-select-test-suites.sh > /tmp/proof-clean-pass.log 2>&1`
- Exit: `0`
- Summary: `Results: 108 passed, 0 failed`

### Proof B: loss of shard failure isolation is caught

Planted violation:

- File/line: `.github/workflows/workflow-tests.yml:255`
- Change: removed `|| status=$?` from the executable suite invocation, leaving `timeout --signal=TERM --kill-after=30s "$SUITE_TIMEOUT_SECONDS" bash "$suite"` as a bare command under GitHub's inherited `bash -e` behavior.

Failure run:

- Command: `bash scripts/development-workflow/tests/test-select-test-suites.sh > /tmp/proof-b-isolation-fail.log 2>&1`
- Exit: `1`
- Failing assertions included:
  - `FAIL: workflow_keeps_failure_isolation — bash -e would abort the shard on the first failing suite`
  - `FAIL: shard_loop_runs_suites_after_hang — expected 'yes', got 'no'`
  - `FAIL: shard_loop_runs_all_five_suites — expected '5', got '0'`
- Summary: `Results: 98 passed, 10 failed`

Pass run after removing the planted violation:

- Command: `bash scripts/development-workflow/tests/test-select-test-suites.sh > /tmp/proof-clean-pass.log 2>&1`
- Exit: `0`
- Summary: `Results: 108 passed, 0 failed`

### Proof C: descendant cleanup after timed suites is caught

Planted violation:

- File/line: `.github/workflows/workflow-tests.yml:286`
- Change: replaced the final process-group cleanup loop with `pass`, leaving timeout handling in place but allowing TERM-ignoring background descendants to survive after the suite shell exits.

Failure run:

- Command: `bash scripts/development-workflow/tests/test-select-test-suites.sh > /tmp/proof-c-descendant-fail.log 2>&1`
- Exit: `1`
- Failing assertion: `FAIL: shard_loop_kills_timeout_descendants — expected 'no', got 'yes'`
- Summary: `Results: 108 passed, 1 failed`

Pass run after removing the planted violation:

- Command: `bash scripts/development-workflow/tests/test-select-test-suites.sh > /tmp/proof-c-descendant-pass.log 2>&1`
- Exit: `0`
- Passing assertion: `PASS: shard_loop_kills_timeout_descendants`
- Summary: `Results: 109 passed, 0 failed`

## Reviewer-Loop Follow-Up: Descendant Cleanup

Codex-github found a legitimate gap on head `f5a2f00f`: GNU `timeout --kill-after` only escalates to `KILL` while the direct `bash "$suite"` command is still running, so a suite can leave a TERM-ignoring background child alive after the shell exits. Head `6ed6ad90` fixes that by starting every suite in a new session from Python, terminating the whole process group on timeout, and performing a final process-group cleanup before the shard loop continues.

The selector harness now includes an executed probe suite that starts `(trap '' TERM; sleep 120) &`, records the child PID, and verifies the child is gone after the timed suite completes. This is not just a structural grep: the harness extracts and executes the actual `Run shard` step from `.github/workflows/workflow-tests.yml`. Proof C above shows this guard fails when the final process-group cleanup is planted out and passes after restoration.

Local proof on `6ed6ad90`:

- `bash scripts/development-workflow/tests/test-select-test-suites.sh` -> `Results: 109 passed, 0 failed`, including `PASS: shard_loop_kills_timeout_descendants`.
- `actionlint .github/workflows/workflow-tests.yml` -> passed.
- `shellcheck --severity=warning scripts/development-workflow/select-test-suites.sh scripts/development-workflow/tests/test-select-test-suites.sh` -> passed.
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` -> examined 2 files, 0 findings.
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop` -> passed.
- `bash scripts/development-workflow/changelog-fragments.sh validate` -> `VALIDATE_RESULT=clean`.
- `git diff --check` -> passed.

## Reviewer-Loop Follow-Up: Slow Suite Weight

Codex-github found a legitimate balancing gap on head `6ed6ad90`: `test-pr-review-loop.sh` documents a measured 210-second clean-tree runtime but lacked a machine-readable `# duration:` header, so the LPT packer used the 5-second fallback and placed it in a multi-suite shard. Head `221116ca` adds `# duration: 210` to that suite.

Local proof on `221116ca`:

- `bash scripts/development-workflow/select-test-suites.sh --all --shards 8 --format json | python3 -m json.tool` -> passed, with `test-pr-review-loop.sh` alone in shard `1/8` and `timeout_minutes: 16`.
- `bash scripts/development-workflow/tests/test-select-test-suites.sh` -> `Results: 109 passed, 0 failed`.
- `actionlint .github/workflows/workflow-tests.yml` -> passed.
- `shellcheck --severity=warning scripts/development-workflow/select-test-suites.sh scripts/development-workflow/tests/test-select-test-suites.sh` -> passed.
- `git diff --check` -> passed.

ShellCheck over the entire large `test-pr-review-loop.sh` file still reports pre-existing warnings far below the added header comment; this PR only adds the duration metadata line at the top of that file.

## Downstream Rollout Proofs

The MOME rollout also proved both required behavioral directions in CI:

- Failure path: with a failure planted in one suite, the required check went red, the failing suite's 11 shard-mates still ran, and 7 of 8 shards still completed.
- Pass path: with the planted failure removed, all 85 selected suites passed and the required check went green.

## Verification

- `bash scripts/development-workflow/tests/test-select-test-suites.sh` -> 109 passed, 0 failed.
- `actionlint .github/workflows/workflow-tests.yml` -> passed.
- `shellcheck --severity=warning scripts/development-workflow/select-test-suites.sh scripts/development-workflow/tests/test-select-test-suites.sh` -> passed.
- `bash scripts/development-workflow/changelog-fragments.sh validate` -> `VALIDATE_RESULT=clean`.
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` -> examined 2 files, 0 findings.
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop` -> passed.
- `bash scripts/development-workflow/select-test-suites.sh --all --shards 8 --format json | python3 -m json.tool >/dev/null` -> passed.
- `git diff --check origin/develop...HEAD` -> passed.
- `bash scripts/development-workflow/scope-residual-gate.sh verify ...` -> `RESULT=pass`, with item 4 explicitly out of scope per the issue correction.
- `bash scripts/development-workflow/run-nested-artifact-guard.sh --mode pre-pr --issue 1722 --expected-branch fix/1722-shard-workflow-tests --approved-base develop --repo-root /Users/lhpaul/Git/ai-dev-framework-template` -> `RESULT=clean`.

## Workflow Security Checklist

- Permissions stay least privilege: `select` and `test` use `contents: read`; `result` uses `{}`.
- `actions/checkout` remains pinned to the full SHA for v4.2.2.
- The workflow intentionally has no path filter; the selector decides whether a PR has matching suites.
- Existing concurrency remains in place.
- No step writes repository state, labels, comments, releases, deployments, statuses, or check runs.

## Pre-Submission Self-Review

- Reviewed `origin/develop...HEAD`; changes are limited to the workflow-test harness, selector, selector tests, and changelog fragment.
- Removed downstream-specific MOME issue counts from template comments; MOME remains only as rollout evidence in this PR body.
- Preserved the stable required check name `workflow test harnesses`.
- Preserved per-suite failure and timeout isolation after changing the matrix granularity from suite to shard.
- Residual scope is explicit: #1722 items 1-3 are covered; original item 4 is excluded because the corrected issue evidence says it is counterproductive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CI gate runs and bills (matrix shape, timeouts, isolation), but scope is limited to the workflow-test harness with extensive self-tests; incorrect packing or isolation could show green while suites were skipped.
> 
> **Overview**
> Replaces **one GitHub Actions job per workflow test suite** with a **fixed-size shard matrix** (default **8** jobs), cutting Actions minute waste from per-job rounding while keeping the required check name **`workflow test harnesses`**.
> 
> **`select-test-suites.sh`** gains **`--shards`**, which packs the selected suites with longest-processing-time-first balancing using optional **`# duration:`** headers (undeclared suites assume a short default). JSON output becomes matrix objects with **`id`**, space-joined **`suites`**, and **`timeout_minutes`**.
> 
> **`workflow-tests.yml`** consumes that shard JSON, uses **`filter: blob:none`** on the select checkout for cheaper merge-base diffs, and runs each shard’s suites **sequentially** with **per-suite `timeout`**, **`|| status=$?`** failure isolation, and a **step-summary table** so pass/fail stays visible per suite even though PR checks list shards.
> 
> **`test-select-test-suites.sh`** adds regression coverage for packing correctness, workflow wiring (including comment-stripped greps so isolation cannot be faked in comments), and an executed probe of the extracted **Run shard** loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11816f09961a1a3807f37bd693908153d63c97ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


