### PR TITLE
docs(spec): framework-mode work-item classification

### DIFF
--- a/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
+++ b/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
@@ -175,11 +175,14 @@ matched against work that is already filed.
 
 **Postconditions**: The release check and the retrospective de-duplication both
 see a complete list. Neither reports "no open framework items" merely because the
-repository stopped using the Workflow class.
+repository stopped using the Workflow class, and neither reports it because the
+lookup could not be performed.
 
 **Information shown**:
 
 - The open items, in the same shape and detail as today.
+- When the lookup could not be performed at all, that it was not performed and
+  why — in place of, and never disguised as, an empty list.
 
 **Considerations**:
 
@@ -194,6 +197,21 @@ repository stopped using the Workflow class.
 - Returning nothing remains a legitimate answer when the board genuinely has no
   open items. The requirement is that emptiness reflects the board, not the
   classification rule.
+- A lookup that could not be completed is a third answer, distinct from both of
+  those, and it must not be dressed up as the second. The tracker may be
+  unreachable, the board or its classification field may be unreadable, the
+  configured tracker may not support this lookup at all. In each of those cases
+  the flow says the lookup was not performed, and why, instead of reporting that
+  there are no open framework items.
+- Being unable to perform the lookup does not stop the release or the
+  retrospective. The lookup is a review aid, not a gate, and the established
+  convention for a tracker read that cannot be performed is to warn, say so, and
+  continue — the same convention the workflow's other best-effort tracker reads
+  and writes already follow. Escalating this one read to a hard stop would make
+  every transient tracker outage a release blocker.
+- What the operator must never have to guess is which of the three answers they
+  are looking at. "The board is empty" and "the lookup failed" produce the same
+  empty list, so the distinction has to come from the report, not from the list.
 
 ---
 
@@ -264,10 +282,35 @@ The agent was never instructed toward a class the same repository refuses.
   from the brief.
 - The routing stop applies to items whose pipeline has not yet been chosen. An
   item already past Backlog keeps the pipeline it started on.
+- The misclassification stop is reported under the recognized stop-condition name
+  `missing_tracker_context`. This feature introduces no new stop-condition name.
+  The classification field is present but cannot be resolved to a pipeline, which
+  is what that condition already covers — a required tracker field that is absent
+  **or unresolvable** — and that name is already recognized by the workflow's
+  guardrails enforcement reference and already listed in this repository's
+  configured stop conditions, so the terminal report stays machine-readable with
+  no vocabulary change. The specificity lives in the rest of the stop message,
+  which names the item and names re-classification as the unblocking action.
+- The misclassification stop is scoped to the misclassified item, never to the
+  run that found it. When a single named item is misclassified, that item's run
+  stops. When a misclassified item is one of many evaluated by a portfolio scan,
+  only that item is held; every other item is still evaluated, and the scan still
+  proposes the largest safe batch of valid items. A misclassified item never
+  terminates a scan and never suppresses an unrelated item from a proposal.
+- A held misclassified item is reported, not dropped. It appears in the scan's
+  category for evaluated candidates that were excluded from the proposal, with
+  its reason and the re-classification that unblocks it.
 - The lookup for open framework items means every open board item in framework
   mode, and keeps its class-filtered meaning in a consumer repository. It must
   never report an empty result as a consequence of the classification rule
   itself.
+- The lookup has three distinguishable answers: the items it found, an empty
+  result because the board holds no open items, and unavailable because the
+  lookup could not be performed. An unavailable lookup is reported as
+  unavailable, with the reason, and is never reported as an empty result. An
+  unavailable lookup does not block the release or retrospective flow, but the
+  flow must state that the lookup was not performed rather than record the
+  review or the de-duplication it feeds as having been satisfied.
 - Every workflow surface that *explains* how to classify an item states the
   framework-mode rule and the consumer rule consistently, so a reader in either
   mode is not misled by the rule for the other.
@@ -306,11 +349,19 @@ Work-item classification values, and what each means in each mode:
 - **Creation refusals**: reported directly to whoever ran the creation command, at
   the moment of the attempt, naming the invalid class and the valid ones. No item
   is created, so nothing is left on the tracker to explain later.
-- **Routing stops**: reported in the run's own report, naming the item, the reason
+- **Routing stops**: reported in the run's own report under the recognized
+  stop-condition name `missing_tracker_context`, naming the item, the reason
   (classification not valid in framework mode), and the re-classification that
   unblocks it.
+- **Held scan candidates**: when a portfolio scan rather than a single-item run
+  meets the misclassified item, the same three pieces of information appear in the
+  scan's report of evaluated candidates it did not propose. The scan continues and
+  its proposal is unaffected apart from that item's absence.
+- **Unavailable framework-item lookup**: when the lookup cannot be performed, the
+  flow that asked for it says so in its own output, with the reason, at the point
+  where the list would otherwise have appeared. This is a report, not a stop.
 - **No new audit trail**: this feature records no events, writes no logs, and
-  posts no tracker comments beyond the two reports above. It has no background or
+  posts no tracker comments beyond the reports above. It has no background or
   scheduled behavior.
 - **No misclassification scan**: nothing in this feature sweeps the board looking
   for misclassified items; a problem surfaces only when an item is created or
@@ -332,6 +383,8 @@ item's class into a pipeline — so the gate is enumerated here.
 | Repository mode | Framework mode / consumer repository | The repository's own workflow configuration declaration that it is the framework template |
 | Item classification | Feature / Bug / Refactor / Workflow / unset | The project board's classification field for the item |
 | Item stage | Still awaiting a pipeline (Backlog) / already on a pipeline | The item's board status, reconciled against work already completed for it, exactly as routing reconciles a stale status today |
+| Routing caller | A single-item run, where the operator named this one item / a portfolio scan, where many items are evaluated together to build a proposed start batch | Which command is asking — the single-item runner or the portfolio scan |
+| Framework-item lookup result | Items found / no open items on the board / lookup could not be performed | The tracker read itself, including whether it completed |
 
 ### Triggers
 
@@ -352,7 +405,8 @@ either mode.
 | Framework | Feature | Route: full pipeline | Unchanged — start the spec stage |
 | Framework | Bug | Route: fast track, subject to the existing scope check | Unchanged — run the existing gate |
 | Framework | Refactor | Route: plan-only | Unchanged — start the plan stage |
-| Framework | Workflow | Misclassified | Stop; report the item and ask for re-classification. Do not infer a pipeline |
+| Framework | Workflow, reached by a single-item run | Misclassified | Stop this item's run under `missing_tracker_context`; report the item and ask for re-classification. Do not infer a pipeline |
+| Framework | Workflow, reached as one item among many in a portfolio scan | Misclassified — that item only | Hold that item and report it among the scan's evaluated-but-not-proposed candidates, with the reason and the re-classification that unblocks it. Continue evaluating every other item and still propose the largest safe batch of valid ones. Do not terminate the scan, and do not stop the whole scan under a stop condition |
 | Framework | Unset | Unchanged from today | Unchanged — this feature does not add behavior for an absent class |
 | Consumer | Feature / Bug / Refactor | Route as today | Unchanged |
 | Consumer | Workflow | Route as today — infer the path from the brief, stop if unclear | Unchanged |
@@ -370,11 +424,12 @@ Creation-time outcomes:
 
 Framework-item lookup outcomes:
 
-| Mode | Board contents | Outcome | Required next action |
-| ---- | -------------- | ------- | -------------------- |
-| Framework | At least one open item | Every open board item, whatever its class | Unchanged — the flow reviews the list as today |
-| Framework | No open items | Empty, and empty only because the board is empty | Unchanged — an empty board is a legitimate answer |
-| Consumer | Any | Only items classified Workflow, as today | Unchanged |
+| Mode | Lookup result | Outcome | Required next action |
+| ---- | ------------- | ------- | -------------------- |
+| Framework | Lookup completed; at least one open item on the board | Every open board item, whatever its class | Unchanged — the flow reviews the list as today |
+| Framework | Lookup completed; no open items on the board | Empty, and empty only because the board is empty — reported as an empty board, distinguishably from an unavailable lookup | Unchanged — an empty board is a legitimate answer |
+| Consumer | Lookup completed | Only items classified Workflow, as today | Unchanged |
+| Either | Lookup could not be performed — the tracker was unreachable, the board or its classification field could not be read, or the configured tracker does not support this lookup | Unavailable. Reported as unavailable, with the reason, in place of a list. Never reported as an empty result, and never silently treated as one | Do not block the flow: the release run and the retrospective both continue. State in the flow's own output that the lookup was not performed and why. Do not record the review or de-duplication it feeds as satisfied — a release must not claim it checked for open framework bugs, and a retrospective must not record a finding as having no related item, on the strength of an unavailable lookup |
 
 ### Mirror surfaces
 
@@ -383,9 +438,10 @@ Framework-item lookup outcomes:
 | Backlog-creation protocol (classification step and its inference table) | States the framework-mode rule; its worked examples do not show a class that framework mode refuses |
 | Repository agent-guidance file, and its per-runner mirrors | States the framework-mode rule in the same words as the canonical copy |
 | Tracker integration guide (classification field table and the Workflow entry) | States that the Workflow option remains on the board but is not valid in framework mode |
-| Every Backlog routing table that turns a class into a pipeline — the single-item routing table and the portfolio batch-proposal table alike | The framework-mode Workflow row reads as misclassified-and-stop, not infer-the-path, in each of them |
+| Every Backlog routing table that turns a class into a pipeline — the single-item routing table and the portfolio batch-proposal table alike | The framework-mode Workflow row reads as misclassified in each of them, never as infer-the-path: stop the run in the single-item table, hold-and-report the item in the portfolio table |
+| The portfolio scan's report categories | The category for evaluated candidates excluded from the proposal admits a misclassified item as a hold reason, so a held item is surfaced with its reason rather than dropped from the report |
 | Retrospective flows that create an item and set its class | Do not direct a framework-mode repository to set a class it refuses |
-| Release and retrospective framework-item lookups | Describe the lookup's framework-mode meaning as every open board item |
+| Release and retrospective framework-item lookups | Describe the lookup's framework-mode meaning as every open board item, and describe what the flow does when the lookup cannot be performed — report it as unavailable and continue, rather than reading it as no open items |
 
 ### Examples
 
@@ -394,8 +450,19 @@ Framework-item lookup outcomes:
   The agent re-files it as a Bug, and it routes exactly as any Bug does today —
   to the fast-track path when the existing scope check allows it.
 - A framework-mode repository is asked to advance an existing Backlog item that
-  was filed months ago as Workflow. The runner stops, names the item, and asks for
-  re-classification. Nothing about the item changes until an operator acts.
+  was filed months ago as Workflow. The runner stops under
+  `missing_tracker_context`, names the item, and asks for re-classification.
+  Nothing about the item changes until an operator acts.
+- A framework-mode portfolio scan evaluates ten Backlog items. Three are still
+  classified Workflow; the other seven are Features, Bugs, and Refactors. The
+  three are held and reported with their reason and the re-classification that
+  unblocks them. The other seven are assessed exactly as they would have been, and
+  the valid ones are proposed as a start batch. The scan does not stop, and no
+  valid item is withheld because a different item was misclassified.
+- A framework-mode release run asks for open framework items and the tracker read
+  fails. The run reports that the lookup could not be performed, and why, instead
+  of reporting that no framework items are open. The release is not blocked, but
+  its output does not claim the open-script-bug review was done.
 - A consumer repository files "the retrospective script drops the last finding"
   and asks for Workflow. The item is created as Workflow, and routing infers its
   path from the brief exactly as it does today.
@@ -476,6 +543,16 @@ silently dropped.
 - [ ] With at least one open item on the board, the framework-mode lookup never
       returns an empty result on the grounds that no item carries the Workflow
       class.
+- [ ] When the lookup cannot be performed at all, the release flow and the
+      retrospective flow each report it as unavailable, with the reason, rather
+      than reporting that there are no open framework items.
+- [ ] An operator reading either flow's output can tell "no open framework items
+      on the board" apart from "the lookup could not be performed" without
+      inspecting the tracker themselves.
+- [ ] An unavailable lookup does not stop the release flow or the retrospective
+      flow, and neither flow records the check it feeds — the open-script-bug
+      review, or matching a finding against already-filed items — as satisfied on
+      the strength of an unavailable result.
 
 ### Routing stops instead of guessing
 
@@ -492,6 +569,17 @@ silently dropped.
 - [ ] In framework mode, an item classified Workflow whose pipeline has already
       started continues on that pipeline — the misclassification stop does not
       fire, and the run proceeds exactly as it did before this feature.
+- [ ] In framework mode, when a portfolio scan rather than a single-item run
+      evaluates a Backlog item classified Workflow, the scan holds only that
+      item — reporting it, with the reason and the re-classification that
+      unblocks it, in the scan's category for evaluated candidates excluded
+      from the proposal — and does not stop the scan itself under any stop
+      condition.
+- [ ] In that same scan, every other evaluated Backlog item is assessed exactly
+      as it would be without the misclassified item present, and the scan still
+      proposes the largest safe batch of valid items; no valid item is withheld
+      from the proposal because a different item in the same scan was
+      misclassified.
 
 ### Guidance surfaces agree
 

--- a/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
+++ b/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
@@ -268,10 +268,13 @@ The agent was never instructed toward a class the same repository refuses.
   mode, and keeps its class-filtered meaning in a consumer repository. It must
   never report an empty result as a consequence of the classification rule
   itself.
-- Every workflow surface that tells an agent how to classify an item, or tells an
-  agent to set a class on an item, states the framework-mode rule and the
-  consumer rule consistently. No surface may instruct an agent to produce a class
-  the same repository refuses.
+- Every workflow surface that *explains* how to classify an item states the
+  framework-mode rule and the consumer rule consistently, so a reader in either
+  mode is not misled by the rule for the other.
+- Every workflow surface that *instructs* an agent to set a class on an item it
+  just created must never direct a framework-mode repository toward a class that
+  same repository refuses. Such a surface is not required to restate both rules;
+  it is required not to produce the refused class.
 - This feature changes no routing behavior for Feature, Bug, or Refactor items,
   in either mode.
 
@@ -309,8 +312,11 @@ Work-item classification values, and what each means in each mode:
 - **No new audit trail**: this feature records no events, writes no logs, and
   posts no tracker comments beyond the two reports above. It has no background or
   scheduled behavior.
-- **No board scanning**: nothing in this feature inspects the board looking for
-  misclassified items; problems surface when an item is created or routed.
+- **No misclassification scan**: nothing in this feature sweeps the board looking
+  for misclassified items; a problem surfaces only when an item is created or
+  routed. The framework-item lookup does read the open items on the board, but
+  that is an existing read serving the release and retrospective flows, not a new
+  scan for misclassification.
 
 ---
 
@@ -325,7 +331,7 @@ item's class into a pipeline — so the gate is enumerated here.
 | ----- | ------ | ------ |
 | Repository mode | Framework mode / consumer repository | The repository's own workflow configuration declaration that it is the framework template |
 | Item classification | Feature / Bug / Refactor / Workflow / unset | The project board's classification field for the item |
-| Item stage | Backlog / past Backlog | The item's board status |
+| Item stage | Still awaiting a pipeline (Backlog) / already on a pipeline | The item's board status, reconciled against work already completed for it, exactly as routing reconciles a stale status today |
 
 ### Triggers
 
@@ -337,6 +343,10 @@ item's class into a pipeline — so the gate is enumerated here.
 
 ### Allowed outcomes and required next actions
 
+Routing outcomes. Every row except the last describes an item still awaiting a
+pipeline; an item already on a pipeline is not re-evaluated by this gate in
+either mode.
+
 | Mode | Classification | Outcome | Required next action |
 | ---- | -------------- | ------- | -------------------- |
 | Framework | Feature | Route: full pipeline | Unchanged — start the spec stage |
@@ -347,14 +357,23 @@ item's class into a pipeline — so the gate is enumerated here.
 | Consumer | Feature / Bug / Refactor | Route as today | Unchanged |
 | Consumer | Workflow | Route as today — infer the path from the brief, stop if unclear | Unchanged |
 | Consumer | Unset | Unchanged from today | Unchanged |
+| Either | Any class, item already on a pipeline | Not re-evaluated | Unchanged — the item continues on the pipeline it started; re-deciding it mid-flight is out of scope |
 
 Creation-time outcomes:
 
-| Mode | Requested class | Outcome |
-| ---- | --------------- | ------- |
-| Framework | Workflow | Refused before creation, with the valid classes named |
-| Framework | Feature / Bug / Refactor | Created as today |
-| Consumer | Any class | Created as today |
+| Mode | Requested class | Outcome | Required next action |
+| ---- | --------------- | ------- | -------------------- |
+| Framework | Workflow | Refused before creation, with the valid classes named | Re-run the request with Feature, Bug, or Refactor |
+| Framework | Feature / Bug / Refactor | Created as today | Unchanged |
+| Consumer | Any class | Created as today | Unchanged |
+
+Framework-item lookup outcomes:
+
+| Mode | Board contents | Outcome | Required next action |
+| ---- | -------------- | ------- | -------------------- |
+| Framework | At least one open item | Every open board item, whatever its class | Unchanged — the flow reviews the list as today |
+| Framework | No open items | Empty, and empty only because the board is empty | Unchanged — an empty board is a legitimate answer |
+| Consumer | Any | Only items classified Workflow, as today | Unchanged |
 
 ### Mirror surfaces
 
@@ -371,7 +390,8 @@ Creation-time outcomes:
 
 - A framework-mode repository files "reviewer loop times out on large diffs" and
   asks for Workflow. The command refuses and names Feature, Bug, and Refactor.
-  The agent re-files it as a Bug, and it routes to the fast-track path.
+  The agent re-files it as a Bug, and it routes exactly as any Bug does today —
+  to the fast-track path when the existing scope check allows it.
 - A framework-mode repository is asked to advance an existing Backlog item that
   was filed months ago as Workflow. The runner stops, names the item, and asks for
   re-classification. Nothing about the item changes until an operator acts.
@@ -381,21 +401,30 @@ Creation-time outcomes:
 - A framework-mode release run asks for open framework items and receives every
   open board item, so a known open script bug affecting the release is still
   caught.
+- A framework-mode item classified Workflow is already past Backlog — its spec is
+  merged and implementation is under way. The runner continues that pipeline. The
+  misclassification stop does not fire, because the pipeline was already chosen.
 
-### Issue-objective traceability
+---
 
-| Brief objective | Disposition |
-| --------------- | ----------- |
-| Creation command refuses the Workflow class in framework mode, with a clear actionable message, and creates no item | *Creating an item in framework mode* |
-| The same invocation still succeeds when the repository is not the framework template | *Consumer repositories are unchanged* |
-| Framework-item lookup means all open board items in framework mode, and keeps its filtered behavior otherwise | *Open framework items stay discoverable* |
-| Backlog-creation protocol, routing protocol, agent-guidance file, and tracker integration guide state the rule consistently | *Guidance surfaces agree* |
-| Routing no longer infers a path for a framework-mode Workflow item | *Routing stops instead of guessing* |
-| Reuse the existing framework-template declaration as the gate rather than adding a switch | *Consumer repositories are unchanged*; Business Rules |
-| Keep the Workflow option on the board's class field | Out of Scope, item 1; Business Rules |
-| No board-scanning CI check | Out of Scope, item 2 |
-| Do not backfill the existing misclassified items | Out of Scope, item 3 |
-| Splitting the two meanings into a separate area field or label | Out of Scope, item 4 — considered and rejected in the brief |
+## Issue-objective Traceability
+
+Every discrete requirement in the brief maps to an acceptance-criteria group
+(named in italics) or to an explicit out-of-scope entry. Nothing in the brief is
+silently dropped.
+
+| Brief objective | Where it comes from in the brief | Disposition |
+| --------------- | -------------------------------- | ----------- |
+| Creation command refuses the Workflow class in framework mode, with a clear actionable message, and creates no item | Acceptance criterion 1; enforcement point 1 | *Creating an item in framework mode* |
+| The same invocation still succeeds when the repository is not the framework template | Acceptance criterion 2 | *Consumer repositories are unchanged* |
+| Framework-item lookup means all open board items in framework mode, and keeps its filtered behavior otherwise | Acceptance criterion 3; required companion change | *Open framework items stay discoverable* |
+| Backlog-creation protocol, routing protocol, agent-guidance file, and tracker integration guide state the rule consistently | Acceptance criterion 4; enforcement point 2 | *Guidance surfaces agree* |
+| Routing no longer infers a path for a framework-mode Workflow item | Acceptance criterion 5; enforcement point 3 | *Routing stops instead of guessing* |
+| Reuse the existing framework-template declaration as the gate rather than adding a switch | Proposed approach | *Consumer repositories are unchanged*; Business Rules |
+| Keep the Workflow option on the board's class field | Out of scope, first bullet | Out of Scope, item 1; Business Rules |
+| No board-scanning CI check | Out of scope, second bullet | Out of Scope, item 2 |
+| Do not backfill the existing misclassified items | Out of scope, third bullet | Out of Scope, item 3 |
+| Splitting the two meanings into a separate area field or label | Alternative considered and rejected | Out of Scope, item 4 — recorded as rejected, not revived |
 
 ---
 
@@ -457,6 +486,9 @@ Creation-time outcomes:
       its board status.
 - [ ] Re-classifying the item as Feature, Bug, or Refactor and re-running it
       routes it to the corresponding pipeline with no further intervention.
+- [ ] In framework mode, an item classified Workflow whose pipeline has already
+      started continues on that pipeline — the misclassification stop does not
+      fire, and the run proceeds exactly as it did before this feature.
 
 ### Guidance surfaces agree
 
@@ -491,6 +523,12 @@ Creation-time outcomes:
 3. **Re-classifying the items already filed with the Workflow class.** Tracked
    separately as #1584, which depends on this landing first so re-typed items are
    not pulled back by guidance that still recommends the old class.
+   **Accepted consequence**: until #1584 lands, the routing stop described above
+   is expected to fire on most of the open Backlog — on the order of the 57
+   Workflow-classed items measured on 2026-08-23. The cost is visible, per item,
+   and cleared by re-classifying that item on the board before re-running it; no
+   item is lost or altered. This spec accepts that cost in exchange for restoring
+   the routing meaning, and it applies only to items still in Backlog.
 4. **Splitting the two meanings into separate fields.** Keeping the class field
    routing-only and moving the framework-versus-product distinction to its own
    field or label is the more principled model, and it was considered and

--- a/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
+++ b/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
@@ -338,7 +338,7 @@ item's class into a pipeline — so the gate is enumerated here.
 | Trigger | Gate evaluated |
 | ------- | -------------- |
 | An agent asks the creation command to file an item with a class | Creation-time class validity |
-| A runner is asked to advance an item | Routing classification |
+| A runner is asked to advance an item, or a portfolio scan proposes a Backlog item to start | Routing classification |
 | A release or retrospective flow asks for open framework items | Framework-item lookup meaning |
 
 ### Allowed outcomes and required next actions
@@ -383,7 +383,7 @@ Framework-item lookup outcomes:
 | Backlog-creation protocol (classification step and its inference table) | States the framework-mode rule; its worked examples do not show a class that framework mode refuses |
 | Repository agent-guidance file, and its per-runner mirrors | States the framework-mode rule in the same words as the canonical copy |
 | Tracker integration guide (classification field table and the Workflow entry) | States that the Workflow option remains on the board but is not valid in framework mode |
-| Routing protocol's Backlog table | Framework-mode Workflow row reads as misclassified-and-stop, not infer-the-path |
+| Every Backlog routing table that turns a class into a pipeline — the single-item routing table and the portfolio batch-proposal table alike | The framework-mode Workflow row reads as misclassified-and-stop, not infer-the-path, in each of them |
 | Retrospective flows that create an item and set its class | Do not direct a framework-mode repository to set a class it refuses |
 | Release and retrospective framework-item lookups | Describe the lookup's framework-mode meaning as every open board item |
 
@@ -486,7 +486,9 @@ silently dropped.
 - [ ] The run starts no pipeline for that item and changes neither its class nor
       its board status.
 - [ ] Re-classifying the item as Feature, Bug, or Refactor and re-running it
-      routes it to the corresponding pipeline with no further intervention.
+      routes the item exactly as that class routes today, with no additional
+      step introduced by this feature — a re-classified Bug still passes
+      through the existing scope check before it reaches the fast-track path.
 - [ ] In framework mode, an item classified Workflow whose pipeline has already
       started continues on that pipeline — the misclassification stop does not
       fire, and the run proceeds exactly as it did before this feature.
@@ -500,8 +502,10 @@ silently dropped.
       every per-runner mirror of that text says the same thing.
 - [ ] The tracker integration guide states that the Workflow option remains on the
       board but is not valid in framework mode.
-- [ ] The routing protocol's Backlog table describes a framework-mode Workflow
-      item as misclassified rather than as an item whose path is inferred.
+- [ ] Every Backlog routing table that turns a class into a pipeline — the
+      single-item routing table and the portfolio batch-proposal table alike —
+      describes a framework-mode Workflow item as misclassified rather than as
+      an item whose path is inferred.
 - [ ] The release-preparation flow and the retrospective flow each describe the
       open-framework-item lookup's framework-mode meaning as every open board
       item, so a reader of either flow is not left expecting a class-filtered

--- a/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
+++ b/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
@@ -1,0 +1,506 @@
+# Framework-Mode Work-Item Classification — Spec
+
+---
+
+## Overview
+
+The work-item classification field on the project board carries two unrelated
+meanings at the same time. Three of its values — Feature, Bug, and Refactor —
+say which pipeline an item takes. The fourth, Workflow, says nothing about the
+pipeline; it says the item is AI-development-framework, process, or tooling work
+rather than product work. In a repository that builds a product, those two
+meanings coexist quietly because framework work is rare. In this repository
+every item is framework work, so the second meaning wins on every item and the
+routing meaning disappears.
+
+That is not agent drift. The workflow's own guidance tells agents to classify
+framework, process, and tooling work as Workflow, and every item here qualifies,
+so agents follow the documented rule correctly and produce a board that cannot
+be routed. Measured on 2026-08-23, 57 of 63 open Backlog items were classified
+Workflow — and Workflow is the one class for which the routing rules give no
+deterministic next action, only "infer the path, or stop and ask a human".
+
+This feature makes the classification field mean one thing in a repository that
+declares itself the framework template. In that repository — **framework mode** —
+Workflow is not a valid class, and every item is a Feature, a Bug, or a Refactor
+*of the framework itself*. The declaration that turns this on already exists and
+already means "this repository is the framework"; no new switch is introduced.
+Repositories that do not make that declaration are **consumer repositories**, and
+nothing about them changes: they keep all four classes, keep using Workflow for
+framework work, and observe no difference in any command, message, or routing
+decision.
+
+---
+
+## Use Cases
+
+### Use Case 1: An agent files a backlog item in framework mode
+
+**Actor**: A backlog agent — the agent or operator creating a work item through
+the workflow's backlog-creation command.
+**Preconditions**: The repository is in framework mode. The agent has decided the
+item is framework, process, or tooling work and is about to classify it Workflow.
+
+**Steps**:
+
+1. The agent runs the backlog-creation command and asks for the Workflow class.
+2. The command recognizes that this repository is in framework mode.
+3. The command refuses the request and explains why.
+
+**Postconditions**: No work item exists. Nothing was created on the tracker,
+nothing was added to the board, and no field was set. The agent can immediately
+re-run the same request with a valid class.
+
+**Information shown**:
+
+- That Workflow is not a valid class in a framework-mode repository.
+- The classes that are valid here — Feature, Bug, and Refactor.
+- That in this repository those words describe the framework itself, so the item
+  should be classified by the pipeline it needs rather than by the fact that it
+  is framework work.
+
+**Actions available**:
+
+- Re-run the request with Feature, Bug, or Refactor.
+- Nothing else is required. There is no confirmation prompt, no override flag,
+  and no way to force the rejected class through this path.
+
+**Considerations**:
+
+- The refusal happens before the item is created, not after. A half-created item
+  that the agent then has to clean up would be worse than the problem being
+  fixed.
+- The refusal is not advice the agent can read and ignore; the command does not
+  proceed.
+- An item filed without any class is out of this feature's scope to reject — the
+  absence of a class is a pre-existing gap, not something this rule introduces.
+
+---
+
+### Use Case 2: An agent files a backlog item in a consumer repository
+
+**Actor**: A backlog agent working in a repository that consumes this framework
+rather than being it.
+**Preconditions**: The repository does not declare itself the framework template
+— the declaration is absent, or present and false. The agent is filing framework,
+process, or tooling work and classifies it Workflow.
+
+**Steps**:
+
+1. The agent runs the backlog-creation command and asks for the Workflow class.
+2. The command finds no framework-mode declaration.
+3. The command creates the item and classifies it Workflow, exactly as it does
+   today.
+
+**Postconditions**: The item exists with the Workflow class. The consumer
+repository's board, routing, release checks, and retrospectives behave exactly as
+they did before this feature.
+
+**Information shown**:
+
+- The same output the command produces today. No new warning, note, or nudge
+  about framework mode appears.
+
+**Considerations**:
+
+- This is the default. A repository that says nothing about being a template is a
+  consumer repository.
+- A declaration whose value is not recognizable as an affirmative is also a
+  consumer repository. Ambiguity resolves toward the behavior that changes
+  nothing.
+- The reserved meaning of Workflow for consumer repositories is unchanged and
+  still recommended there: product work is Feature or Bug, framework work is
+  Workflow.
+
+---
+
+### Use Case 3: The Work Item Runner meets a misclassified Backlog item
+
+**Actor**: The Work Item Runner, and the operator who reads the run's report.
+**Preconditions**: The repository is in framework mode. A Backlog item carries the
+Workflow class — typically one filed before this rule existed. The runner has been
+asked to advance it.
+
+**Steps**:
+
+1. The runner reads the item's class to decide which pipeline it takes.
+2. It finds the Workflow class, which framework mode does not accept.
+3. It treats the item as misclassified and stops, rather than inferring a path
+   from the brief.
+
+**Postconditions**: The item is untouched — its class, its board status, and its
+branches and pull requests are exactly as they were. No pipeline was started.
+
+**Information shown**:
+
+- The item, named.
+- That its class is not valid in a framework-mode repository, and that this is a
+  classification problem rather than a problem with the brief.
+- The valid classes, and that re-classifying the item is what unblocks it.
+
+**Actions available**:
+
+- Re-classify the item on the board as Feature, Bug, or Refactor, then re-run it.
+
+**Considerations**:
+
+- Stopping is the point. Before this feature the runner was allowed to guess the
+  path from the brief and only stop when the brief was unclear; a guess that
+  lands on the wrong pipeline is more expensive to undo than a stop.
+- Until the pre-existing items are re-classified, this stop is expected to fire
+  on most of the open Backlog. That is a visible, per-item, immediately
+  actionable cost, and it is the trade this feature accepts in exchange for
+  restoring the routing meaning. The bulk re-classification is separate work.
+- Items already past Backlog are unaffected. Their pipeline was chosen when they
+  started, and re-deciding it mid-flight would be a regression, so the
+  misclassification stop applies only where classification is the routing input.
+
+---
+
+### Use Case 4: A release or retrospective run looks for open framework items
+
+**Actor**: The agent running the release-preparation flow, and the agent running
+the retrospective flow.
+**Preconditions**: The repository is in framework mode. Both flows include a step
+that asks the tracker for the open framework-tooling items, so that known script
+bugs can be reviewed before a release and so that retrospective findings can be
+matched against work that is already filed.
+
+**Steps**:
+
+1. The flow asks for the open framework items.
+2. Because the repository is in framework mode — where every item is framework
+   work — the answer is every open item on the board.
+3. The flow reviews that list as it does today.
+
+**Postconditions**: The release check and the retrospective de-duplication both
+see a complete list. Neither reports "no open framework items" merely because the
+repository stopped using the Workflow class.
+
+**Information shown**:
+
+- The open items, in the same shape and detail as today.
+
+**Considerations**:
+
+- This is the part of the change that must not be skipped. If the repository stops
+  using Workflow and this lookup keeps filtering on it, both flows quietly return
+  nothing — a release stops catching known open script bugs, and every
+  retrospective finding looks new. A visible problem would be traded for a silent
+  one.
+- In a consumer repository the lookup keeps its current meaning and still filters
+  to the Workflow class, because there the distinction between framework work and
+  product work is real.
+- Returning nothing remains a legitimate answer when the board genuinely has no
+  open items. The requirement is that emptiness reflects the board, not the
+  classification rule.
+
+---
+
+### Use Case 5: An agent consults the classification guidance
+
+**Actor**: Any workflow agent deciding how to classify an item, reading the
+workflow's guidance before acting.
+**Preconditions**: The agent is working in a framework-mode repository and is
+about to choose a class.
+
+**Steps**:
+
+1. The agent reads the classification guidance on whichever surface it reached
+   first — the backlog-creation protocol, the repository's agent guidance file,
+   the tracker integration guide, or the routing protocol.
+2. Every one of those surfaces states the framework-mode rule.
+3. The agent chooses Feature, Bug, or Refactor.
+
+**Postconditions**: The agent's choice matches what the creation command accepts.
+The agent was never instructed toward a class the same repository refuses.
+
+**Information shown**:
+
+- The framework-mode rule: in a repository that declares itself the framework
+  template, Workflow is not a valid class and every item is a Feature, Bug, or
+  Refactor of the framework.
+- The consumer-repository rule, unchanged and still stated, so a reader of the
+  shared guidance is not left thinking the framework-mode rule applies to them.
+
+**Considerations**:
+
+- The original problem was created by correct agents following correct-looking
+  guidance. Leaving any surface stating the old rule reproduces it.
+- Guidance that is mirrored across runner-specific copies has to agree with the
+  canonical copy, or the rule an agent sees depends on which runner it is.
+- Surfaces that instruct an agent to *set* the Workflow class on an item it just
+  created count as guidance for this purpose, not just surfaces that describe the
+  field.
+
+---
+
+## Business Rules
+
+- A repository is in **framework mode** when it declares in its workflow
+  configuration that it is the framework template. This is the same existing
+  declaration that already gates the template-fit check and the template-specific
+  setup step; no new configuration is introduced.
+- A repository is a **consumer repository** when that declaration is absent,
+  false, or not recognizable as an affirmative. Consumer behavior is the default
+  and is unchanged by this feature in every respect.
+- In framework mode the valid classes are Feature, Bug, and Refactor, and they
+  describe the framework itself: a defect in the framework is a Bug, a new
+  framework capability is a Feature, and restructuring the framework without
+  changing its behavior is a Refactor.
+- In framework mode the Workflow class is not valid. It carries no routing
+  meaning there, because the distinction it draws — framework work versus product
+  work — is true of every item.
+- The Workflow option is not removed from the board's class field. It stays, so
+  historical items keep a readable classification and consumer boards that share
+  the field definition are untouched. The rule is enforced when a class is
+  written, not by deleting the option.
+- Rejection is complete: when the creation command refuses a class, no item is
+  created, no board entry is added, and no field is set.
+- A rejection message names the invalid class, names the valid classes, and is
+  enough on its own for the agent to retry correctly. It is never a bare failure.
+- In framework mode a Backlog item carrying the Workflow class is misclassified.
+  Routing stops and asks for re-classification instead of inferring a pipeline
+  from the brief.
+- The routing stop applies to items whose pipeline has not yet been chosen. An
+  item already past Backlog keeps the pipeline it started on.
+- The lookup for open framework items means every open board item in framework
+  mode, and keeps its class-filtered meaning in a consumer repository. It must
+  never report an empty result as a consequence of the classification rule
+  itself.
+- Every workflow surface that tells an agent how to classify an item, or tells an
+  agent to set a class on an item, states the framework-mode rule and the
+  consumer rule consistently. No surface may instruct an agent to produce a class
+  the same repository refuses.
+- This feature changes no routing behavior for Feature, Bug, or Refactor items,
+  in either mode.
+
+---
+
+## Statuses / Enum Values
+
+Work-item classification values, and what each means in each mode:
+
+| Code value | Display label | Meaning in a consumer repository | Meaning in framework mode |
+| ---------- | ------------- | -------------------------------- | ------------------------- |
+| `Feature`  | Feature       | Product capability; full pipeline — spec, plan, implementation | Framework capability; same full pipeline |
+| `Bug`      | Bug           | Product defect; fast-track fix path when the scope check allows | Framework defect; same fast-track path |
+| `Refactor` | Refactor      | Restructuring without behavior change; plan-only path | Framework restructuring; same plan-only path |
+| `Workflow` | Workflow      | AI-development-framework, process, or tooling work; pipeline inferred from the brief | Not valid — rejected on creation, treated as misclassified on routing |
+
+**Valid transitions**:
+
+- Any class → any other class, by an operator editing the board. This feature adds
+  no transition restrictions; it constrains only which values may be written
+  through the workflow's creation command and which values route.
+- Workflow → Feature, Bug, or Refactor is the re-classification an operator
+  performs to unblock a misclassified framework-mode item.
+
+---
+
+## Operational Visibility
+
+- **Creation refusals**: reported directly to whoever ran the creation command, at
+  the moment of the attempt, naming the invalid class and the valid ones. No item
+  is created, so nothing is left on the tracker to explain later.
+- **Routing stops**: reported in the run's own report, naming the item, the reason
+  (classification not valid in framework mode), and the re-classification that
+  unblocks it.
+- **No new audit trail**: this feature records no events, writes no logs, and
+  posts no tracker comments beyond the two reports above. It has no background or
+  scheduled behavior.
+- **No board scanning**: nothing in this feature inspects the board looking for
+  misclassified items; problems surface when an item is created or routed.
+
+---
+
+## Decision-Gate Consistency Matrix
+
+This feature modifies a workflow decision gate — the rule that turns a Backlog
+item's class into a pipeline — so the gate is enumerated here.
+
+### Gate inputs
+
+| Input | Values | Source |
+| ----- | ------ | ------ |
+| Repository mode | Framework mode / consumer repository | The repository's own workflow configuration declaration that it is the framework template |
+| Item classification | Feature / Bug / Refactor / Workflow / unset | The project board's classification field for the item |
+| Item stage | Backlog / past Backlog | The item's board status |
+
+### Triggers
+
+| Trigger | Gate evaluated |
+| ------- | -------------- |
+| An agent asks the creation command to file an item with a class | Creation-time class validity |
+| A runner is asked to advance a Backlog item | Routing classification |
+| A release or retrospective flow asks for open framework items | Framework-item lookup meaning |
+
+### Allowed outcomes and required next actions
+
+| Mode | Classification | Outcome | Required next action |
+| ---- | -------------- | ------- | -------------------- |
+| Framework | Feature | Route: full pipeline | Unchanged — start the spec stage |
+| Framework | Bug | Route: fast track, subject to the existing scope check | Unchanged — run the existing gate |
+| Framework | Refactor | Route: plan-only | Unchanged — start the plan stage |
+| Framework | Workflow | Misclassified | Stop; report the item and ask for re-classification. Do not infer a pipeline |
+| Framework | Unset | Unchanged from today | Unchanged — this feature does not add behavior for an absent class |
+| Consumer | Feature / Bug / Refactor | Route as today | Unchanged |
+| Consumer | Workflow | Route as today — infer the path from the brief, stop if unclear | Unchanged |
+| Consumer | Unset | Unchanged from today | Unchanged |
+
+Creation-time outcomes:
+
+| Mode | Requested class | Outcome |
+| ---- | --------------- | ------- |
+| Framework | Workflow | Refused before creation, with the valid classes named |
+| Framework | Feature / Bug / Refactor | Created as today |
+| Consumer | Any class | Created as today |
+
+### Mirror surfaces
+
+| Surface | Required alignment |
+| ------- | ------------------ |
+| Backlog-creation protocol (classification step and its inference table) | States the framework-mode rule; its worked examples do not show a class that framework mode refuses |
+| Repository agent-guidance file, and its per-runner mirrors | States the framework-mode rule in the same words as the canonical copy |
+| Tracker integration guide (classification field table and the Workflow entry) | States that the Workflow option remains on the board but is not valid in framework mode |
+| Routing protocol's Backlog table | Framework-mode Workflow row reads as misclassified-and-stop, not infer-the-path |
+| Retrospective flows that create an item and set its class | Do not direct a framework-mode repository to set a class it refuses |
+| Release and retrospective framework-item lookups | Describe the lookup's framework-mode meaning as every open board item |
+
+### Examples
+
+- A framework-mode repository files "reviewer loop times out on large diffs" and
+  asks for Workflow. The command refuses and names Feature, Bug, and Refactor.
+  The agent re-files it as a Bug, and it routes to the fast-track path.
+- A framework-mode repository is asked to advance an existing Backlog item that
+  was filed months ago as Workflow. The runner stops, names the item, and asks for
+  re-classification. Nothing about the item changes until an operator acts.
+- A consumer repository files "the retrospective script drops the last finding"
+  and asks for Workflow. The item is created as Workflow, and routing infers its
+  path from the brief exactly as it does today.
+- A framework-mode release run asks for open framework items and receives every
+  open board item, so a known open script bug affecting the release is still
+  caught.
+
+### Issue-objective traceability
+
+| Brief objective | Disposition |
+| --------------- | ----------- |
+| Creation command refuses the Workflow class in framework mode, with a clear actionable message, and creates no item | *Creating an item in framework mode* |
+| The same invocation still succeeds when the repository is not the framework template | *Consumer repositories are unchanged* |
+| Framework-item lookup means all open board items in framework mode, and keeps its filtered behavior otherwise | *Open framework items stay discoverable* |
+| Backlog-creation protocol, routing protocol, agent-guidance file, and tracker integration guide state the rule consistently | *Guidance surfaces agree* |
+| Routing no longer infers a path for a framework-mode Workflow item | *Routing stops instead of guessing* |
+| Reuse the existing framework-template declaration as the gate rather than adding a switch | *Consumer repositories are unchanged*; Business Rules |
+| Keep the Workflow option on the board's class field | Out of Scope, item 1; Business Rules |
+| No board-scanning CI check | Out of Scope, item 2 |
+| Do not backfill the existing misclassified items | Out of Scope, item 3 |
+| Splitting the two meanings into a separate area field or label | Out of Scope, item 4 — considered and rejected in the brief |
+
+---
+
+## Relationship to Other Work Items
+
+- The bulk re-classification of the already-filed misclassified items (#1584)
+  depends on this landing first, so that re-typed items are not pulled back
+  toward the old class by guidance that still recommends it. This spec does not
+  perform that re-classification.
+- The items sharing this batch (#1462, #1496, #1515, #1529, #1561) were assessed
+  as orthogonal to this one. Nothing here orders against them.
+
+---
+
+## Acceptance Criteria
+
+### Creating an item in framework mode
+
+- [ ] In a repository that declares itself the framework template, asking the
+      backlog-creation command to file an item with the Workflow class fails, and
+      no item is created on the tracker or added to the board.
+- [ ] The failure message names Workflow as invalid here and names Feature, Bug,
+      and Refactor as the valid classes, so the agent can retry without consulting
+      another document.
+- [ ] Re-running the same request with Feature, Bug, or Refactor succeeds and
+      produces an item classified as asked.
+- [ ] There is no flag, environment variable, or confirmation prompt through which
+      the creation command will accept the Workflow class in framework mode.
+
+### Consumer repositories are unchanged
+
+- [ ] In a repository whose framework-template declaration is absent, the same
+      request with the Workflow class succeeds and the item is classified
+      Workflow.
+- [ ] The same holds when the declaration is present and false, and when its value
+      is not recognizable as an affirmative.
+- [ ] A consumer repository's creation output for every class is identical to its
+      output before this feature — no added warning or note about framework mode.
+- [ ] A consumer repository's Backlog routing for every class, including Workflow,
+      is identical to its behavior before this feature.
+
+### Open framework items stay discoverable
+
+- [ ] In framework mode, the lookup used by the release flow and the retrospective
+      flow returns every open board item.
+- [ ] In a consumer repository, the same lookup returns only items classified
+      Workflow, as it does today.
+- [ ] With at least one open item on the board, the framework-mode lookup never
+      returns an empty result on the grounds that no item carries the Workflow
+      class.
+
+### Routing stops instead of guessing
+
+- [ ] In framework mode, asking a runner to advance a Backlog item classified
+      Workflow stops the run and reports the item as misclassified.
+- [ ] The stop names the item, states that its class is not valid in a
+      framework-mode repository, and names the re-classification that unblocks it.
+- [ ] The run starts no pipeline for that item and changes neither its class nor
+      its board status.
+- [ ] Re-classifying the item as Feature, Bug, or Refactor and re-running it
+      routes it to the corresponding pipeline with no further intervention.
+
+### Guidance surfaces agree
+
+- [ ] The backlog-creation protocol's classification step and its class-inference
+      table state the framework-mode rule, and no worked example in that protocol
+      shows a class framework mode refuses.
+- [ ] The repository's agent-guidance file states the framework-mode rule, and
+      every per-runner mirror of that text says the same thing.
+- [ ] The tracker integration guide states that the Workflow option remains on the
+      board but is not valid in framework mode.
+- [ ] The routing protocol's Backlog table describes a framework-mode Workflow
+      item as misclassified rather than as an item whose path is inferred.
+- [ ] No workflow surface directs an agent in a framework-mode repository to set
+      the Workflow class on an item, including the retrospective flows that create
+      an item and classify it.
+- [ ] Reading any one of these surfaces alone is enough to classify an item in a
+      way the creation command accepts.
+
+---
+
+## Out of Scope (MVP)
+
+1. **Removing the Workflow option from the board's classification field.** It
+   stays. Removing it would orphan the classification of historical items, and
+   consumer boards that share the field definition may legitimately still want
+   it. The rule is enforced when a class is written instead.
+2. **A scheduled or per-pull-request check that scans the board for misclassified
+   items.** This repository has repeatedly hit tracker API rate limits during
+   batch runs, and a repeated scan of a several-hundred-item board is a flaky
+   guard for a low-frequency problem. Refusing the class at creation time and
+   stopping at routing time is sufficient.
+3. **Re-classifying the items already filed with the Workflow class.** Tracked
+   separately as #1584, which depends on this landing first so re-typed items are
+   not pulled back by guidance that still recommends the old class.
+4. **Splitting the two meanings into separate fields.** Keeping the class field
+   routing-only and moving the framework-versus-product distinction to its own
+   field or label is the more principled model, and it was considered and
+   rejected in the brief: it is a breaking board change for every consumer that
+   already has the Workflow option, and it needs a migration and a
+   template-sync story to solve a problem the existing framework-template
+   declaration solves cheaply.
+5. **Changing how consumer repositories classify framework work.** They keep all
+   four classes and keep using Workflow for framework, process, and tooling work.
+6. **Changing the pipelines themselves.** Feature, Bug, and Refactor route exactly
+   as they do today, in both modes.
+7. **Rejecting or defaulting an item filed with no class at all.** The absent-class
+   case is a pre-existing gap that this feature neither worsens nor fixes.

--- a/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
+++ b/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
@@ -289,7 +289,7 @@ Work-item classification values, and what each means in each mode:
 | `Feature`  | Feature       | Product capability; full pipeline — spec, plan, implementation | Framework capability; same full pipeline |
 | `Bug`      | Bug           | Product defect; fast-track fix path when the scope check allows | Framework defect; same fast-track path |
 | `Refactor` | Refactor      | Restructuring without behavior change; plan-only path | Framework restructuring; same plan-only path |
-| `Workflow` | Workflow      | AI-development-framework, process, or tooling work; pipeline inferred from the brief | Not valid — rejected on creation, treated as misclassified on routing |
+| `Workflow` | Workflow      | AI-development-framework, process, or tooling work; pipeline inferred from the brief | Not valid — refused on creation, and treated as misclassified when routing an item still awaiting a pipeline |
 
 **Valid transitions**:
 
@@ -338,7 +338,7 @@ item's class into a pipeline — so the gate is enumerated here.
 | Trigger | Gate evaluated |
 | ------- | -------------- |
 | An agent asks the creation command to file an item with a class | Creation-time class validity |
-| A runner is asked to advance a Backlog item | Routing classification |
+| A runner is asked to advance an item | Routing classification |
 | A release or retrospective flow asks for open framework items | Framework-item lookup meaning |
 
 ### Allowed outcomes and required next actions
@@ -365,7 +365,8 @@ Creation-time outcomes:
 | ---- | --------------- | ------- | -------------------- |
 | Framework | Workflow | Refused before creation, with the valid classes named | Re-run the request with Feature, Bug, or Refactor |
 | Framework | Feature / Bug / Refactor | Created as today | Unchanged |
-| Consumer | Any class | Created as today | Unchanged |
+| Framework | Unset — no class requested | Created as today | Unchanged — this feature does not add behavior for an absent class |
+| Consumer | Any class, or none | Created as today | Unchanged |
 
 Framework-item lookup outcomes:
 
@@ -501,6 +502,10 @@ silently dropped.
       board but is not valid in framework mode.
 - [ ] The routing protocol's Backlog table describes a framework-mode Workflow
       item as misclassified rather than as an item whose path is inferred.
+- [ ] The release-preparation flow and the retrospective flow each describe the
+      open-framework-item lookup's framework-mode meaning as every open board
+      item, so a reader of either flow is not left expecting a class-filtered
+      result there.
 - [ ] No workflow surface directs an agent in a framework-mode repository to set
       the Workflow class on an item, including the retrospective flows that create
       an item and classify it.

--- a/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
+++ b/docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md
@@ -212,6 +212,11 @@ lookup could not be performed.
 - What the operator must never have to guess is which of the three answers they
   are looking at. "The board is empty" and "the lookup failed" produce the same
   empty list, so the distinction has to come from the report, not from the list.
+- This third answer is scoped to framework mode, the same as every other step in
+  this use case. A consumer repository's lookup failure is unaffected by this
+  feature and keeps its current behavior, even though that current behavior is
+  also an unlabeled empty result — fixing that is a pre-existing gap this
+  feature does not widen its scope to close.
 
 ---
 
@@ -304,13 +309,21 @@ The agent was never instructed toward a class the same repository refuses.
   mode, and keeps its class-filtered meaning in a consumer repository. It must
   never report an empty result as a consequence of the classification rule
   itself.
-- The lookup has three distinguishable answers: the items it found, an empty
-  result because the board holds no open items, and unavailable because the
-  lookup could not be performed. An unavailable lookup is reported as
+- In framework mode, the lookup has three distinguishable answers: the items it
+  found, an empty result because the board holds no open items, and unavailable
+  because the lookup could not be performed. An unavailable lookup is reported as
   unavailable, with the reason, and is never reported as an empty result. An
   unavailable lookup does not block the release or retrospective flow, but the
   flow must state that the lookup was not performed rather than record the
   review or the de-duplication it feeds as having been satisfied.
+- This distinguishable-unavailable requirement applies to framework mode only.
+  A consumer repository's lookup keeps its current failure behavior unchanged,
+  exactly like every other part of the lookup's consumer-mode meaning — this
+  feature does not touch how a consumer-repository lookup failure is reported,
+  even though today's failure behavior there is also a return of `[]`.
+  Widening the requirement to consumer mode would be new consumer-facing
+  behavior, which contradicts the guarantee that consumer repositories are
+  unaffected in every respect.
 - Every workflow surface that *explains* how to classify an item states the
   framework-mode rule and the consumer rule consistently, so a reader in either
   mode is not misled by the rule for the other.
@@ -357,9 +370,11 @@ Work-item classification values, and what each means in each mode:
   meets the misclassified item, the same three pieces of information appear in the
   scan's report of evaluated candidates it did not propose. The scan continues and
   its proposal is unaffected apart from that item's absence.
-- **Unavailable framework-item lookup**: when the lookup cannot be performed, the
-  flow that asked for it says so in its own output, with the reason, at the point
-  where the list would otherwise have appeared. This is a report, not a stop.
+- **Unavailable framework-item lookup**: in framework mode, when the lookup
+  cannot be performed, the flow that asked for it says so in its own output,
+  with the reason, at the point where the list would otherwise have appeared.
+  This is a report, not a stop. A consumer-repository lookup failure is
+  unaffected by this feature and keeps its current, unreported behavior.
 - **No new audit trail**: this feature records no events, writes no logs, and
   posts no tracker comments beyond the reports above. It has no background or
   scheduled behavior.
@@ -429,7 +444,8 @@ Framework-item lookup outcomes:
 | Framework | Lookup completed; at least one open item on the board | Every open board item, whatever its class | Unchanged — the flow reviews the list as today |
 | Framework | Lookup completed; no open items on the board | Empty, and empty only because the board is empty — reported as an empty board, distinguishably from an unavailable lookup | Unchanged — an empty board is a legitimate answer |
 | Consumer | Lookup completed | Only items classified Workflow, as today | Unchanged |
-| Either | Lookup could not be performed — the tracker was unreachable, the board or its classification field could not be read, or the configured tracker does not support this lookup | Unavailable. Reported as unavailable, with the reason, in place of a list. Never reported as an empty result, and never silently treated as one | Do not block the flow: the release run and the retrospective both continue. State in the flow's own output that the lookup was not performed and why. Do not record the review or de-duplication it feeds as satisfied — a release must not claim it checked for open framework bugs, and a retrospective must not record a finding as having no related item, on the strength of an unavailable lookup |
+| Framework | Lookup could not be performed — the tracker was unreachable, the board or its classification field could not be read, or the configured tracker does not support this lookup | Unavailable. Reported as unavailable, with the reason, in place of a list. Never reported as an empty result, and never silently treated as one | Do not block the flow: the release run and the retrospective both continue. State in the flow's own output that the lookup was not performed and why. Do not record the review or de-duplication it feeds as satisfied — a release must not claim it checked for open framework bugs, and a retrospective must not record a finding as having no related item, on the strength of an unavailable lookup |
+| Consumer | Lookup could not be performed | Unchanged from today — this feature does not alter how a consumer-repository lookup failure is handled, including today's return of an empty list on failure | Unchanged — out of scope for this feature |
 
 ### Mirror surfaces
 
@@ -441,7 +457,7 @@ Framework-item lookup outcomes:
 | Every Backlog routing table that turns a class into a pipeline — the single-item routing table and the portfolio batch-proposal table alike | The framework-mode Workflow row reads as misclassified in each of them, never as infer-the-path: stop the run in the single-item table, hold-and-report the item in the portfolio table |
 | The portfolio scan's report categories | The category for evaluated candidates excluded from the proposal admits a misclassified item as a hold reason, so a held item is surfaced with its reason rather than dropped from the report |
 | Retrospective flows that create an item and set its class | Do not direct a framework-mode repository to set a class it refuses |
-| Release and retrospective framework-item lookups | Describe the lookup's framework-mode meaning as every open board item, and describe what the flow does when the lookup cannot be performed — report it as unavailable and continue, rather than reading it as no open items |
+| Release and retrospective framework-item lookups | Describe the lookup's framework-mode meaning as every open board item, and describe what the flow does in framework mode when the lookup cannot be performed — report it as unavailable and continue, rather than reading it as no open items. Do not extend the unavailable-reporting requirement to the consumer-mode lookup, whose failure handling this feature leaves unchanged |
 
 ### Examples
 
@@ -543,16 +559,21 @@ silently dropped.
 - [ ] With at least one open item on the board, the framework-mode lookup never
       returns an empty result on the grounds that no item carries the Workflow
       class.
-- [ ] When the lookup cannot be performed at all, the release flow and the
-      retrospective flow each report it as unavailable, with the reason, rather
-      than reporting that there are no open framework items.
-- [ ] An operator reading either flow's output can tell "no open framework items
-      on the board" apart from "the lookup could not be performed" without
-      inspecting the tracker themselves.
-- [ ] An unavailable lookup does not stop the release flow or the retrospective
-      flow, and neither flow records the check it feeds — the open-script-bug
-      review, or matching a finding against already-filed items — as satisfied on
-      the strength of an unavailable result.
+- [ ] In framework mode, when the lookup cannot be performed at all, the
+      release flow and the retrospective flow each report it as unavailable,
+      with the reason, rather than reporting that there are no open framework
+      items.
+- [ ] In framework mode, an operator reading either flow's output can tell "no
+      open framework items on the board" apart from "the lookup could not be
+      performed" without inspecting the tracker themselves.
+- [ ] In framework mode, an unavailable lookup does not stop the release flow
+      or the retrospective flow, and neither flow records the check it feeds —
+      the open-script-bug review, or matching a finding against already-filed
+      items — as satisfied on the strength of an unavailable result.
+- [ ] A consumer repository's lookup failure behavior is unchanged by this
+      feature — the unavailable-versus-empty distinction required above applies
+      only in framework mode, and no new reporting requirement is introduced for
+      a consumer-repository lookup failure.
 
 ### Routing stops instead of guessing
 


### PR DESCRIPTION
Spec for #1583. The board's work-item classification field carries two unrelated meanings at once, and in this repository one of them destroys the other.

## Why

Three classification values — Feature, Bug, Refactor — say which pipeline an item takes. The fourth, Workflow, says nothing about the pipeline; it says "this is framework work, not product work". In a product repository those coexist because framework work is rare. Here every item is framework work, so the domain meaning wins on every item and the routing meaning disappears.

This is not agent drift. The workflow's own guidance instructs agents to classify framework/process/tooling work as Workflow, every item here qualifies, so agents follow the documented rule correctly and produce an unroutable board. Measured 2026-08-23: **57 of 63 open Backlog items** were classified Workflow — the one class for which the routing table gives no deterministic next action, only "infer the path from the brief, or stop and ask".

## What the spec requires

- **Framework mode** reuses the existing `template.is_template: true` declaration, which already means "this repository IS the framework" and already gates the Protocol 02 template-fit check. No new switch.
- In framework mode, Workflow is not a valid class. Every item is a Feature, Bug, or Refactor **of the framework itself**.
- The creation command refuses the class **before** the item exists, naming the valid classes — not a warning the agent can read past.
- Routing treats a framework-mode Workflow Backlog item as **misclassified** and stops for re-classification, rather than guess-routing it.
- The open-framework-item lookup consumed by the release and retrospective flows must mean **every open board item** in framework mode. Without this the change trades a visible problem for a silent one: releases stop catching known open script bugs and every retrospective finding looks new.
- Consumer repositories are **completely unaffected** — same classes, same messages, same routing. The declaration being absent, false, or unrecognizable all resolve to consumer behavior.

Spec file: [`docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md`](docs/specs/developments/20260911230727_1583-template-mode-type-routing/1_1583-template-mode-type-routing_specs.md)

`Refs #1583` rather than `Closes #1583`: this item runs the full pipeline, and this repository's spec pull requests for full-pipeline items reference the issue (PR #1723 for #1495) while the implementation pull request closes it.

Refs #1583

## Coverage Matrix summary

Full table is in the spec under *Issue-objective traceability*. Acceptance criteria are referenced by group heading, not by number, because numbers shift during review.

| Brief objective | Disposition |
| --- | --- |
| AC1 — creation refuses Workflow in framework mode, clear message, no issue created | *Creating an item in framework mode* |
| AC2 — same invocation still succeeds when `is_template` is false or absent | *Consumer repositories are unchanged* |
| AC3 — framework-item lookup returns all open board items in framework mode, filtered otherwise | *Open framework items stay discoverable* |
| AC4 — Protocol 00, Protocol 91, `CLAUDE.md`, `github-projects.md` state the rule consistently | *Guidance surfaces agree* |
| AC5 — Protocol 91's Backlog table no longer guess-routes a framework-mode Workflow item | *Routing stops instead of guessing* |
| Enforcement point 1 — `add-backlog-item.sh` rejects `--type Workflow` before issue creation | *Creating an item in framework mode* |
| Enforcement point 2 — documentation consistency across the three named surfaces | *Guidance surfaces agree* |
| Enforcement point 3 — Protocol 91 stops for re-classification | *Routing stops instead of guessing* |
| Required companion change — `list_open_workflow_type_issues` | *Open framework items stay discoverable* |
| Gate on the existing `template.is_template`, not a new switch | *Consumer repositories are unchanged*; Business Rules |
| Keep the Workflow option on the board's Type field | Out of Scope 1; Business Rules |
| No board-scanning CI check | Out of Scope 2 |
| Do not backfill the existing 57 items | Out of Scope 3 |
| Rejected alternative — separate `Area` field / `scope:framework` label | Out of Scope 4 |

### Deferral Notes

- **Out of Scope 1 — removing the Workflow option from the board's Type field.** The brief keeps it deliberately: removing it would orphan the classification of historical items, and consumer boards sharing the field definition may still want it. Enforced at write time instead. No human confirmation requested; the brief decides it.
- **Out of Scope 2 — a CI check that scans the board for misclassified items.** The brief records repeated tracker rate-limit failures during batch runs, making a repeated scan of a 500+ item board a flaky guard for a low-frequency problem. No human confirmation requested.
- **Out of Scope 3 — backfilling the 57 existing Workflow-typed items.** Tracked as #1584, which the brief states depends on this landing first so re-typed items are not pulled back by guidance that still recommends the old class. No human confirmation requested. **Known consequence, stated in the spec**: until #1584 lands, the new routing stop is expected to fire on most of the open Backlog. That is accepted as a visible, per-item, immediately actionable cost in exchange for restoring the routing axis.
- **Out of Scope 4 — splitting the two meanings into a separate field or label.** Considered and rejected in the brief: a breaking board change for every consumer that already has Workflow in its Type single-select, requiring a migration plus a sync-template story. Recorded as a rejected alternative, not resurrected as a recommendation. No human confirmation requested.
- Out of Scope items 5–7 (consumer classification conventions, the pipelines themselves, items filed with no class at all) are MVP boundary rather than brief objectives, and none appears in the brief.

### Documentation surfaces beyond the brief's four named ones

The brief names Protocol 00, Protocol 91, `CLAUDE.md`, and `github-projects.md`. While mapping them, two further surfaces were found that *instruct an agent to set* the Workflow class rather than merely describe the field: `06-retrospective-protocol.md` Step 5 and `06b-meta-retrospective-protocol.md`, both of which direct a new issue to be typed Workflow. In framework mode those would instruct an agent toward a class the same repository refuses — the exact failure mode this item exists to end. The spec therefore states the requirement as "no surface directs an agent to set a class the repository refuses" and names those flows as mirror surfaces. This is a derived consequence of AC4, not a scope expansion; flagging it here so a reviewer can reject it if read otherwise. The per-runner mirrors of the `CLAUDE.md` text (`.claude/agents/orchestrator.md`, `.cursor/agents/orchestrator.md`) are likewise covered.

Internal review added one further surface on the same reasoning: **two** Backlog routing tables in this repository turn a class into a pipeline, not one — `91-orchestrate-work-protocol.md` (single item) and `90-batch-orchestrate-work-protocol.md` (portfolio batch proposal). Both carry a `Backlog (Workflow)` row with the guess-routing text this feature eliminates. Enumerating only the first would have left the batch path still inferring a pipeline from the brief, contradicting the spec's own business rule. The mirror-surfaces table and AC5's criterion now cover every Backlog routing table rather than a single named protocol.

### Post-ready findings from `codex-github` (fixed at `d35d99de`)

After the PR left draft, `codex-github`'s ready-phase review returned three blocking findings, all inline comments on the Decision-Gate Consistency Matrix. All three are clarifications of existing AC3 (open framework items stay discoverable) and AC5 (routing stops instead of guessing) — no new brief objective is introduced, so the Coverage Matrix table above is unchanged; the traceability disposition groups those two AC headings already cover the fixes.

- **Lookup-failure outcome undefined**: the matrix said an empty framework-mode result occurs only when the board is empty, but `list_open_workflow_type_issues` also returns an empty list on a tracker error, unresolvable owner/project number, or unparseable response — indistinguishable from a genuinely empty board. Added a third, distinguishable "lookup could not be performed" answer throughout Use Case 4, Business Rules, the Framework-item lookup outcomes table, Operational Visibility, Mirror surfaces, Examples, and Acceptance Criteria: it is reported as unavailable with a reason, never disguised as an empty result, and never blocks the release or retrospective flow.
- **Mixed portfolio-scan behavior unspecified**: the matrix didn't say whether a misclassified item found during a `/run-work` scan holds only itself or terminates the whole scan — material because most of the existing Backlog is still Workflow-classed until #1584 lands. Specified that only the misclassified item is held and reported in the scan's existing `HELD - not included in proposed batch` category (Protocol 90 Step 5.2, "evaluated candidates excluded from the proposal"), while every other item is evaluated normally and the scan still proposes its largest safe batch. Added the caller-scoped gate-table row, a mirror-surfaces row for the scan's report categories, a worked example, and two new acceptance criteria under *Routing stops instead of guessing* — the prior pass had described this in the matrix but left it untested.
- **Routing stop had no recognized stop-condition name**: mapped the misclassification stop to the existing `missing_tracker_context` condition (`guardrails-enforcement.md`: "a required tracker field ... is absent or unresolvable") rather than inventing a new vocabulary entry — the classification field is present but cannot be resolved to a pipeline in framework mode, which is the "unresolvable" half of that definition. This is the mapping option the finding itself offered as an alternative to a new condition name, and it avoids touching `guardrails-enforcement.md` and every repository's `.ai-dev-workflow.yaml` stop-condition list for a single case.

### Step 7 local-ai-reviewer finding (fixed at `47ffe93c`)

`local-ai-reviewer` (Step 7, first platform) caught a genuine scope-creep contradiction in the `d35d99de` fix: the Framework-item lookup outcomes table stated the new unavailable-lookup outcome for "Either" mode, but Business Rules guarantees consumer-repository behavior is unchanged **in every respect** — and the existing `list_open_workflow_type_issues` already silently returns `[]` on failure in consumer mode today, so requiring distinguishable unavailable-reporting there would be new consumer-facing behavior this feature never proposed. Rescoped the unavailable-lookup requirement to framework mode throughout Use Case 4, Business Rules, the outcomes table, Operational Visibility, Mirror surfaces, and Acceptance Criteria, and added an explicit `Consumer | Lookup could not be performed | Unchanged from today` row/bullet at each of those five locations so the out-of-scope consumer-mode behavior is stated rather than left to inference.

## Document Quality Gate

- **Brief coverage**: Checked — all 5 acceptance criteria, all 3 enforcement points, the required companion change, the gating decision, all 3 explicit out-of-scope items, and the rejected alternative from #1583's body map to an acceptance-criterion group or an Out-of-Scope entry with a deferral note. Nothing in the brief is silently dropped.
- **Internal consistency**: Checked — swept for the mode vocabulary (**framework mode** / **consumer repository**), the class vocabulary (Feature / Bug / Refactor / Workflow), **misclassified**, and the three actors (backlog agent, Work Item Runner, release/retrospective agent) across Overview, all five use cases, Business Rules, Statuses, Operational Visibility, the decision-gate matrix, and every acceptance-criteria group. "Class" is used consistently for the field's value and "classification field" for the field, so the two never swap meaning mid-document.
- **Naming and casing consistency**: Checked — display labels appear in one casing everywhere (Feature, Bug, Refactor, Workflow; Backlog). The mode names are lowercase prose terms, bolded only on first definition, in both the spec and this description.
- **Behavioral guarantees**: Checked — every guarantee has a criterion that can fail. The no-partial-creation guarantee is testable by a rejected request leaving no issue and no board item; the consumer-unchanged guarantee by running each class in a repository with the declaration absent, false, and unrecognizable; the never-silently-empty guarantee by a framework-mode lookup against a board with open items and no Workflow-classed item; the no-override guarantee by the absence of any flag, env var, or prompt that accepts the refused class.
- **Complex workflow decision-gate matrix**: Checked — this spec modifies the Backlog routing gate, so the matrix is included with gate inputs (mode, classification, item stage, routing caller, framework-item lookup result), triggers separated from inputs, allowed outcomes with required next actions enumerated across both modes and including the unset-class, past-Backlog, mixed-portfolio-scan, and lookup-unavailable rows, mirror surfaces, and seven worked examples covering both modes. The unset-class case is stated as explicitly unchanged rather than left to inference, and the past-Backlog case is stated so the stop is not read as re-deciding in-flight items. The two rows added for `codex-github`'s post-ready findings (mixed-scan outcome, lookup-unavailable outcome) each have a corresponding acceptance-criteria bullet — the mixed-scan outcome's criteria were added in this pass; the lookup-unavailable outcome's were present from the same pass that added the row.
- **Reviewer-risk categories**: Checked — CLI-surface completeness (refusal path, success path, absence of an override); concurrency (not applicable — no shared state, no background work, no ordering between runs; the feature evaluates one request or one item at a time); single-snapshot semantics (not applicable — no snapshot is taken; the mode declaration and the item's class are each read once per operation); missing edge cases (declaration absent / false / unrecognizable; class unset; item already past Backlog; board genuinely empty); vague actors and triggers (each use case names its actor, and triggers are tabulated separately from inputs); untestable ACs (each names an observable difference); hidden dependencies (none — the `Depends on` line is removed; the one real ordering relationship, #1584 depending on this, is recorded under *Relationship to Other Work Items*); accidental implementation design (no regex, function body, exit code, parsing mechanic, or code-level algorithm appears — the scripts, protocols, and config key are named only where they *are* the product surface, per this repository's developer-tooling audience); stale template content (placeholder grep returns nothing; the UX Rules section is deleted).
- **Placeholder cleanup**: Checked — the Protocol 01 template-placeholder grep returns no output.
- **Not-applicable rationale**: UX Rules section deleted — this feature has no UI; its entire surface is a command's output and a run report, both covered under Operational Visibility. `Depends on` line removed — no upstream dependency. Open Questions section removed — none remain; the spec/product checkpoint for this item was explicitly waived by the human (the recommender matched the word "ambiguous" inside a blockquote *quoting Protocol 91's existing routing table*, not in the author's own prose), and the brief settles approach, gating, enforcement points, companion change, out-of-scope list, rejected alternative, and acceptance criteria. No `changelog.d/` fragment — spec-only pull requests are exempt. No design assets — the tracker item has none and none were invented.

## Spec-dispatch context

`blocking=false`. Batch peers #1462, #1496, #1515, #1529, and #1561 were classified **Orthogonal**; no dependency language toward them was added. Zero open pull requests existed at dispatch, so there is no same-surface open-PR evidence to reconcile. The one recorded ordering relationship is #1584 depending on this landing first, taken from the brief itself.

## Verification

- `markdownlint-cli2` on the spec: 1 file, **0 errors**
- `scripts/lint/markdown-heuristic-lint.py` on the spec: exit **0**
- Protocol 01 template-placeholder grep: **no output**
- Nested-artifact guard, `pre-pr` mode: `RESULT=clean`, `UNEXPECTED_COUNT=0`
- Push verified: local SHA == remote SHA (`47ffe93c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6h93B1Wv5HmoDxbsdiYur



